### PR TITLE
Benchmark and optimize path finding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,16 @@ jobs:
     - name: Check formatting
       run: |
         cargo fmt --all -- --check
+
+  testbench:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: Build benchmark
+      run: |
+        cargo bench --manifest-path crates/awbrn-map/bench/Cargo.toml -- --test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode

--- a/crates/awbrn-map/bench/.gitignore
+++ b/crates/awbrn-map/bench/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+/target

--- a/crates/awbrn-map/bench/Cargo.toml
+++ b/crates/awbrn-map/bench/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+publish = false
+name = "awbrn-map-bench"
+version = "0.0.1"
+authors = ["Nick Babcock <nbabcock19@hotmail.com>"]
+license = "MIT"
+edition = "2021"
+
+[workspace]
+
+[lib]
+bench = false
+
+[[bench]]
+name = "awbrn-map-bench"
+harness = false
+path = "src/bench.rs"
+
+[dependencies]
+criterion = "0.5.1"
+awbrn-map = { path = ".." }
+awbrn-core = { path = "../../awbrn-core" }
+
+[profile.release]
+debug = true
+
+[profile.bench]
+debug = true

--- a/crates/awbrn-map/bench/src/bench.rs
+++ b/crates/awbrn-map/bench/src/bench.rs
@@ -1,0 +1,35 @@
+use awbrn_map::{Position, TerrainCosts};
+use criterion::{black_box, BenchmarkId, Criterion};
+
+struct TestMovement;
+
+impl TerrainCosts for TestMovement {
+    fn cost(&self, _terrain: awbrn_core::MovementTerrain) -> Option<u8> {
+        Some(1)
+    }
+}
+
+fn parser(c: &mut Criterion) {
+    let map = awbrn_map::AwbwMap::new(40, 40, awbrn_core::Terrain::Plain);
+    let mut pathfinder = map.pathfinder();
+    let mut group = c.benchmark_group("pathfinding");
+    group.bench_function(BenchmarkId::from_parameter("sidewinder-fighter"), |b| {
+        b.iter(|| {
+            let reachable = pathfinder.reachable(Position::new(15, 15), 11, TestMovement);
+            let count = reachable.into_positions().count();
+            black_box(count);
+        });
+    });
+
+    group.bench_function(BenchmarkId::from_parameter("infantry"), |b| {
+        b.iter(|| {
+            let reachable = pathfinder.reachable(Position::new(15, 15), 3, TestMovement);
+            let count = reachable.into_positions().count();
+            black_box(count);        });
+    });
+
+    group.finish();
+}
+
+criterion::criterion_group!(benches, parser);
+criterion::criterion_main!(benches);

--- a/crates/awbrn-map/bench/src/lib.rs
+++ b/crates/awbrn-map/bench/src/lib.rs
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/crates/awbrn-map/src/awbrn_map.rs
+++ b/crates/awbrn-map/src/awbrn_map.rs
@@ -80,6 +80,14 @@ impl MovementMap for AwbrnMap {
             .map(|x| x.as_terrain())
             .map(MovementTerrain::from)
     }
+
+    fn width(&self) -> usize {
+        self.width
+    }
+
+    fn height(&self) -> usize {
+        self.height()
+    }
 }
 
 #[cfg(test)]

--- a/crates/awbrn-map/src/awbw_map.rs
+++ b/crates/awbrn-map/src/awbw_map.rs
@@ -116,6 +116,14 @@ impl MovementMap for AwbwMap {
     fn terrain_at(&self, pos: Position) -> Option<MovementTerrain> {
         self.terrain_at(pos).map(MovementTerrain::from)
     }
+
+    fn width(&self) -> usize {
+        self.width
+    }
+
+    fn height(&self) -> usize {
+        self.height()
+    }
 }
 
 impl fmt::Display for AwbwMap {

--- a/crates/awbrn-map/src/lib.rs
+++ b/crates/awbrn-map/src/lib.rs
@@ -7,4 +7,5 @@ mod position;
 pub use awbrn_map::AwbrnMap;
 pub use awbw_map::AwbwMap;
 pub use map_error::MapError;
+pub use pathfinding::TerrainCosts;
 pub use position::Position;


### PR DESCRIPTION
Previously took over 1ms to pathfind a sidewinder fighter. I was able to optimize it 100x so it only takes 10us.