### PR TITLE
Tie game worker to the lifetime of the route

### DIFF
--- a/web/src/canvas_courier/dom_transport.ts
+++ b/web/src/canvas_courier/dom_transport.ts
@@ -186,16 +186,6 @@ export class CanvasCourierTransport {
     this.inputQueue.writer.enqueueVisibility(document.hidden);
   }
 
-  detachSurface(canvas: HTMLCanvasElement): void {
-    if (this.activeSurface?.canvas !== canvas) {
-      return;
-    }
-
-    this.enqueueDetachEvents();
-    this.activeSurface = undefined;
-    this.releaseSurfaceBindings();
-  }
-
   dispose(): void {
     this.activeSurface = undefined;
     this.canvasSize = undefined;
@@ -207,11 +197,6 @@ export class CanvasCourierTransport {
     const nextSize = this.measureSurface(surface);
     this.canvasSize = nextSize;
     this.inputQueue.writer.enqueueResize(nextSize);
-  }
-
-  private enqueueDetachEvents(): void {
-    this.inputQueue.writer.enqueuePointerLeave();
-    this.inputQueue.writer.enqueueBlur(performance.now());
   }
 
   private releaseSurfaceBindings(): void {

--- a/web/src/canvas_courier/types.ts
+++ b/web/src/canvas_courier/types.ts
@@ -8,5 +8,4 @@ export interface CanvasCourierSurface extends CanvasCourierDomSurface {
 
 export interface CanvasCourierController {
   attachSurface(surface: CanvasCourierSurface): void;
-  detachSurface(canvas: HTMLCanvasElement): void;
 }

--- a/web/src/canvas_courier/useCanvasCourierSurface.ts
+++ b/web/src/canvas_courier/useCanvasCourierSurface.ts
@@ -1,10 +1,14 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useEffectEvent, useRef } from "react";
 import type { CanvasCourierController } from "./types";
 
 export function useCanvasCourierSurface({ controller }: { controller: CanvasCourierController }) {
   const surfaceRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const offscreenRef = useRef<OffscreenCanvas | null>(null);
+
+  const attachSurface = useEffectEvent((canvas: HTMLCanvasElement, offscreen: OffscreenCanvas) => {
+    controller.attachSurface({ canvas, offscreen });
+  });
 
   const focus = useCallback(() => {
     canvasRef.current?.focus({ preventScroll: true });
@@ -21,13 +25,13 @@ export function useCanvasCourierSurface({ controller }: { controller: CanvasCour
       return;
     }
 
-    offscreenRef.current ??= canvas.transferControlToOffscreen();
-    controller.attachSurface({ canvas, offscreen: offscreenRef.current });
+    if (offscreenRef.current === null) {
+      offscreenRef.current = canvas.transferControlToOffscreen();
+      attachSurface(canvas, offscreenRef.current);
+    }
 
-    return () => {
-      controller.detachSurface(canvas);
-    };
-  }, [controller]);
+    // No cleanup as transferring is a one-way operation
+  }, []);
 
   return {
     surfaceRef,

--- a/web/src/engine/game_runner.ts
+++ b/web/src/engine/game_runner.ts
@@ -31,6 +31,12 @@ export class GameRunner implements CanvasCourierController {
   private worker: GameWorker | undefined;
 
   attachSurface(surface: GameSurface): void {
+    if (this.activeSurface?.canvas === surface.canvas) {
+      this.activeSurface = surface;
+      this.applyMapDimensions();
+      return;
+    }
+
     const version = ++this.surfaceVersion;
     this.activeSurface = surface;
 
@@ -44,16 +50,6 @@ export class GameRunner implements CanvasCourierController {
         console.error("GameRunner failed to initialize:", error);
       }
     });
-  }
-
-  detachSurface(canvas: HTMLCanvasElement): void {
-    if (this.activeSurface?.canvas !== canvas) {
-      return;
-    }
-
-    this.surfaceVersion += 1;
-    this.transport.detachSurface(canvas);
-    this.activeSurface = undefined;
   }
 
   async loadReplay(file: File | FileSystemFileHandle): Promise<void> {

--- a/web/src/engine/runtime_context.tsx
+++ b/web/src/engine/runtime_context.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, useEffect, useRef, type ReactNode } from "react";
+import { useLocation } from "@tanstack/react-router";
+import { useGameStore } from "./store";
+import { GameRuntimeRegistry, type PreviewRunnerScope } from "./runtime_registry";
+
+const GameRuntimeContext = createContext<GameRuntimeRegistry | null>(null);
+
+export function GameRuntimeProvider({ children }: { children: ReactNode }) {
+  const pathname = useLocation({
+    select: (location) => location.pathname,
+  });
+  const registryRef = useRef<GameRuntimeRegistry | null>(null);
+
+  registryRef.current ??= new GameRuntimeRegistry(undefined, {
+    onDisposeReplay: () => {
+      useGameStore.getState().actions.reset();
+    },
+  });
+
+  useEffect(() => {
+    registryRef.current?.syncPathname(pathname);
+  }, [pathname]);
+
+  useEffect(() => {
+    return () => {
+      registryRef.current?.disposeAll();
+    };
+  }, []);
+
+  return (
+    <GameRuntimeContext.Provider value={registryRef.current}>
+      {children}
+    </GameRuntimeContext.Provider>
+  );
+}
+
+function useGameRuntimeRegistry(): GameRuntimeRegistry {
+  const registry = useContext(GameRuntimeContext);
+  if (!registry) {
+    throw new Error("GameRuntimeProvider is required for game runtime hooks.");
+  }
+
+  return registry;
+}
+
+export function usePreviewRunner(scope: PreviewRunnerScope) {
+  return useGameRuntimeRegistry().getPreviewRunner(scope);
+}
+
+export function useReplayRunner() {
+  return useGameRuntimeRegistry().getReplayRunner();
+}

--- a/web/src/engine/runtime_registry.test.ts
+++ b/web/src/engine/runtime_registry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { GameRuntimeRegistry } from "./runtime_registry";
+
+class TestRunner {
+  dispose = vi.fn();
+}
+
+describe("GameRuntimeRegistry", () => {
+  it("keeps the replay runner alive across same-route syncs", () => {
+    const registry = new GameRuntimeRegistry(() => new TestRunner());
+    const runner = registry.getReplayRunner();
+
+    registry.syncPathname("/");
+    registry.syncPathname("/");
+
+    expect(registry.getReplayRunner()).toBe(runner);
+    expect(runner.dispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes only the replay runner when leaving the home route", () => {
+    const onDisposeReplay = vi.fn();
+    const registry = new GameRuntimeRegistry(() => new TestRunner(), { onDisposeReplay });
+    const replayRunner = registry.getReplayRunner();
+    const previewRunner = registry.getPreviewRunner("matches-new");
+
+    registry.syncPathname("/");
+    registry.syncPathname("/matches/new");
+
+    expect(replayRunner.dispose).toHaveBeenCalledTimes(1);
+    expect(onDisposeReplay).toHaveBeenCalledTimes(1);
+    expect(previewRunner.dispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes only the matches-new preview runner when leaving that route", () => {
+    const registry = new GameRuntimeRegistry(() => new TestRunner());
+    const matchesNewRunner = registry.getPreviewRunner("matches-new");
+    const lobbyRunner = registry.getPreviewRunner("match-lobby");
+
+    registry.syncPathname("/matches/new");
+    registry.syncPathname("/matches/abc123");
+
+    expect(matchesNewRunner.dispose).toHaveBeenCalledTimes(1);
+    expect(lobbyRunner.dispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes only the match-lobby preview runner when leaving that route", () => {
+    const registry = new GameRuntimeRegistry(() => new TestRunner());
+    const matchesNewRunner = registry.getPreviewRunner("matches-new");
+    const lobbyRunner = registry.getPreviewRunner("match-lobby");
+
+    registry.syncPathname("/matches/abc123");
+    registry.syncPathname("/matches");
+
+    expect(lobbyRunner.dispose).toHaveBeenCalledTimes(1);
+    expect(matchesNewRunner.dispose).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/engine/runtime_registry.ts
+++ b/web/src/engine/runtime_registry.ts
@@ -1,0 +1,100 @@
+import { GameRunner } from "./game_runner";
+
+export type PreviewRunnerScope = "match-lobby" | "matches-new";
+
+interface RunnerLike {
+  dispose(): void;
+}
+
+interface RuntimeRegistryOptions {
+  onDisposeReplay?: () => void;
+}
+
+const MATCH_LOBBY_PATH_PATTERN = /^\/matches\/[^/]+$/;
+
+function isReplayPath(pathname: string): boolean {
+  return pathname === "/";
+}
+
+function isMatchesNewPath(pathname: string): boolean {
+  return pathname === "/matches/new";
+}
+
+function isMatchLobbyPath(pathname: string): boolean {
+  return pathname !== "/matches/new" && MATCH_LOBBY_PATH_PATTERN.test(pathname);
+}
+
+export class GameRuntimeRegistry<TRunner extends RunnerLike = GameRunner> {
+  private currentPathname: string | undefined;
+  private previewRunners = new Map<PreviewRunnerScope, TRunner>();
+  private replayRunner: TRunner | undefined;
+
+  constructor(
+    private readonly createRunner: () => TRunner = () => new GameRunner() as unknown as TRunner,
+    private readonly options: RuntimeRegistryOptions = {},
+  ) {}
+
+  getPreviewRunner(scope: PreviewRunnerScope): TRunner {
+    let runner = this.previewRunners.get(scope);
+    if (!runner) {
+      runner = this.createRunner();
+      this.previewRunners.set(scope, runner);
+    }
+
+    return runner;
+  }
+
+  getReplayRunner(): TRunner {
+    this.replayRunner ??= this.createRunner();
+    return this.replayRunner;
+  }
+
+  syncPathname(pathname: string): void {
+    const previousPathname = this.currentPathname;
+    this.currentPathname = pathname;
+
+    if (!previousPathname || previousPathname === pathname) {
+      return;
+    }
+
+    if (isReplayPath(previousPathname) && !isReplayPath(pathname)) {
+      this.disposeReplayRunner();
+    }
+
+    if (isMatchesNewPath(previousPathname) && !isMatchesNewPath(pathname)) {
+      this.disposePreviewRunner("matches-new");
+    }
+
+    if (isMatchLobbyPath(previousPathname) && !isMatchLobbyPath(pathname)) {
+      this.disposePreviewRunner("match-lobby");
+    }
+  }
+
+  disposeAll(): void {
+    this.disposeReplayRunner();
+
+    for (const scope of this.previewRunners.keys()) {
+      this.disposePreviewRunner(scope);
+    }
+  }
+
+  private disposePreviewRunner(scope: PreviewRunnerScope): void {
+    const runner = this.previewRunners.get(scope);
+    if (!runner) {
+      return;
+    }
+
+    this.previewRunners.delete(scope);
+    runner.dispose();
+  }
+
+  private disposeReplayRunner(): void {
+    if (!this.replayRunner) {
+      return;
+    }
+
+    this.replayRunner.dispose();
+    this.replayRunner = undefined;
+    this.options.onDisposeReplay?.();
+  }
+}

--- a/web/src/engine/store.ts
+++ b/web/src/engine/store.ts
@@ -9,6 +9,7 @@ interface GameState {
 interface GameActions {
   setCurrentDay: (day: number) => void;
   setPlayerRoster: (playerRoster: PlayerRosterSnapshot | null) => void;
+  reset: () => void;
 }
 
 export const useGameStore = create<GameState & { actions: GameActions }>((set) => ({
@@ -17,6 +18,7 @@ export const useGameStore = create<GameState & { actions: GameActions }>((set) =
   actions: {
     setCurrentDay: (day) => set({ currentDay: day }),
     setPlayerRoster: (playerRoster) => set({ playerRoster }),
+    reset: () => set({ currentDay: 1, playerRoster: null }),
   },
 }));
 

--- a/web/src/matches/components/MatchMapPreview.tsx
+++ b/web/src/matches/components/MatchMapPreview.tsx
@@ -1,7 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useCanvasCourierSurface } from "#/canvas_courier/index.ts";
-import { GameRunner } from "#/engine/game_runner.ts";
+import type { GameRunner } from "#/engine/game_runner.ts";
 import { tokens } from "#/ui/theme.stylex.ts";
 import type { XStyle } from "#/ui/stylex.ts";
 
@@ -38,11 +38,15 @@ const styles = stylex.create({
   },
 });
 
-export function MatchMapPreview({ mapId, xstyle }: { mapId: number | null; xstyle?: XStyle }) {
-  const [runner] = useState(() => new GameRunner());
-
-  useEffect(() => () => runner.dispose(), [runner]);
-
+export function MatchMapPreview({
+  mapId,
+  runner,
+  xstyle,
+}: {
+  mapId: number | null;
+  runner: GameRunner;
+  xstyle?: XStyle;
+}) {
   const { canvasRef, surfaceRef } = useCanvasCourierSurface({
     controller: runner,
   });

--- a/web/src/matches/screens/MatchLobbyPage.tsx
+++ b/web/src/matches/screens/MatchLobbyPage.tsx
@@ -18,6 +18,7 @@ import {
   loadCoPortraitCatalog,
   type CoPortraitCatalog,
 } from "#/components/co_portraits.ts";
+import { usePreviewRunner } from "#/engine/runtime_context.tsx";
 import { defaultFactionIdForSlot, getFactionById } from "#/factions.ts";
 import { getFactionVisual } from "#/faction_visuals.ts";
 import { PlayerHeader } from "#/components/PlayerHeader.tsx";
@@ -46,6 +47,7 @@ export function MatchLobbyPage({
   joinSlug: string | null;
 }) {
   const session = useAppSession();
+  const previewRunner = usePreviewRunner("match-lobby");
   const portraitCatalog = useMemo(() => loadCoPortraitCatalog(), []);
   const [match, setMatch] = useState<MatchSnapshot | null>(null);
   const [mapData, setMapData] = useState<AwbwMapData | null>(null);
@@ -273,7 +275,11 @@ export function MatchLobbyPage({
                     </div>
 
                     <div {...stylex.props(styles.mapPreviewWrap)}>
-                      <MatchMapPreview mapId={match.mapId} xstyle={styles.previewCanvas} />
+                      <MatchMapPreview
+                        mapId={match.mapId}
+                        runner={previewRunner}
+                        xstyle={styles.previewCanvas}
+                      />
                     </div>
 
                     <div {...stylex.props(styles.metaGrid)}>

--- a/web/src/matches/screens/NewMatchPage.tsx
+++ b/web/src/matches/screens/NewMatchPage.tsx
@@ -4,6 +4,7 @@ import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { useAppSession } from "#/auth/useAppSession.ts";
 import { awbwMapAssetPath } from "#/awbw/paths.ts";
 import type { AwbwMapData } from "#/awbw/schemas.ts";
+import { usePreviewRunner } from "#/engine/runtime_context.tsx";
 import {
   Button,
   CheckboxField,
@@ -24,6 +25,7 @@ import { createMatchFn } from "#/matches/matches.functions.ts";
 export function NewMatchPage() {
   const navigate = useNavigate();
   const session = useAppSession();
+  const previewRunner = usePreviewRunner("matches-new");
   const [matchName, setMatchName] = useState("");
   const [mapIdInput, setMapIdInput] = useState("162795");
   const [mapData, setMapData] = useState<AwbwMapData | null>(null);
@@ -289,7 +291,11 @@ export function NewMatchPage() {
               </Stack>
               {mapData && parsedMapId !== null ? (
                 <Stack gap="md">
-                  <MatchMapPreview mapId={parsedMapId} xstyle={styles.previewCanvas} />
+                  <MatchMapPreview
+                    mapId={parsedMapId}
+                    runner={previewRunner}
+                    xstyle={styles.previewCanvas}
+                  />
                   <div {...stylex.props(styles.metaGrid)}>
                     <div {...stylex.props(styles.metaItem)}>
                       <Text size="sm" tone="muted">

--- a/web/src/replay/ReplayPage.tsx
+++ b/web/src/replay/ReplayPage.tsx
@@ -7,7 +7,7 @@ import { CoPortrait } from "#/components/CoPortrait.tsx";
 import { FactionSelectionControl } from "#/components/FactionSelectionControl.tsx";
 import { loadCoPortraitCatalog, type CoPortraitCatalog } from "#/components/co_portraits.ts";
 import { PlayerHeader } from "#/components/PlayerHeader.tsx";
-import { GameRunner } from "#/engine/game_runner.ts";
+import { useReplayRunner } from "#/engine/runtime_context.tsx";
 import { useGameActions, useGameStore } from "#/engine/store.ts";
 import { getFactionVisual } from "#/faction_visuals.ts";
 import { getFactionByCode } from "#/factions.ts";
@@ -67,9 +67,7 @@ export function ReplayPage() {
   const gameActions = useGameActions();
   const [portraitCatalog] = useState<CoPortraitCatalog>(() => loadCoPortraitCatalog());
   const [playerNames, setPlayerNames] = useState<Record<number, string>>({});
-  const [runner] = useState(() => new GameRunner());
-
-  useEffect(() => () => runner.dispose(), [runner]);
+  const runner = useReplayRunner();
 
   const { canvasRef, focus, surfaceRef } = useCanvasCourierSurface({
     controller: runner,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { getSessionFn } from "#/auth/auth.functions.ts";
 import { DefaultCatchBoundary } from "#/components/DefaultCatchBoundary.tsx";
 import { NotFound } from "#/components/NotFound.tsx";
+import { GameRuntimeProvider } from "#/engine/runtime_context.tsx";
 import { Layout } from "#/layouts/Layout.tsx";
 import { DevStyleXInject } from "#/styles/DevStyleXInject.tsx";
 import resetCss from "#/styles/reset.css?url";
@@ -28,9 +29,11 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <Layout>
-      <Outlet />
-    </Layout>
+    <GameRuntimeProvider>
+      <Layout>
+        <Outlet />
+      </Layout>
+    </GameRuntimeProvider>
   );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified canvas surface lifecycle management by consolidating disposal patterns
  * Introduced centralized runtime context for improved game runner lifecycle and state management
  * Implemented route-aware resource cleanup to automatically reset game state when navigating between different app sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->