### PR TITLE
Add my matches page

### DIFF
--- a/web/src/layouts/Layout.tsx
+++ b/web/src/layouts/Layout.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { authClient } from "#/auth/client.ts";
 import { useAppSession } from "#/auth/useAppSession.ts";
 import { Button, ButtonLink, Text, Wordmark } from "#/ui/primitives.tsx";
-import { tokens } from "#/ui/theme.stylex.ts";
+import { media, tokens } from "#/ui/theme.stylex.ts";
 
 const styles = stylex.create({
   shell: {
@@ -30,15 +30,15 @@ const styles = stylex.create({
     boxShadow: tokens.shadowHardLg,
     flexWrap: {
       default: "nowrap",
-      "@media (max-width: 640px)": "wrap",
+      [media.compact]: "wrap",
     },
     alignItems: {
       default: "center",
-      "@media (max-width: 640px)": "flex-start",
+      [media.compact]: "flex-start",
     },
     paddingBlock: {
       default: null,
-      "@media (max-width: 640px)": tokens.space3,
+      [media.compact]: tokens.space3,
     },
   },
   navCluster: {
@@ -53,15 +53,15 @@ const styles = stylex.create({
     gap: tokens.space1,
     order: {
       default: null,
-      "@media (max-width: 640px)": 3,
+      [media.compact]: 3,
     },
     width: {
       default: null,
-      "@media (max-width: 640px)": "100%",
+      [media.compact]: "100%",
     },
     justifyContent: {
       default: null,
-      "@media (max-width: 640px)": "space-between",
+      [media.compact]: "space-between",
     },
   },
   navLink: {
@@ -201,6 +201,15 @@ export function Layout({ children }: { children: ReactNode }) {
           >
             Matches
           </Link>
+          {session ? (
+            <Link
+              to="/my/matches"
+              className={navLinkClassName}
+              activeProps={{ className: navLinkActiveClassName }}
+            >
+              My Matches
+            </Link>
+          ) : null}
           <Link
             to="/matches/new"
             className={navLinkClassName}

--- a/web/src/matches/matches.functions.ts
+++ b/web/src/matches/matches.functions.ts
@@ -2,7 +2,13 @@ import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { sessionMiddleware } from "#/auth/session.middleware.ts";
 import { getFactionById } from "#/factions.ts";
-import { createMatch, getMatchSnapshot, listMatches, mutateMatch } from "./matches.server";
+import {
+  createMatch,
+  getMatchSnapshot,
+  listMatches,
+  listMyMatches,
+  mutateMatch,
+} from "./matches.server";
 import {
   matchBrowseRequestSchema,
   matchCreateRequestSchema,
@@ -13,6 +19,15 @@ export const listMatchesFn = createServerFn({ method: "GET" })
   .inputValidator(matchBrowseRequestSchema)
   .handler(async ({ data }) => {
     const result = await listMatches(data);
+    if (!result.ok) throw new Error(result.error.message);
+    return result.value;
+  });
+
+export const listMyMatchesFn = createServerFn({ method: "GET" })
+  .middleware([sessionMiddleware])
+  .handler(async ({ context }) => {
+    if (!context.session) throw new Response("Unauthorized", { status: 401 });
+    const result = await listMyMatches(context.session.user.id);
     if (!result.ok) throw new Error(result.error.message);
     return result.value;
   });

--- a/web/src/matches/matches.server.ts
+++ b/web/src/matches/matches.server.ts
@@ -12,7 +12,10 @@ import type {
   MatchPhase,
   MatchSettings,
   MatchSnapshot,
+  MyMatchesResponse,
+  MyMatchSummary,
 } from "./schemas";
+import { ONGOING_MATCH_PHASES } from "./my_matches";
 import {
   MATCH_BROWSE_PAGE_SIZE,
   decodeMatchBrowseCursor,
@@ -65,6 +68,7 @@ type MatchActionDiagnostics =
 type MatchRow = Awaited<ReturnType<typeof queryMatchRow>>;
 type MatchParticipantRow = Awaited<ReturnType<typeof queryParticipantRows>>[number];
 type MatchBrowseRow = Awaited<ReturnType<typeof queryBrowseRows>>[number];
+type MyMatchRow = Awaited<ReturnType<typeof queryMyMatchRows>>[number];
 
 export async function createMatch(
   input: MatchCreateRequest,
@@ -181,6 +185,21 @@ export async function listMatches(
           })
         : null,
   });
+}
+
+export async function listMyMatches(viewerUserId: string): Promise<MatchResult<MyMatchesResponse>> {
+  const rows = await queryMyMatchRows(viewerUserId);
+  const myMatches: MyMatchSummary[] = [];
+
+  for (const row of rows) {
+    const settings = parseMatchSettingsValue(row.settings);
+    if (!settings.ok) {
+      return settings;
+    }
+    myMatches.push(toMyMatchSummary(row, settings.value));
+  }
+
+  return ok({ matches: myMatches });
 }
 
 export async function mutateMatch(
@@ -656,6 +675,53 @@ async function queryBrowseParticipantRows(matchIds: readonly string[]) {
     .all();
 }
 
+async function queryMyMatchRows(viewerUserId: string) {
+  return db
+    .select({
+      matchId: matches.id,
+      name: matches.name,
+      phase: matches.phase,
+      creatorName: user.name,
+      mapId: matches.mapId,
+      maxPlayers: matches.maxPlayers,
+      participantCount: sql<number>`(
+        SELECT COUNT(*)
+        FROM match_participants p
+        WHERE p.matchId = ${matches.id}
+      )`.as("participantCount"),
+      isPrivate: matches.isPrivate,
+      settings: matches.settings,
+      createdAt: matches.createdAt,
+      updatedAt: matches.updatedAt,
+      startedAt: matches.startedAt,
+      viewerSlotIndex: matchParticipants.slotIndex,
+      viewerFactionId: matchParticipants.factionId,
+      viewerCoId: matchParticipants.coId,
+      viewerReady: matchParticipants.ready,
+      viewerJoinedAt: matchParticipants.joinedAt,
+      viewerUpdatedAt: matchParticipants.updatedAt,
+    })
+    .from(matches)
+    .innerJoin(user, eq(user.id, matches.creatorUserId))
+    .innerJoin(
+      matchParticipants,
+      and(eq(matchParticipants.matchId, matches.id), eq(matchParticipants.userId, viewerUserId)),
+    )
+    .where(inArray(matches.phase, ONGOING_MATCH_PHASES))
+    .orderBy(
+      sql`CASE ${matches.phase}
+        WHEN 'active' THEN 0
+        WHEN 'starting' THEN 1
+        WHEN 'lobby' THEN 2
+        WHEN 'draft' THEN 3
+        ELSE 4
+      END`,
+      desc(matches.updatedAt),
+      desc(matches.id),
+    )
+    .all();
+}
+
 function parseMatchSettingsValue(value: unknown): MatchResult<MatchSettings> {
   try {
     const result = matchSettingsSchema.safeParse(value);
@@ -702,6 +768,34 @@ function toMatchBrowseSummary(
     joinedPlayerNames,
     settings,
     createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function toMyMatchSummary(row: MyMatchRow, settings: MatchSettings): MyMatchSummary {
+  const participantCount = Number(row.participantCount);
+
+  return {
+    matchId: row.matchId,
+    name: row.name,
+    phase: row.phase,
+    creatorName: row.creatorName,
+    mapId: row.mapId,
+    maxPlayers: row.maxPlayers,
+    participantCount,
+    openSlotCount: Math.max(0, row.maxPlayers - participantCount),
+    isPrivate: row.isPrivate,
+    settings,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    startedAt: row.startedAt === null ? null : row.startedAt.toISOString(),
+    viewerParticipant: {
+      slotIndex: row.viewerSlotIndex,
+      factionId: row.viewerFactionId,
+      coId: row.viewerCoId,
+      ready: row.viewerReady,
+      joinedAt: row.viewerJoinedAt.toISOString(),
+      updatedAt: row.viewerUpdatedAt.toISOString(),
+    },
   };
 }
 

--- a/web/src/matches/my_matches.test.ts
+++ b/web/src/matches/my_matches.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatMyMatchPhaseLabel,
+  myMatchActionLabel,
+  myMatchPhaseRank,
+  ONGOING_MATCH_PHASES,
+} from "./my_matches.ts";
+import type { MatchPhase } from "./schemas.ts";
+
+describe("my matches phases", () => {
+  it("defines the ongoing match phases", () => {
+    expect(ONGOING_MATCH_PHASES).toEqual(["draft", "lobby", "starting", "active"]);
+  });
+
+  it("orders active work before setup phases", () => {
+    const phases: MatchPhase[] = ["draft", "lobby", "starting", "active"];
+    expect(phases.sort((a, b) => myMatchPhaseRank(a) - myMatchPhaseRank(b))).toEqual([
+      "active",
+      "starting",
+      "lobby",
+      "draft",
+    ]);
+  });
+
+  it("uses stable player-facing phase and action labels", () => {
+    expect(formatMyMatchPhaseLabel("active")).toBe("Active");
+    expect(myMatchActionLabel("active")).toBe("Open Match");
+    expect(myMatchActionLabel("starting")).toBe("View Starting Match");
+    expect(myMatchActionLabel("lobby")).toBe("Open Lobby");
+  });
+});

--- a/web/src/matches/my_matches.ts
+++ b/web/src/matches/my_matches.ts
@@ -1,0 +1,54 @@
+import type { MatchPhase } from "./schemas";
+
+export const ONGOING_MATCH_PHASES = [
+  "draft",
+  "lobby",
+  "starting",
+  "active",
+] as const satisfies readonly MatchPhase[];
+
+const phaseRank: Record<MatchPhase, number> = {
+  active: 0,
+  starting: 1,
+  lobby: 2,
+  draft: 3,
+  completed: 4,
+  cancelled: 5,
+};
+
+export function myMatchPhaseRank(phase: MatchPhase): number {
+  return phaseRank[phase];
+}
+
+export function formatMyMatchPhaseLabel(phase: MatchPhase): string {
+  switch (phase) {
+    case "active":
+      return "Active";
+    case "starting":
+      return "Starting";
+    case "lobby":
+      return "Lobby";
+    case "draft":
+      return "Draft";
+    case "completed":
+      return "Complete";
+    case "cancelled":
+      return "Cancelled";
+  }
+}
+
+export function myMatchActionLabel(phase: MatchPhase): string {
+  switch (phase) {
+    case "active":
+      return "Open Match";
+    case "starting":
+      return "View Starting Match";
+    case "lobby":
+    case "draft":
+      return "Open Lobby";
+    case "completed":
+      return "View Match";
+    case "cancelled":
+      return "View Match";
+  }
+}

--- a/web/src/matches/schemas.ts
+++ b/web/src/matches/schemas.ts
@@ -67,6 +67,36 @@ export interface MatchBrowseResponse {
   nextCursor: string | null;
 }
 
+export interface MyMatchParticipantSummary {
+  slotIndex: number;
+  factionId: number;
+  coId: number | null;
+  ready: boolean;
+  joinedAt: string;
+  updatedAt: string;
+}
+
+export interface MyMatchSummary {
+  matchId: string;
+  name: string;
+  phase: MatchPhase;
+  creatorName: string;
+  mapId: number;
+  maxPlayers: number;
+  participantCount: number;
+  openSlotCount: number;
+  isPrivate: boolean;
+  settings: MatchSettings;
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+  viewerParticipant: MyMatchParticipantSummary;
+}
+
+export interface MyMatchesResponse {
+  matches: MyMatchSummary[];
+}
+
 export interface MatchParticipantSnapshot {
   userId: string;
   userName: string;

--- a/web/src/matches/screens/MyMatchesPage.tsx
+++ b/web/src/matches/screens/MyMatchesPage.tsx
@@ -1,0 +1,351 @@
+import { Link } from "@tanstack/react-router";
+import * as stylex from "@stylexjs/stylex";
+import { awbwSmallMapAssetPath } from "#/awbw/paths.ts";
+import { getCoPortraitByAwbwId } from "#/components/co_portraits.ts";
+import { getFactionById } from "#/factions.ts";
+import {
+  Badge,
+  ButtonLink,
+  EmptyState,
+  Frame,
+  Heading,
+  Inline,
+  Kicker,
+  Page,
+  Section,
+  Stack,
+  Text,
+} from "#/ui/primitives.tsx";
+import { sxClassName } from "#/ui/stylex.ts";
+import { media, tokens } from "#/ui/theme.stylex.ts";
+import type { MatchPhase, MyMatchSummary } from "#/matches/schemas.ts";
+import { formatMyMatchPhaseLabel, myMatchActionLabel } from "#/matches/my_matches.ts";
+
+export function MyMatchesPage({
+  loadedAt,
+  matches,
+}: {
+  loadedAt: string;
+  matches: MyMatchSummary[];
+}) {
+  return (
+    <Page width="wide">
+      <Section>
+        <Stack gap="lg">
+          <div {...stylex.props(styles.header)}>
+            <Stack gap="sm">
+              <Kicker>My Matches</Kicker>
+              <Heading size="display">Ongoing games</Heading>
+              <Text size="lg" tone="strong" xstyle={styles.headerText}>
+                Jump back into lobbies and active matches you have joined.
+              </Text>
+            </Stack>
+            <Inline gap="sm" xstyle={styles.headerActions}>
+              <ButtonLink size="sm" tone="brand" to="/matches/new">
+                Create Match
+              </ButtonLink>
+              <ButtonLink size="sm" tone="neutral" variant="outline" to="/matches">
+                Browse Lobbies
+              </ButtonLink>
+            </Inline>
+          </div>
+
+          {matches.length === 0 ? (
+            <Frame xstyle={styles.stateFrame}>
+              <EmptyState
+                kicker="No Ongoing Games"
+                title="You are not in any active matches or lobbies"
+                description="Create a match or join an open lobby to see it here."
+                actions={
+                  <>
+                    <ButtonLink size="sm" tone="brand" to="/matches/new">
+                      Create Match
+                    </ButtonLink>
+                    <ButtonLink size="sm" tone="neutral" variant="outline" to="/matches">
+                      Browse Lobbies
+                    </ButtonLink>
+                  </>
+                }
+              />
+            </Frame>
+          ) : (
+            <Frame padding="none">
+              <div {...stylex.props(styles.listHeader)}>
+                <Text size="sm" tone="muted" xstyle={styles.listMeta}>
+                  {matches.length === 1 ? "1 ongoing game" : `${matches.length} ongoing games`}
+                </Text>
+              </div>
+              <div {...stylex.props(styles.list)}>
+                {matches.map((match) => (
+                  <MyMatchRow key={match.matchId} loadedAt={loadedAt} match={match} />
+                ))}
+              </div>
+            </Frame>
+          )}
+        </Stack>
+      </Section>
+    </Page>
+  );
+}
+
+function MyMatchRow({ loadedAt, match }: { loadedAt: string; match: MyMatchSummary }) {
+  const faction = getFactionById(match.viewerParticipant.factionId);
+  const coName = getCoPortraitByAwbwId(match.viewerParticipant.coId)?.displayName ?? "No CO";
+
+  return (
+    <Link className={rowClassName} params={{ matchId: match.matchId }} to="/matches/$matchId">
+      <div {...stylex.props(styles.rowMain)}>
+        <div {...stylex.props(styles.thumbWrap)}>
+          <img
+            alt={`Map preview for ${match.name}`}
+            src={awbwSmallMapAssetPath(match.mapId)}
+            {...stylex.props(styles.thumb)}
+          />
+        </div>
+
+        <Stack gap="xs" xstyle={styles.rowTitleBlock}>
+          <Inline gap="sm" xstyle={styles.titleLine}>
+            <Heading size="lg" xstyle={styles.rowTitle}>
+              {match.name}
+            </Heading>
+            <Badge tone={phaseBadgeTone(match.phase)} xstyle={styles.phaseBadge}>
+              {formatMyMatchPhaseLabel(match.phase)}
+            </Badge>
+          </Inline>
+          <Inline gap="sm" xstyle={styles.rowMetaWrap}>
+            <Text size="sm" tone="muted" xstyle={styles.rowMeta}>
+              Host {match.creatorName}
+            </Text>
+            <Text size="sm" tone="muted" xstyle={styles.rowMeta}>
+              Map {match.mapId}
+            </Text>
+            <Text size="sm" tone="muted" xstyle={styles.rowMeta}>
+              {match.isPrivate ? "Private" : "Public"}
+            </Text>
+            <Text size="sm" tone="muted" xstyle={styles.rowMeta}>
+              {match.settings.fogEnabled ? "Fog on" : "Fog off"}
+            </Text>
+            <Text size="sm" tone="muted" xstyle={styles.rowMeta}>
+              {match.settings.startingFunds.toLocaleString()} funds
+            </Text>
+          </Inline>
+          <Text size="sm" tone="muted">
+            Slot {match.viewerParticipant.slotIndex + 1}: {faction?.displayName ?? "Unknown army"} |{" "}
+            {coName} | {match.viewerParticipant.ready ? "Ready" : "Not ready"}
+          </Text>
+        </Stack>
+
+        <div {...stylex.props(styles.rowStats)}>
+          <div {...stylex.props(styles.statBlock)}>
+            <Text size="sm" tone="muted" xstyle={styles.statLabel}>
+              Players
+            </Text>
+            <Text tone="strong">
+              {match.participantCount} / {match.maxPlayers}
+            </Text>
+          </div>
+          <div {...stylex.props(styles.statBlock)}>
+            <Text size="sm" tone="muted" xstyle={styles.statLabel}>
+              Updated
+            </Text>
+            <Text tone="strong">{formatRelativeTime(match.updatedAt, loadedAt)}</Text>
+          </div>
+          <div {...stylex.props(styles.statBlock, styles.actionBlock)}>
+            <Text size="sm" tone="muted" xstyle={styles.statLabel}>
+              Next
+            </Text>
+            <Text tone="strong">{myMatchActionLabel(match.phase)}</Text>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function phaseBadgeTone(phase: MatchPhase): "neutral" | "brand" | "success" | "danger" {
+  switch (phase) {
+    case "active":
+      return "success";
+    case "starting":
+      return "brand";
+    case "cancelled":
+      return "danger";
+    case "draft":
+    case "lobby":
+    case "completed":
+      return "neutral";
+  }
+}
+
+function formatRelativeTime(iso: string, nowIso: string): string {
+  const deltaMs = Date.parse(nowIso) - Date.parse(iso);
+  const deltaMinutes = Math.round(deltaMs / 60_000);
+  const formatter = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+  if (Math.abs(deltaMinutes) < 60) {
+    return formatter.format(-deltaMinutes, "minute");
+  }
+
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (Math.abs(deltaHours) < 24) {
+    return formatter.format(-deltaHours, "hour");
+  }
+
+  const deltaDays = Math.round(deltaHours / 24);
+  return formatter.format(-deltaDays, "day");
+}
+
+const styles = stylex.create({
+  header: {
+    display: "grid",
+    gap: tokens.space4,
+    gridTemplateColumns: {
+      default: "minmax(0, 1fr) auto",
+      [media.compact]: "1fr",
+    },
+    alignItems: "end",
+  },
+  headerText: {
+    maxWidth: 640,
+  },
+  headerActions: {
+    justifyContent: {
+      default: "flex-end",
+      [media.compact]: "flex-start",
+    },
+  },
+  stateFrame: {
+    minHeight: 280,
+  },
+  listHeader: {
+    minHeight: 54,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingInline: tokens.space4,
+    borderBottomWidth: 3,
+    borderBottomStyle: "solid",
+    borderBottomColor: tokens.strokeHeavy,
+    backgroundColor: tokens.panelRaised,
+  },
+  listMeta: {
+    fontFamily: tokens.fontPixel,
+    letterSpacing: tokens.trackingPixel,
+    textTransform: "uppercase",
+  },
+  list: {
+    display: "grid",
+  },
+  row: {
+    color: tokens.inkStrong,
+    textDecoration: "none",
+    borderBottomWidth: 2,
+    borderBottomStyle: "solid",
+    borderBottomColor: tokens.strokeBase,
+    backgroundColor: {
+      default: tokens.panelBg,
+      ":hover": tokens.panelRaised,
+    },
+    transitionDuration: tokens.transitionFast,
+    transitionProperty: "background-color, transform, box-shadow",
+  },
+  rowInteractive: {
+    transform: {
+      default: "translateY(0)",
+      ":hover": "translate(-1px, -1px)",
+      ":active": `translate(${tokens.pressOffsetSm}, ${tokens.pressOffsetSm})`,
+    },
+    boxShadow: {
+      default: "none",
+      ":hover": tokens.shadowHardSm,
+      ":active": "none",
+    },
+  },
+  rowMain: {
+    display: "grid",
+    gap: tokens.space4,
+    gridTemplateColumns: {
+      default: "128px minmax(0, 1fr) minmax(220px, auto)",
+      [media.narrow]: "96px minmax(0, 1fr)",
+      [media.compact]: "1fr",
+    },
+    alignItems: "center",
+    padding: tokens.space4,
+  },
+  thumbWrap: {
+    inlineSize: "100%",
+    aspectRatio: "4 / 3",
+    overflow: "hidden",
+    borderWidth: 2,
+    borderStyle: "solid",
+    borderColor: tokens.strokeHeavy,
+    borderRadius: tokens.radius2,
+    backgroundColor: tokens.panelInset,
+  },
+  thumb: {
+    display: "block",
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    imageRendering: "pixelated",
+  },
+  rowTitleBlock: {
+    minWidth: 0,
+  },
+  titleLine: {
+    alignItems: "center",
+  },
+  phaseBadge: {
+    flexShrink: 0,
+  },
+  rowTitle: {
+    minWidth: 0,
+    overflowWrap: "anywhere",
+  },
+  rowMetaWrap: {
+    rowGap: tokens.space1,
+  },
+  rowMeta: {
+    fontFamily: tokens.fontPixel,
+    letterSpacing: tokens.trackingPixel,
+    textTransform: "uppercase",
+  },
+  rowStats: {
+    display: "grid",
+    gap: tokens.space3,
+    gridColumn: {
+      default: "auto",
+      [media.narrow]: "1 / -1",
+    },
+    gridTemplateColumns: {
+      default: "repeat(3, minmax(0, 1fr))",
+      [media.compact]: "1fr",
+    },
+    minWidth: {
+      default: 220,
+      [media.compact]: 0,
+    },
+  },
+  statBlock: {
+    minWidth: 0,
+    display: "grid",
+    gap: tokens.space1,
+    padding: tokens.space3,
+    borderWidth: 2,
+    borderStyle: "solid",
+    borderColor: tokens.strokeBase,
+    borderRadius: tokens.radius2,
+    backgroundColor: tokens.panelRaised,
+    boxShadow: tokens.highlightInset,
+  },
+  actionBlock: {
+    borderColor: tokens.strokeHeavy,
+  },
+  statLabel: {
+    fontFamily: tokens.fontPixel,
+    letterSpacing: tokens.trackingPixel,
+    textTransform: "uppercase",
+  },
+});
+
+const rowClassName = sxClassName(styles.row, styles.rowInteractive);

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as AuthRouteImport } from './routes/auth'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as MatchesIndexRouteImport } from './routes/matches/index'
+import { Route as MyMatchesRouteImport } from './routes/my/matches'
 import { Route as MatchesNewRouteImport } from './routes/matches/new'
 import { Route as MatchesMatchIdRouteImport } from './routes/matches/$matchId'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
@@ -38,6 +39,11 @@ const IndexRoute = IndexRouteImport.update({
 const MatchesIndexRoute = MatchesIndexRouteImport.update({
   id: '/matches/',
   path: '/matches/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MyMatchesRoute = MyMatchesRouteImport.update({
+  id: '/my/matches',
+  path: '/my/matches',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MatchesNewRoute = MatchesNewRouteImport.update({
@@ -77,6 +83,7 @@ export interface FileRoutesByFullPath {
   '/auth': typeof AuthRoute
   '/matches/$matchId': typeof MatchesMatchIdRoute
   '/matches/new': typeof MatchesNewRoute
+  '/my/matches': typeof MyMatchesRoute
   '/matches/': typeof MatchesIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/awbw/map/$mapId': typeof ApiAwbwMapMapIdRoute
@@ -89,6 +96,7 @@ export interface FileRoutesByTo {
   '/auth': typeof AuthRoute
   '/matches/$matchId': typeof MatchesMatchIdRoute
   '/matches/new': typeof MatchesNewRoute
+  '/my/matches': typeof MyMatchesRoute
   '/matches': typeof MatchesIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/awbw/map/$mapId': typeof ApiAwbwMapMapIdRoute
@@ -102,6 +110,7 @@ export interface FileRoutesById {
   '/auth': typeof AuthRoute
   '/matches/$matchId': typeof MatchesMatchIdRoute
   '/matches/new': typeof MatchesNewRoute
+  '/my/matches': typeof MyMatchesRoute
   '/matches/': typeof MatchesIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/awbw/map/$mapId': typeof ApiAwbwMapMapIdRoute
@@ -116,6 +125,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/matches/$matchId'
     | '/matches/new'
+    | '/my/matches'
     | '/matches/'
     | '/api/auth/$'
     | '/api/awbw/map/$mapId'
@@ -128,6 +138,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/matches/$matchId'
     | '/matches/new'
+    | '/my/matches'
     | '/matches'
     | '/api/auth/$'
     | '/api/awbw/map/$mapId'
@@ -140,6 +151,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/matches/$matchId'
     | '/matches/new'
+    | '/my/matches'
     | '/matches/'
     | '/api/auth/$'
     | '/api/awbw/map/$mapId'
@@ -153,6 +165,7 @@ export interface RootRouteChildren {
   AuthRoute: typeof AuthRoute
   MatchesMatchIdRoute: typeof MatchesMatchIdRoute
   MatchesNewRoute: typeof MatchesNewRoute
+  MyMatchesRoute: typeof MyMatchesRoute
   MatchesIndexRoute: typeof MatchesIndexRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiAwbwMapMapIdRoute: typeof ApiAwbwMapMapIdRoute
@@ -188,6 +201,13 @@ declare module '@tanstack/react-router' {
       path: '/matches'
       fullPath: '/matches/'
       preLoaderRoute: typeof MatchesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/my/matches': {
+      id: '/my/matches'
+      path: '/my/matches'
+      fullPath: '/my/matches'
+      preLoaderRoute: typeof MyMatchesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/matches/new': {
@@ -241,6 +261,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthRoute: AuthRoute,
   MatchesMatchIdRoute: MatchesMatchIdRoute,
   MatchesNewRoute: MatchesNewRoute,
+  MyMatchesRoute: MyMatchesRoute,
   MatchesIndexRoute: MatchesIndexRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiAwbwMapMapIdRoute: ApiAwbwMapMapIdRoute,

--- a/web/src/routes/my/matches.tsx
+++ b/web/src/routes/my/matches.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { ensureSessionFn } from "#/auth/auth.functions.ts";
+import { MyMatchesPage } from "#/matches/screens/MyMatchesPage.tsx";
+import { listMyMatchesFn } from "#/matches/matches.functions.ts";
+
+export const Route = createFileRoute("/my/matches")({
+  loader: async () => {
+    try {
+      await ensureSessionFn();
+      const data = await listMyMatchesFn();
+      return {
+        ...data,
+        loadedAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (isUnauthorizedResponse(error)) {
+        throw redirect({ to: "/auth" });
+      }
+      throw error;
+    }
+  },
+  component: MyMatchesRoute,
+});
+
+function MyMatchesRoute() {
+  const data = Route.useLoaderData();
+  return <MyMatchesPage loadedAt={data.loadedAt} matches={data.matches} />;
+}
+
+function isUnauthorizedResponse(error: unknown): boolean {
+  return (
+    (error instanceof Response && error.status === 401) ||
+    (typeof error === "object" && error !== null && "status" in error && error.status === 401)
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "My Matches" page (nav link shown when signed in) listing your ongoing matches with map, phase badge, host, player counts, your slot/faction/CO and readiness; click a match to open details.
  * Empty state offers "Create Match" and "Browse Lobbies" actions.

* **Style**
  * Improved responsive layout and navigation behavior on smaller screens.

* **Tests**
  * Added tests for match-phase utilities and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->