### PR TITLE
Implement undo replay turn command

### DIFF
--- a/crates/awbrn-bevy/src/commands/replay_turn.rs
+++ b/crates/awbrn-bevy/src/commands/replay_turn.rs
@@ -4,7 +4,7 @@
 //! immediate mutations that are visible to subsequent queries within the same
 //! command execution.
 
-use awbrn_core::{GraphicalTerrain, PlayerFaction, Property};
+use awbrn_core::{AwbwTerrain, GraphicalTerrain, PlayerFaction, Property};
 use awbrn_map::Position;
 use awbw_replay::turn_models::{
     Action, CaptureAction, CombatUnit, FireAction, LoadAction, MoveAction, UnitMap, UpdatedInfo,
@@ -430,5 +430,200 @@ impl ReplayTurnCommand {
                 break;
             }
         }
+    }
+}
+
+/// A command to reset the replay to its initial state.
+///
+/// This despawns all units, clears the unit ID map, resets terrain ownership,
+/// and resets the replay state to turn 0/day 1.
+pub struct ResetReplayCommand;
+
+impl Command for ResetReplayCommand {
+    fn apply(self, world: &mut World) {
+        // 1. Despawn all unit entities
+        let unit_entities: Vec<Entity> = {
+            let mut query = world.query_filtered::<Entity, With<AwbwUnitId>>();
+            query.iter(world).collect()
+        };
+
+        for entity in unit_entities {
+            world.entity_mut(entity).despawn();
+        }
+
+        // 2. Clear StrongIdMap<AwbwUnitId>
+        world.resource_mut::<StrongIdMap<AwbwUnitId>>().clear();
+
+        // 3. Reset terrain tiles to initial ownership
+        Self::reset_terrain(world);
+
+        // 4. Reset ReplayState
+        world.resource_mut::<ReplayState>().turn = 0;
+        world.resource_mut::<ReplayState>().day = 1;
+
+        // 5. Re-spawn initial units
+        Self::spawn_initial_units(world);
+
+        log::info!("Replay reset to initial state");
+    }
+}
+
+impl ResetReplayCommand {
+    /// Reset terrain tiles to their initial ownership based on replay buildings data.
+    fn reset_terrain(world: &mut World) {
+        // Build a map of initial building ownership from replay data
+        let initial_buildings: std::collections::HashMap<Position, AwbwTerrain> = {
+            let loaded_replay = world.resource::<LoadedReplay>();
+            loaded_replay
+                .0
+                .games
+                .first()
+                .map(|game| {
+                    game.buildings
+                        .iter()
+                        .map(|b| (Position::new(b.x as usize, b.y as usize), b.terrain_id))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+
+        if initial_buildings.is_empty() {
+            return;
+        }
+
+        // Get current weather for sprite updates
+        let weather = world.resource::<CurrentWeather>().weather();
+
+        // Query and update terrain tiles
+        let mut query = world.query::<(&mut TerrainTile, &mut Sprite)>();
+        for (mut terrain_tile, mut sprite) in query.iter_mut(world) {
+            // Only reset properties that have initial state in replay data
+            if let Some(&AwbwTerrain::Property(property)) =
+                initial_buildings.get(&terrain_tile.position)
+            {
+                terrain_tile.terrain = GraphicalTerrain::Property(property);
+
+                // Update sprite to match initial ownership
+                let sprite_index = awbrn_core::spritesheet_index(weather, terrain_tile.terrain);
+                if let Some(atlas) = &mut sprite.texture_atlas {
+                    atlas.index = sprite_index.index() as usize;
+                }
+            }
+        }
+    }
+
+    /// Spawn initial units from replay data.
+    fn spawn_initial_units(world: &mut World) {
+        // Extract data needed for spawning
+        let (players, replay_units) = {
+            let loaded_replay = world.resource::<LoadedReplay>();
+            if let Some(first_game) = loaded_replay.0.games.first() {
+                (first_game.players.clone(), first_game.units.clone())
+            } else {
+                return;
+            }
+        };
+
+        // Spawn each initial unit
+        for unit in &replay_units {
+            let faction = players
+                .iter()
+                .find(|p| p.id == unit.players_id)
+                .map(|p| p.faction)
+                .unwrap_or(PlayerFaction::OrangeStar);
+
+            let mut entity = world.spawn((
+                MapPosition::new(unit.x as usize, unit.y as usize),
+                Faction(faction),
+                AwbwUnitId(unit.id),
+                Unit(unit.name),
+            ));
+
+            // Handle units that start carried (in transports)
+            if unit.carried {
+                entity.insert(Visibility::Hidden);
+            }
+
+            // Handle units with initial damage
+            let hp_value = unit.hit_points.round() as u8;
+            if hp_value < 10 {
+                entity.insert(GraphicalHp(hp_value));
+            }
+        }
+
+        // Set up cargo relationships for transports
+        for unit in &replay_units {
+            let cargo1_id = unit.cargo1_units_id;
+            let cargo2_id = unit.cargo2_units_id;
+
+            // Check if this unit has cargo (non-zero cargo IDs indicate cargo)
+            if cargo1_id.as_u32() == 0 && cargo2_id.as_u32() == 0 {
+                continue;
+            }
+
+            // Get the transport entity
+            let transport_entity = {
+                let units = world.resource::<StrongIdMap<AwbwUnitId>>();
+                units.get(&AwbwUnitId(unit.id))
+            };
+
+            let Some(transport_entity) = transport_entity else {
+                continue;
+            };
+
+            // Build cargo component
+            let mut has_cargo = HasCargo::new();
+            if cargo1_id.as_u32() != 0 {
+                has_cargo.add_cargo(AwbwUnitId(cargo1_id));
+            }
+            if cargo2_id.as_u32() != 0 {
+                has_cargo.add_cargo(AwbwUnitId(cargo2_id));
+            }
+
+            if !has_cargo.is_empty() {
+                world.entity_mut(transport_entity).insert(has_cargo);
+            }
+        }
+    }
+}
+
+/// A command to undo the last replay turn.
+///
+/// This resets to the initial state and replays all turns up to (but not including)
+/// the current turn.
+pub struct UndoTurnCommand;
+
+impl Command for UndoTurnCommand {
+    fn apply(self, world: &mut World) {
+        let current_turn = world.resource::<ReplayState>().turn;
+
+        // Nothing to undo at turn 0
+        if current_turn == 0 {
+            log::info!("Already at the beginning of the replay");
+            return;
+        }
+
+        let target_turn = current_turn - 1;
+
+        // Clone turns before reset (to avoid borrow issues)
+        let turns = world.resource::<LoadedReplay>().0.turns.clone();
+
+        // Reset to initial state
+        ResetReplayCommand.apply(world);
+
+        // Replay all turns from 0 to target_turn-1
+        for turn_idx in 0..target_turn as usize {
+            if let Some(action) = turns.get(turn_idx) {
+                ReplayTurnCommand {
+                    action: action.clone(),
+                }
+                .apply(world);
+            }
+        }
+
+        // Update turn counter (ResetReplayCommand sets it to 0, we need target_turn)
+        world.resource_mut::<ReplayState>().turn = target_turn;
+
+        log::info!("Undid turn, now at turn {}", target_turn);
     }
 }

--- a/crates/awbrn-bevy/src/ecs.rs
+++ b/crates/awbrn-bevy/src/ecs.rs
@@ -193,6 +193,10 @@ where
     pub fn remove(&mut self, strong_id: T) -> Option<Entity> {
         self.units.remove(&strong_id)
     }
+
+    pub fn clear(&mut self) {
+        self.units.clear();
+    }
 }
 
 impl<T> Default for StrongIdMap<T> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced undo functionality for replay progression, allowing reversal to previous turns.
  * Added replay reset capability to restore the initial game state with all terrain and units restored.
  * Enhanced replay navigation controls for improved playback management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->