### PR TITLE
Wire up match WebSocket and active match page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,8 +540,8 @@ dependencies = [
  "bevy",
  "insta",
  "serde",
- "serde-wasm-bindgen",
  "serde_json",
+ "tsify",
  "wasm-bindgen",
 ]
 

--- a/crates/awbrn-server/Cargo.toml
+++ b/crates/awbrn-server/Cargo.toml
@@ -12,8 +12,8 @@ awbrn-map = { path = "../awbrn-map", features = ["bevy"] }
 awbrn-types = { path = "../awbrn-types", features = ["bevy"] }
 bevy = { workspace = true, features = ["std", "bevy_log"] }
 serde_json.workspace = true
-serde-wasm-bindgen.workspace = true
 serde.workspace = true
+tsify.workspace = true
 wasm-bindgen.workspace = true
 
 [dev-dependencies]

--- a/crates/awbrn-server/src/wasm.rs
+++ b/crates/awbrn-server/src/wasm.rs
@@ -4,23 +4,31 @@ use awbrn_map::{AwbrnMap, AwbwMap, AwbwMapData};
 use awbrn_types::PlayerFaction;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use crate::{GameServer, GameSetup, PlayerSetup};
 
 #[wasm_bindgen]
-pub struct WasmMatch;
+pub struct WasmMatch {
+    #[allow(dead_code)]
+    server: GameServer,
+}
 
 #[wasm_bindgen]
 impl WasmMatch {
     #[wasm_bindgen(constructor)]
-    pub fn new(setup: JsValue) -> Result<Self, JsError> {
-        let setup = serde_wasm_bindgen::from_value::<MatchSetupInput>(setup)
-            .map_err(|error| invalid_input("setup", error.to_string()))?
+    pub fn new(setup: MatchSetupInput) -> Result<Self, JsError> {
+        let setup: GameSetup = setup
             .try_into()
             .map_err(|reason| invalid_input("setup", reason))?;
-        GameServer::new(setup).map_err(setup_error)?;
-        Ok(Self)
+        let server = GameServer::new(setup).map_err(setup_error)?;
+        Ok(Self { server })
+    }
+
+    /// Stub: future implementation will validate and apply game actions from WebSocket messages.
+    pub fn process_action(&mut self, _action: JsValue) -> Result<JsValue, JsError> {
+        Err(JsError::new("game actions are not yet implemented"))
     }
 }
 
@@ -38,48 +46,32 @@ where
     details: T,
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[allow(dead_code)]
-struct MatchSetupInput {
-    match_id: Option<String>,
-    map_id: Option<u32>,
-    map: Option<AwbwMapData>,
-    players: Vec<PlayerSetupInput>,
-    fog_enabled: bool,
-    starting_funds: Option<u32>,
+#[derive(Tsify, Deserialize)]
+#[tsify(from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchSetupInput {
+    #[tsify(type = "unknown")]
+    pub map: AwbwMapData,
+    pub players: Vec<PlayerSetupInput>,
+    pub fog_enabled: bool,
+    pub starting_funds: u32,
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct PlayerSetupInput {
-    faction: Option<PlayerFaction>,
-    faction_id: Option<u8>,
-    team: Option<NonZeroU8>,
-    starting_funds: Option<u32>,
-    co_id: Option<u32>,
-}
-
-impl MatchSetupInput {
-    fn resolve_map(&self) -> Result<&AwbwMapData, String> {
-        self.map
-            .as_ref()
-            .ok_or_else(|| "map payload is required".to_string())
-    }
+#[derive(Tsify, Deserialize)]
+#[tsify(from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct PlayerSetupInput {
+    pub faction_id: u8,
+    #[tsify(type = "number | null")]
+    pub team: Option<NonZeroU8>,
+    pub starting_funds: u32,
+    pub co_id: u32,
 }
 
 impl PlayerSetupInput {
     fn resolve_faction(&self) -> Result<PlayerFaction, String> {
-        if let Some(faction) = self.faction {
-            return Ok(faction);
-        }
-
-        let Some(faction_id) = self.faction_id else {
-            return Err("player faction is required".to_string());
-        };
-
-        PlayerFaction::from_awbw_id(faction_id)
-            .ok_or_else(|| format!("unknown AWBW factionId {faction_id}"))
+        PlayerFaction::from_awbw_id(self.faction_id)
+            .ok_or_else(|| format!("unknown AWBW factionId {}", self.faction_id))
     }
 }
 
@@ -87,9 +79,7 @@ impl TryFrom<MatchSetupInput> for GameSetup {
     type Error = String;
 
     fn try_from(value: MatchSetupInput) -> Result<Self, Self::Error> {
-        let default_starting_funds = value.starting_funds.unwrap_or(0);
-        let awbw_map =
-            AwbwMap::try_from(value.resolve_map()?).map_err(|error| error.to_string())?;
+        let awbw_map = AwbwMap::try_from(&value.map).map_err(|error| error.to_string())?;
 
         Ok(Self {
             map: AwbrnMap::from_map(&awbw_map),
@@ -100,8 +90,8 @@ impl TryFrom<MatchSetupInput> for GameSetup {
                     Ok(PlayerSetup {
                         faction: player.resolve_faction()?,
                         team: player.team,
-                        starting_funds: player.starting_funds.unwrap_or(default_starting_funds),
-                        co_id: player.co_id,
+                        starting_funds: player.starting_funds,
+                        co_id: Some(player.co_id),
                     })
                 })
                 .collect::<Result<Vec<_>, String>>()?,

--- a/web/src/awbw/schemas.ts
+++ b/web/src/awbw/schemas.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+export const predeployedUnitSchema = z.object({
+  "Unit ID": z.number().int(),
+  "Unit X": z.number().int(),
+  "Unit Y": z.number().int(),
+  "Unit HP": z.number().int(),
+  "Country Code": z.string(),
+});
+
 export const awbwMapDataSchema = z.object({
   Name: z.string(),
   Author: z.string(),
@@ -8,7 +16,8 @@ export const awbwMapDataSchema = z.object({
   "Size X": z.number(),
   "Size Y": z.number(),
   "Terrain Map": z.array(z.array(z.number())),
-  "Predeployed Units": z.array(z.unknown()),
+  "Predeployed Units": z.array(predeployedUnitSchema),
 });
 
+export type PredeployedUnit = z.infer<typeof predeployedUnitSchema>;
 export type AwbwMapData = z.infer<typeof awbwMapDataSchema>;

--- a/web/src/engine/asset_manifest.ts
+++ b/web/src/engine/asset_manifest.ts
@@ -20,4 +20,4 @@ export const gameAssetConfig: GameAssetConfig = {
 };
 
 export const coPortraitAtlas = coPortraitAtlasData;
-export const coPortraitSheetAssetUrl = toAbsoluteAssetUrl(coPortraitSheetUrl);
+export const coPortraitSheetAssetUrl = coPortraitSheetUrl;

--- a/web/src/matches/match_durable_object.ts
+++ b/web/src/matches/match_durable_object.ts
@@ -1,13 +1,36 @@
 import { DurableObject } from "cloudflare:workers";
 import { drizzle, DrizzleSqliteDODatabase } from "drizzle-orm/durable-sqlite";
 import { migrate } from "drizzle-orm/durable-sqlite/migrator";
-import { count } from "drizzle-orm";
+import { count, eq } from "drizzle-orm";
 import { WasmMatch, initSync } from "#/wasm/awbrn_server.js";
 import matchWasmModule from "../wasm/awbrn_server_bg.wasm";
 import { normalizeCaughtError, ok, type MatchResult } from "./match_protocol";
-import type { MatchCreateResponse } from "./schemas";
+import { matchSetupSchema } from "./schemas";
+import type { MatchCreateResponse, MatchSetup } from "./schemas";
 import migrations from "../../drizzle/match/migrations";
 import { matchEventsTable } from "#/db/match.ts";
+import { getRequestSession } from "#/auth/auth.server.ts";
+
+// TODO: replace with a concrete type once game actions are defined
+type GameActionPayload = Record<string, unknown>;
+
+type MatchEvent =
+  | { kind: "setup"; payload: MatchSetup }
+  | { kind: "action"; payload: GameActionPayload };
+
+function parseMatchEvent(row: { kind: string; payload: unknown }): MatchEvent | null {
+  switch (row.kind) {
+    case "setup": {
+      const result = matchSetupSchema.safeParse(row.payload);
+      return result.success ? { kind: "setup", payload: result.data } : null;
+    }
+    case "action":
+      // TODO: parse against a concrete schema when game actions are defined
+      return { kind: "action", payload: row.payload as GameActionPayload };
+    default:
+      return null;
+  }
+}
 
 let wasmInitialized = false;
 
@@ -22,6 +45,7 @@ function ensureMatchWasmInitialized(): void {
 
 export class MatchDurableObject extends DurableObject<CloudflareBindings> {
   private readonly db: DrizzleSqliteDODatabase;
+  private wasmMatch: WasmMatch | null = null;
 
   constructor(ctx: DurableObjectState, env: CloudflareBindings) {
     super(ctx, env);
@@ -31,7 +55,59 @@ export class MatchDurableObject extends DurableObject<CloudflareBindings> {
     });
   }
 
-  async initializeMatch(setup: unknown): Promise<MatchResult<MatchCreateResponse>> {
+  async fetch(request: Request): Promise<Response> {
+    if (request.headers.get("Upgrade") === "websocket") {
+      const session = await getRequestSession(request);
+      if (!session) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+
+      const setup = this.readSetupEvent();
+      if (!setup) {
+        return new Response("Match not initialized", { status: 503 });
+      }
+
+      return this.handleWebSocketUpgrade(session.user.id, setup);
+    }
+    return new Response("Not found", { status: 404 });
+  }
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const { userId, slotIndex } = ws.deserializeAttachment() as {
+      userId: string;
+      slotIndex: number | null;
+    };
+    const game = this.loadGame();
+    if (game === null) {
+      ws.send(JSON.stringify({ type: "error", message: "match not initialized" }));
+      return;
+    }
+    try {
+      const text = typeof message === "string" ? message : new TextDecoder().decode(message);
+      const action = JSON.parse(text) as GameActionPayload;
+      if (slotIndex === null) {
+        // Spectators cannot submit actions
+        ws.send(JSON.stringify({ type: "error", message: "spectators cannot submit actions" }));
+        return;
+      }
+      // TODO: call game.processAction(slotIndex, action), persist event, broadcast result
+      void action;
+      void userId;
+      this.broadcast({ type: "ack" });
+    } catch {
+      ws.send(JSON.stringify({ type: "error", message: "invalid message" }));
+    }
+  }
+
+  async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
+    ws.close(code, reason);
+  }
+
+  async webSocketError(_ws: WebSocket, error: unknown): Promise<void> {
+    console.error("WebSocket error in match DO:", error);
+  }
+
+  async initializeMatch(setup: MatchSetup): Promise<MatchResult<MatchCreateResponse>> {
     try {
       const matchId = extractMatchId(setup);
 
@@ -40,12 +116,61 @@ export class MatchDurableObject extends DurableObject<CloudflareBindings> {
       }
 
       ensureMatchWasmInitialized();
-      new WasmMatch(setup);
-      this.appendEvent("setup", setup);
+      this.wasmMatch = new WasmMatch(setup);
+      this.appendEvent({ kind: "setup", payload: setup });
 
       return ok({ matchId, joinSlug: null });
     } catch (error) {
       return normalizeCaughtError(error);
+    }
+  }
+
+  private handleWebSocketUpgrade(userId: string, setup: MatchSetup): Response {
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+    const slotIndex = setup.players.findIndex((p) => p.userId === userId);
+    this.ctx.acceptWebSocket(server);
+    server.serializeAttachment({ userId, slotIndex: slotIndex >= 0 ? slotIndex : null });
+    server.send(
+      JSON.stringify({ type: "connected", slotIndex: slotIndex >= 0 ? slotIndex : null }),
+    );
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  private readSetupEvent(): MatchSetup | null {
+    const row = this.db.select().from(matchEventsTable).where(eq(matchEventsTable.seq, 1)).get();
+    if (!row) {
+      return null;
+    }
+    const event = parseMatchEvent(row);
+    return event?.kind === "setup" ? event.payload : null;
+  }
+
+  private loadGame(): WasmMatch | null {
+    if (this.wasmMatch !== null) {
+      return this.wasmMatch;
+    }
+    const setup = this.readSetupEvent();
+    if (!setup) {
+      return null;
+    }
+    ensureMatchWasmInitialized();
+    try {
+      this.wasmMatch = new WasmMatch(setup);
+      return this.wasmMatch;
+    } catch {
+      return null;
+    }
+  }
+
+  private broadcast(message: unknown): void {
+    const text = JSON.stringify(message);
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        ws.send(text);
+      } catch {
+        // ignore closed connections
+      }
     }
   }
 
@@ -54,12 +179,12 @@ export class MatchDurableObject extends DurableObject<CloudflareBindings> {
     return (result?.value ?? 0) > 0;
   }
 
-  private appendEvent(kind: string, payload: unknown): void {
+  private appendEvent(event: MatchEvent): void {
     this.db
       .insert(matchEventsTable)
       .values({
-        kind,
-        payload,
+        kind: event.kind,
+        payload: event.payload,
         createdAt: new Date(),
       })
       .run();

--- a/web/src/matches/match_websocket.ts
+++ b/web/src/matches/match_websocket.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type MatchWebSocketStatus = "connecting" | "connected" | "disconnected" | "error";
+
+export interface MatchWebSocketMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface MatchWebSocket {
+  status: MatchWebSocketStatus;
+  sendMessage: (message: unknown) => void;
+}
+
+const BASE_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+export function useMatchWebSocket(
+  matchId: string,
+  onMessage: (msg: MatchWebSocketMessage) => void,
+): MatchWebSocket {
+  const [status, setStatus] = useState<MatchWebSocketStatus>("connecting");
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const unmountedRef = useRef(false);
+  const onMessageRef = useRef(onMessage);
+  onMessageRef.current = onMessage;
+
+  const connect = useCallback(() => {
+    if (unmountedRef.current) return;
+    if (wsRef.current?.readyState === WebSocket.CONNECTING) return;
+
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${protocol}//${window.location.host}/api/matches/${matchId}/ws`;
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+    setStatus("connecting");
+
+    ws.addEventListener("open", () => {
+      if (unmountedRef.current || wsRef.current !== ws) return;
+      reconnectAttemptRef.current = 0;
+      setStatus("connected");
+    });
+
+    ws.addEventListener("message", (event: MessageEvent<string>) => {
+      if (unmountedRef.current || wsRef.current !== ws) return;
+      try {
+        const parsed = JSON.parse(event.data) as MatchWebSocketMessage;
+        onMessageRef.current(parsed);
+      } catch {
+        // ignore unparseable frames
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      if (unmountedRef.current || wsRef.current !== ws) return;
+      wsRef.current = null;
+      setStatus("disconnected");
+      const attempt = reconnectAttemptRef.current;
+      const delay = Math.min(BASE_RECONNECT_DELAY_MS * 2 ** attempt, MAX_RECONNECT_DELAY_MS);
+      const jitter = delay * 0.2 * Math.random();
+      reconnectAttemptRef.current = attempt + 1;
+      reconnectTimerRef.current = setTimeout(connect, delay + jitter);
+    });
+
+    ws.addEventListener("error", () => {
+      if (unmountedRef.current || wsRef.current !== ws) return;
+      setStatus("error");
+      // close fires after error, which triggers the reconnect
+    });
+  }, [matchId]);
+
+  useEffect(() => {
+    unmountedRef.current = false;
+    reconnectAttemptRef.current = 0;
+    connect();
+
+    return () => {
+      unmountedRef.current = true;
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, [connect]);
+
+  const sendMessage = useCallback((message: unknown) => {
+    const ws = wsRef.current;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(message));
+    }
+  }, []);
+
+  return { status, sendMessage };
+}

--- a/web/src/matches/matches.server.ts
+++ b/web/src/matches/matches.server.ts
@@ -11,6 +11,7 @@ import type {
   MatchParticipantSnapshot,
   MatchPhase,
   MatchSettings,
+  MatchSetup,
   MatchSnapshot,
   MyMatchesResponse,
   MyMatchSummary,
@@ -39,22 +40,6 @@ const ACTIVE_MATCH_PHASE: MatchPhase = "active";
 interface MatchViewer {
   id: string;
   name: string;
-}
-
-interface MatchSetupPlayer {
-  factionId: number;
-  team: null;
-  startingFunds: number;
-  coId: number;
-}
-
-interface MatchSetup {
-  matchId: string;
-  mapId: number;
-  map: AwbwMapData;
-  players: MatchSetupPlayer[];
-  fogEnabled: boolean;
-  startingFunds: number;
 }
 
 type MatchActionDiagnostics =
@@ -530,7 +515,9 @@ async function buildMatchSetup(row: NonNullable<MatchRow>): Promise<MatchResult<
     map,
     fogEnabled: settings.value.fogEnabled,
     startingFunds: settings.value.startingFunds,
+    creatorUserId: row.creatorUserId,
     players: participantRows.map((participant) => ({
+      userId: participant.userId,
       factionId: participant.factionId,
       team: null,
       startingFunds: settings.value.startingFunds,

--- a/web/src/matches/schemas.ts
+++ b/web/src/matches/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { awbwMapDataSchema } from "#/awbw/schemas.ts";
 
 export const matchSettingsSchema = z.object({
   fogEnabled: z.boolean(),
@@ -129,3 +130,24 @@ export interface MatchSnapshot {
 export interface MatchMutationResponse {
   match: MatchSnapshot;
 }
+
+export const matchSetupPlayerSchema = z.object({
+  userId: z.string(),
+  factionId: z.number().int(),
+  team: z.null(),
+  startingFunds: z.number().int().nonnegative(),
+  coId: z.number().int(),
+});
+
+export const matchSetupSchema = z.object({
+  matchId: z.string(),
+  mapId: z.number().int().positive(),
+  map: awbwMapDataSchema,
+  players: z.array(matchSetupPlayerSchema),
+  fogEnabled: z.boolean(),
+  startingFunds: z.number().int().nonnegative(),
+  creatorUserId: z.string(),
+});
+
+export type MatchSetupPlayer = z.infer<typeof matchSetupPlayerSchema>;
+export type MatchSetup = z.infer<typeof matchSetupSchema>;

--- a/web/src/matches/screens/MatchActivePage.tsx
+++ b/web/src/matches/screens/MatchActivePage.tsx
@@ -1,0 +1,184 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import * as stylex from "@stylexjs/stylex";
+import { useMemo } from "react";
+import { CoPortrait } from "#/components/CoPortrait.tsx";
+import {
+  DEFAULT_CO_PORTRAIT_KEY,
+  getCoPortraitByAwbwId,
+  loadCoPortraitCatalog,
+} from "#/components/co_portraits.ts";
+import { getFactionById } from "#/factions.ts";
+import { getFactionVisual } from "#/faction_visuals.ts";
+import { PlayerHeader } from "#/components/PlayerHeader.tsx";
+import { Frame, Heading, Kicker, Page, Section, Text } from "#/ui/primitives.tsx";
+import { tokens } from "#/ui/theme.stylex.ts";
+import { matchDetailQueryOptions } from "#/matches/matches.queries.ts";
+import { useMatchWebSocket } from "#/matches/match_websocket.ts";
+
+export function MatchActivePage({ matchId }: { matchId: string }) {
+  const { data: match } = useSuspenseQuery(matchDetailQueryOptions(matchId, null));
+  const portraitCatalog = useMemo(() => loadCoPortraitCatalog(), []);
+  const { status } = useMatchWebSocket(matchId, (_msg) => {
+    // TODO: apply incoming game events to local state
+  });
+
+  return (
+    <Page width="wide">
+      <Section>
+        <div {...stylex.props(styles.layout)}>
+          <header {...stylex.props(styles.header)}>
+            <div {...stylex.props(styles.headerCopy)}>
+              <Kicker xstyle={styles.headerKicker}>Match Active</Kicker>
+              <Heading size="display">{match.name}</Heading>
+              <Text size="lg" tone="strong">
+                Map {match.mapId} · {match.maxPlayers} players ·{" "}
+                {match.settings.fogEnabled ? "Fog on" : "Fog off"}
+              </Text>
+            </div>
+          </header>
+
+          <div {...stylex.props(styles.mainGrid)}>
+            <Frame as="section" surface="panel" padding="none" xstyle={styles.gameSection}>
+              <div {...stylex.props(styles.gamePlaceholder)}>
+                <Kicker>Game Board</Kicker>
+                <Text tone="muted">
+                  {status === "connected"
+                    ? "Connected. Game canvas will render here."
+                    : status === "connecting"
+                      ? "Connecting to match..."
+                      : status === "error"
+                        ? "Connection error — retrying."
+                        : "Disconnected — reconnecting."}
+                </Text>
+                <div {...stylex.props(styles.statusDot(status))} />
+              </div>
+            </Frame>
+
+            <Frame as="section" surface="panel" padding="none" xstyle={styles.rosterSection}>
+              <div {...stylex.props(styles.rosterInner)}>
+                <div {...stylex.props(styles.sectionHeader)}>
+                  <Kicker>Roster</Kicker>
+                  <Heading size="lg">Players</Heading>
+                </div>
+
+                <div {...stylex.props(styles.participantList)}>
+                  {match.participants.map((participant) => {
+                    const faction = getFactionById(participant.factionId);
+                    const factionVisual = getFactionVisual(faction?.code ?? "os");
+                    const portrait = getCoPortraitByAwbwId(participant.coId);
+
+                    return (
+                      <div
+                        key={participant.slotIndex}
+                        {...stylex.props(styles.participantCard(factionVisual.accent))}
+                      >
+                        <PlayerHeader
+                          factionCode={faction?.code ?? "os"}
+                          name={participant.userName}
+                        />
+                        <div {...stylex.props(styles.participantBody)}>
+                          <CoPortrait
+                            catalog={portraitCatalog}
+                            coKey={portrait?.key ?? DEFAULT_CO_PORTRAIT_KEY}
+                            fallbackLabel={portrait?.displayName ?? "No CO"}
+                          />
+                          <Text size="sm" tone="muted">
+                            {portrait?.displayName ?? "No CO"}
+                          </Text>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </Frame>
+          </div>
+        </div>
+      </Section>
+    </Page>
+  );
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  connected: "#4ade80",
+  connecting: "#facc15",
+  disconnected: "#94a3b8",
+  error: "#f87171",
+};
+
+const styles = stylex.create({
+  layout: {
+    display: "grid",
+    gap: tokens.space6,
+  },
+  header: {
+    paddingBottom: tokens.space5,
+    borderBottomWidth: 3,
+    borderBottomStyle: "solid",
+    borderBottomColor: tokens.chromeBorderSoft,
+  },
+  headerCopy: {
+    display: "grid",
+    gap: tokens.space2,
+  },
+  headerKicker: {
+    color: tokens.brandHover,
+  },
+  mainGrid: {
+    display: "grid",
+    gap: tokens.space8,
+    gridTemplateColumns: {
+      default: "minmax(0, 1fr) minmax(360px, 460px)",
+      "@media (max-width: 980px)": "1fr",
+    },
+    alignItems: "start",
+  },
+  gameSection: {
+    overflow: "visible",
+    minHeight: 360,
+  },
+  gamePlaceholder: {
+    display: "grid",
+    gap: tokens.space3,
+    padding: tokens.space6,
+    alignContent: "start",
+  },
+  statusDot: (status: string) => ({
+    width: 10,
+    height: 10,
+    borderRadius: "50%",
+    backgroundColor: STATUS_COLORS[status] ?? STATUS_COLORS.disconnected,
+  }),
+  rosterSection: {
+    overflow: "visible",
+  },
+  rosterInner: {
+    display: "grid",
+    gap: tokens.space4,
+    alignContent: "start",
+    padding: tokens.space6,
+  },
+  sectionHeader: {
+    display: "grid",
+    gap: tokens.space1,
+  },
+  participantList: {
+    display: "grid",
+    gap: tokens.space3,
+  },
+  participantCard: (accent: string) => ({
+    display: "grid",
+    borderWidth: 2,
+    borderStyle: "solid",
+    borderColor: accent,
+    borderRadius: tokens.radius2,
+    overflow: "hidden",
+    boxShadow: `${tokens.highlightInset}, ${tokens.shadowHardSm}`,
+  }),
+  participantBody: {
+    display: "flex",
+    alignItems: "center",
+    gap: tokens.space3,
+    padding: tokens.space3,
+  },
+});

--- a/web/src/routes/matches/$matchId.tsx
+++ b/web/src/routes/matches/$matchId.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { matchDetailQueryOptions } from "#/matches/matches.queries.ts";
+import { MatchActivePage } from "#/matches/screens/MatchActivePage.tsx";
 import { MatchLobbyPage } from "#/matches/screens/MatchLobbyPage.tsx";
 
 type MatchSearch = {
@@ -18,11 +20,17 @@ export const Route = createFileRoute("/matches/$matchId")({
       matchDetailQueryOptions(params.matchId, deps.joinSlug),
     );
   },
-  component: MatchLobbyRouteComponent,
+  component: MatchRouteComponent,
 });
 
-function MatchLobbyRouteComponent() {
+function MatchRouteComponent() {
   const { matchId } = Route.useParams();
   const search = Route.useSearch();
-  return <MatchLobbyPage matchId={matchId} joinSlug={search.join ?? null} />;
+  const joinSlug = search.join ?? null;
+  const { data: match } = useSuspenseQuery(matchDetailQueryOptions(matchId, joinSlug));
+
+  if (match.phase === "active") {
+    return <MatchActivePage matchId={matchId} />;
+  }
+  return <MatchLobbyPage matchId={matchId} joinSlug={joinSlug} />;
 }

--- a/web/src/server.ts
+++ b/web/src/server.ts
@@ -1,5 +1,6 @@
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 import { MatchDurableObject } from "#/matches/match_durable_object.ts";
+import { getMatchStub } from "#/matches/match_service.ts";
 
 export { MatchDurableObject };
 
@@ -17,13 +18,12 @@ export default createServerEntry({
     const websocketMatch = MATCH_WEBSOCKET_PATTERN.exec(request.url);
     if (websocketMatch && request.headers.get("Upgrade") === "websocket") {
       const { matchId } = websocketMatch.pathname.groups;
-      // TODO: forward websocket upgrades to the match durable object via:
-      // const stub = env.MATCHES.get(env.MATCHES.idFromString(matchId));
-      // return stub.fetch(request);
-      // This websocket path is reserved for future match traffic once the runtime protocol exists.
-      return new Response(`Match websocket forwarding is not implemented for ${matchId}`, {
+      if (matchId) {
+        return getMatchStub(matchId).fetch(request);
+      }
+      return new Response("Invalid match ID", {
+        status: 400,
         headers: crossOriginIsolationHeaders,
-        status: 501,
       });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time match WebSocket support with per-connection auth, broadcasting, and in-memory match caching
  * Client hook for reliable match WebSocket connections with reconnect/backoff
  * New Active Match page showing live board, connection status, and roster
  * Validated match setup schemas and types for persisted setups
  * WASM-backed match instance exposed with an action endpoint (currently returns “not yet implemented”)

* **Chores**
  * Simplified asset export for CO portrait sheet URL
<!-- end of auto-generated comment: release notes by coderabbit.ai -->