### PR TITLE
Build action

### DIFF
--- a/crates/awbrn-server/src/apply.rs
+++ b/crates/awbrn-server/src/apply.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use crate::command::{GameCommand, PostMoveAction};
 use crate::damage::{CombatInput, CombatSide, LuckCap, PercentMod, TerrainStars};
 use crate::player::PlayerRegistry;
+use crate::server::spawn_unit_entity;
 use crate::setup::GameRng;
 use crate::state::{ServerGameState, TurnPhase};
 use crate::unit_id::ServerUnitId;
@@ -67,6 +68,11 @@ pub(crate) enum ApplyOutcome {
         tile: awbrn_map::Position,
         progress: u8,
     },
+    UnitBuilt {
+        tile: awbrn_map::Position,
+        unit_type: awbrn_types::Unit,
+        unit_id: ServerUnitId,
+    },
 }
 
 /// Apply a validated command to the world. Returns the outcome for view generation.
@@ -77,10 +83,38 @@ pub(crate) fn apply_command(world: &mut World, command: &GameCommand) -> ApplyOu
             path,
             action,
         } => apply_move_unit(world, *unit_id, path, action.as_ref()),
-        GameCommand::Build { .. } => {
-            unreachable!("build should have been rejected by validation")
-        }
+        GameCommand::Build {
+            position,
+            unit_type,
+        } => apply_build(world, *position, *unit_type),
         GameCommand::EndTurn => apply_end_turn(world),
+    }
+}
+
+fn apply_build(
+    world: &mut World,
+    tile: awbrn_map::Position,
+    unit_type: awbrn_types::Unit,
+) -> ApplyOutcome {
+    let player = world.resource::<ServerGameState>().active_player;
+    let faction = world
+        .resource::<PlayerRegistry>()
+        .faction_for_player(player)
+        .expect("validated build player must have a faction");
+    let cost = unit_type.base_cost();
+
+    world
+        .resource_mut::<PlayerRegistry>()
+        .get_mut(player)
+        .expect("validated build player must exist")
+        .funds -= cost;
+
+    let unit_id = spawn_unit_entity(world, tile, unit_type, faction, false);
+
+    ApplyOutcome::UnitBuilt {
+        tile,
+        unit_type,
+        unit_id,
     }
 }
 

--- a/crates/awbrn-server/src/command.rs
+++ b/crates/awbrn-server/src/command.rs
@@ -51,6 +51,22 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_build() {
+        let json = r#"{"type":"build","position":{"x":0,"y":0},"unit_type":"Infantry"}"#;
+        let cmd: GameCommand = serde_json::from_str(json).unwrap();
+        match cmd {
+            GameCommand::Build {
+                position,
+                unit_type,
+            } => {
+                assert_eq!(position, Position::new(0, 0));
+                assert_eq!(unit_type, awbrn_types::Unit::Infantry);
+            }
+            other => panic!("expected Build, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn deserialize_post_move_action_capture() {
         let json = r#"{"type":"capture"}"#;
         let action: PostMoveAction = serde_json::from_str(json).unwrap();

--- a/crates/awbrn-server/src/server.rs
+++ b/crates/awbrn-server/src/server.rs
@@ -10,6 +10,7 @@ use crate::validate;
 use crate::view::{self, CommandResult, PlayerView};
 
 use awbrn_map::Position;
+use awbrn_types::{PlayerFaction, Unit};
 
 /// Authoritative game server that owns a Bevy World and processes player commands.
 pub struct GameServer {
@@ -59,26 +60,38 @@ impl GameServer {
     pub fn spawn_unit(
         &mut self,
         position: Position,
-        unit_type: awbrn_types::Unit,
-        faction: awbrn_types::PlayerFaction,
+        unit_type: Unit,
+        faction: PlayerFaction,
     ) -> ServerUnitId {
-        let id = self
-            .world
-            .resource_mut::<crate::state::ServerGameState>()
-            .allocate_unit_id();
-
-        self.world.spawn((
-            awbrn_game::MapPosition::from(position),
-            awbrn_game::world::Unit(unit_type),
-            awbrn_game::world::Faction(faction),
-            awbrn_game::world::UnitHp(awbrn_types::ExactHp::new(100)),
-            awbrn_game::world::Fuel(unit_type.max_fuel()),
-            awbrn_game::world::Ammo(unit_type.max_ammo()),
-            awbrn_game::world::VisionRange(unit_type.base_vision()),
-            awbrn_game::world::UnitActive,
-            id,
-        ));
-
-        id
+        spawn_unit_entity(&mut self.world, position, unit_type, faction, true)
     }
+}
+
+pub(crate) fn spawn_unit_entity(
+    world: &mut World,
+    position: Position,
+    unit_type: Unit,
+    faction: PlayerFaction,
+    active: bool,
+) -> ServerUnitId {
+    let id = world
+        .resource_mut::<crate::state::ServerGameState>()
+        .allocate_unit_id();
+
+    let mut entity = world.spawn((
+        awbrn_game::MapPosition::from(position),
+        awbrn_game::world::Unit(unit_type),
+        awbrn_game::world::Faction(faction),
+        awbrn_game::world::UnitHp(awbrn_types::ExactHp::new(100)),
+        awbrn_game::world::Fuel(unit_type.max_fuel()),
+        awbrn_game::world::Ammo(unit_type.max_ammo()),
+        awbrn_game::world::VisionRange(unit_type.base_vision()),
+        id,
+    ));
+
+    if active {
+        entity.insert(awbrn_game::world::UnitActive);
+    }
+
+    id
 }

--- a/crates/awbrn-server/src/validate.rs
+++ b/crates/awbrn-server/src/validate.rs
@@ -14,6 +14,7 @@ use awbrn_game::world::{Ammo, BoardIndex, Faction, Fuel, GameMap, StrongIdMap, U
 use awbrn_map::Position;
 use awbrn_types::{
     Faction as TerrainFaction, GraphicalTerrain, MovementCost, MovementTerrain, PlayerFaction,
+    PropertyKind, UnitDomain,
 };
 
 #[derive(SystemParam)]
@@ -60,14 +61,68 @@ pub(crate) fn validate_command(
             path,
             action,
         } => validate_move_unit(world, player, *unit_id, path, action.as_ref()),
-        GameCommand::Build { .. } => {
-            // Build validation will be added in a future phase.
-            Err(CommandError::InvalidAction {
-                reason: "build not yet implemented".into(),
-            })
-        }
+        GameCommand::Build {
+            position,
+            unit_type,
+        } => validate_build(world, player, *position, *unit_type),
         GameCommand::EndTurn => Ok(()),
     }
+}
+
+fn validate_build(
+    world: &World,
+    player: PlayerId,
+    position: Position,
+    unit_type: awbrn_types::Unit,
+) -> Result<(), CommandError> {
+    let player_faction = world
+        .resource::<PlayerRegistry>()
+        .faction_for_player(player)
+        .ok_or(CommandError::InvalidBuildLocation)?;
+
+    let terrain = world
+        .resource::<GameMap>()
+        .terrain_at(position)
+        .ok_or(CommandError::InvalidBuildLocation)?;
+
+    let GraphicalTerrain::Property(property) = terrain else {
+        return Err(CommandError::InvalidBuildLocation);
+    };
+
+    if property.faction() != TerrainFaction::Player(player_faction) {
+        return Err(CommandError::InvalidBuildLocation);
+    }
+
+    let required_domain = match property.kind() {
+        PropertyKind::Base => UnitDomain::Ground,
+        PropertyKind::Airport => UnitDomain::Air,
+        PropertyKind::Port => UnitDomain::Sea,
+        _ => return Err(CommandError::InvalidBuildLocation),
+    };
+
+    if unit_type.domain() != required_domain {
+        return Err(CommandError::InvalidBuildLocation);
+    }
+
+    let occupied = world
+        .resource::<BoardIndex>()
+        .unit_entity(position)
+        .map_err(|_| CommandError::InvalidBuildLocation)?;
+    if occupied.is_some() {
+        return Err(CommandError::InvalidBuildLocation);
+    }
+
+    let cost = unit_type.base_cost();
+    let available = world
+        .resource::<PlayerRegistry>()
+        .get(player)
+        .map(|slot| slot.funds)
+        .ok_or(CommandError::InvalidBuildLocation)?;
+    if available < cost {
+        return Err(CommandError::InsufficientFunds { cost, available });
+    }
+
+    Ok(())
 }
 
 fn validate_move_unit(

--- a/crates/awbrn-server/src/view.rs
+++ b/crates/awbrn-server/src/view.rs
@@ -8,7 +8,7 @@ use awbrn_game::MapPosition;
 use awbrn_game::replay::{PowerVisionBoosts, range_modifier_for_weather};
 use awbrn_game::world::{
     Ammo, CaptureProgress, CarriedBy, CurrentWeather, Faction, FogOfWarMap, Fuel, GameMap,
-    GraphicalHp, Unit, VisionRange, collect_friendly_units, rebuild_fog_map,
+    GraphicalHp, StrongIdMap, Unit, VisionRange, collect_friendly_units, rebuild_fog_map,
 };
 use awbrn_map::Position;
 use awbrn_types::PlayerFaction;
@@ -115,6 +115,9 @@ pub struct PlayerUpdate {
     pub combat_event: Option<UnitCombatEvent>,
     /// Capture event (if a capture action was visible to this player).
     pub capture_event: Option<CaptureEvent>,
+    /// Updated funds for this player, when the command changed their balance.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub my_funds: Option<u32>,
     /// Current game state.
     pub state: GameStateHeader,
 }
@@ -290,6 +293,7 @@ fn build_player_update(
                 turn_change: None,
                 combat_event: None,
                 capture_event: None,
+                my_funds: None,
                 state: header.clone(),
             }
         }
@@ -308,8 +312,89 @@ fn build_player_update(
             }),
             combat_event: None,
             capture_event: None,
+            my_funds: None,
             state: header.clone(),
         },
+        ApplyOutcome::UnitBuilt {
+            tile,
+            unit_type,
+            unit_id,
+        } => {
+            let entity = world
+                .resource::<StrongIdMap<ServerUnitId>>()
+                .get(unit_id)
+                .expect("built unit must exist");
+            let faction = world
+                .entity(entity)
+                .get::<Faction>()
+                .expect("built unit must have faction")
+                .0;
+
+            let mut units_revealed = Vec::new();
+            let mut units_removed = Vec::new();
+            let mut terrain_revealed = Vec::new();
+            let is_friendly_unit = friendly_factions.contains(&faction);
+
+            if is_friendly_unit {
+                if let Some(visible) = entity_to_visible_unit(world, entity, &friendly_factions) {
+                    units_revealed.push(visible);
+                }
+
+                let pre_enemies = visible_enemy_units(world, &friendly_factions, pre_fog);
+                let post_enemies = visible_enemy_units(world, &friendly_factions, post_fog);
+
+                for (uid, ent) in &post_enemies {
+                    if !pre_enemies.contains_key(uid)
+                        && let Some(visible) =
+                            entity_to_visible_unit(world, *ent, &friendly_factions)
+                    {
+                        units_revealed.push(visible);
+                    }
+                }
+                for uid in pre_enemies.keys() {
+                    if !post_enemies.contains_key(uid) {
+                        units_removed.push(*uid);
+                    }
+                }
+
+                terrain_revealed = terrain_diff(world, pre_fog, post_fog);
+            } else {
+                let is_air = unit_type.domain() == awbrn_types::UnitDomain::Air;
+                let tile_is_visible = post_fog
+                    .map(|fog| fog.is_unit_visible(*tile, is_air))
+                    .unwrap_or(true);
+
+                if tile_is_visible
+                    && let Some(visible) = entity_to_visible_unit(world, entity, &friendly_factions)
+                {
+                    units_revealed.push(visible);
+                }
+            }
+
+            let my_funds = world
+                .resource::<PlayerRegistry>()
+                .player_for_faction(faction)
+                .filter(|owner| *owner == player)
+                .and_then(|owner| {
+                    world
+                        .resource::<PlayerRegistry>()
+                        .get(owner)
+                        .map(|slot| slot.funds)
+                });
+
+            PlayerUpdate {
+                units_revealed,
+                units_moved: Vec::new(),
+                units_removed,
+                terrain_revealed,
+                terrain_changed: Vec::new(),
+                turn_change: None,
+                combat_event: None,
+                capture_event: None,
+                my_funds,
+                state: header.clone(),
+            }
+        }
         ApplyOutcome::UnitAttacked {
             attacker_id,
             attacker_entity,
@@ -452,6 +537,7 @@ fn build_player_update(
                 turn_change: None,
                 combat_event,
                 capture_event: None,
+                my_funds: None,
                 state: header.clone(),
             }
         }
@@ -496,6 +582,7 @@ fn build_player_update(
                 turn_change: None,
                 combat_event: None,
                 capture_event,
+                my_funds: None,
                 state: header.clone(),
             }
         }
@@ -555,6 +642,7 @@ fn build_player_update(
                 turn_change: None,
                 combat_event: None,
                 capture_event,
+                my_funds: None,
                 state: header.clone(),
             }
         }

--- a/crates/awbrn-server/tests/server.rs
+++ b/crates/awbrn-server/tests/server.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU8;
 
 use awbrn_map::{AwbrnMap, Position};
-use awbrn_types::{Faction as TerrainFaction, GraphicalTerrain, PlayerFaction, Property};
+use awbrn_types::{Faction as TerrainFaction, GraphicalTerrain, PlayerFaction, Property, Unit};
 
 use awbrn_server::{
     CaptureEvent, Co, CommandError, GameCommand, GameServer, GameSetup, PlayerId, PlayerSetup,
@@ -21,6 +21,13 @@ fn capture_command(unit_id: ServerUnitId, position: Position) -> GameCommand {
         unit_id,
         path: vec![position],
         action: Some(PostMoveAction::Capture),
+    }
+}
+
+fn build_command(position: Position, unit_type: Unit) -> GameCommand {
+    GameCommand::Build {
+        position,
+        unit_type,
     }
 }
 
@@ -44,6 +51,18 @@ fn two_player_setup(width: usize, height: usize) -> GameSetup {
         fog_enabled: false,
         rng_seed: 0,
     }
+}
+
+fn two_player_setup_with_funds(width: usize, height: usize, p1_funds: u32) -> GameSetup {
+    let mut setup = two_player_setup(width, height);
+    setup.players[0].starting_funds = p1_funds;
+    setup
+}
+
+fn set_property(setup: &mut GameSetup, position: Position, property: Property) {
+    setup
+        .map
+        .set_terrain(position, GraphicalTerrain::Property(property));
 }
 
 fn allied_player_setup(width: usize, height: usize) -> GameSetup {
@@ -142,6 +161,296 @@ fn create_server_and_spawn_unit() {
     assert_eq!(view.my_funds, 1000);
     assert_eq!(view.state.day, 1);
     assert_eq!(view.state.active_player, p1());
+}
+
+#[test]
+fn build_infantry_from_owned_base_deducts_funds_and_spawns_unit() {
+    let base = Position::new(0, 0);
+    let mut setup = two_player_setup(3, 3);
+    set_property(
+        &mut setup,
+        base,
+        Property::Base(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    let mut server = GameServer::new(setup).unwrap();
+
+    let result = server
+        .submit_command(p1(), build_command(base, Unit::Infantry))
+        .unwrap();
+
+    let p1_update = result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p1())
+        .unwrap()
+        .1
+        .clone();
+    assert_eq!(p1_update.my_funds, Some(0));
+    let built = p1_update
+        .units_revealed
+        .iter()
+        .find(|unit| unit.position == base && unit.unit_type == Unit::Infantry)
+        .expect("owner should see the built unit");
+    assert_eq!(built.hp, 10);
+    assert_eq!(built.fuel, Some(Unit::Infantry.max_fuel()));
+    assert_eq!(built.ammo, Some(Unit::Infantry.max_ammo()));
+
+    let view = server.player_view(p1());
+    assert_eq!(view.my_funds, 0);
+    let built = view
+        .units
+        .iter()
+        .find(|unit| unit.position == base && unit.unit_type == Unit::Infantry)
+        .expect("built unit should appear in player_view");
+    assert_eq!(built.hp, 10);
+    assert_eq!(built.fuel, Some(Unit::Infantry.max_fuel()));
+    assert_eq!(built.ammo, Some(Unit::Infantry.max_ammo()));
+
+    let p2_update = result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p2())
+        .unwrap()
+        .1
+        .clone();
+    assert_eq!(p2_update.my_funds, None);
+}
+
+#[test]
+fn built_unit_cannot_act_until_next_turn_and_id_is_registered() {
+    let base = Position::new(0, 0);
+    let mut setup = two_player_setup(3, 3);
+    set_property(
+        &mut setup,
+        base,
+        Property::Base(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    let mut server = GameServer::new(setup).unwrap();
+
+    let result = server
+        .submit_command(p1(), build_command(base, Unit::Infantry))
+        .unwrap();
+    let built_id = result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p1())
+        .unwrap()
+        .1
+        .units_revealed
+        .iter()
+        .find(|unit| unit.position == base && unit.unit_type == Unit::Infantry)
+        .unwrap()
+        .id;
+
+    let err = server
+        .submit_command(
+            p1(),
+            GameCommand::MoveUnit {
+                unit_id: built_id,
+                path: vec![base, Position::new(1, 0)],
+                action: Some(PostMoveAction::Wait),
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(err, CommandError::UnitAlreadyActed(id) if id == built_id));
+
+    server.submit_command(p1(), GameCommand::EndTurn).unwrap();
+    server.submit_command(p2(), GameCommand::EndTurn).unwrap();
+
+    server
+        .submit_command(
+            p1(),
+            GameCommand::MoveUnit {
+                unit_id: built_id,
+                path: vec![base, Position::new(1, 0)],
+                action: Some(PostMoveAction::Wait),
+            },
+        )
+        .expect("built unit id should be registered and active next turn");
+}
+
+#[test]
+fn build_rejects_insufficient_funds() {
+    let base = Position::new(0, 0);
+    let mut setup = two_player_setup_with_funds(3, 3, 1000);
+    set_property(
+        &mut setup,
+        base,
+        Property::Base(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    let mut server = GameServer::new(setup).unwrap();
+
+    let err = server
+        .submit_command(p1(), build_command(base, Unit::Mech))
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CommandError::InsufficientFunds {
+            cost: 3000,
+            available: 1000
+        }
+    ));
+}
+
+#[test]
+fn build_rejects_occupied_facility() {
+    let base = Position::new(0, 0);
+    let mut setup = two_player_setup(3, 3);
+    set_property(
+        &mut setup,
+        base,
+        Property::Base(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    let mut server = GameServer::new(setup).unwrap();
+    server.spawn_unit(base, Unit::Infantry, PlayerFaction::OrangeStar);
+
+    let err = server
+        .submit_command(p1(), build_command(base, Unit::Infantry))
+        .unwrap_err();
+
+    assert!(matches!(err, CommandError::InvalidBuildLocation));
+}
+
+#[test]
+fn build_rejects_unit_domain_that_facility_cannot_produce() {
+    let base = Position::new(0, 0);
+    let mut setup = two_player_setup_with_funds(3, 3, 30000);
+    set_property(
+        &mut setup,
+        base,
+        Property::Base(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    let mut server = GameServer::new(setup).unwrap();
+
+    let err = server
+        .submit_command(p1(), build_command(base, Unit::Battleship))
+        .unwrap_err();
+
+    assert!(matches!(err, CommandError::InvalidBuildLocation));
+}
+
+#[test]
+fn build_rejects_facility_not_owned_by_player() {
+    let neutral_base = Position::new(0, 0);
+    let enemy_base = Position::new(1, 0);
+    let mut setup = two_player_setup(3, 3);
+    set_property(
+        &mut setup,
+        neutral_base,
+        Property::Base(TerrainFaction::Neutral),
+    );
+    set_property(
+        &mut setup,
+        enemy_base,
+        Property::Base(TerrainFaction::Player(PlayerFaction::BlueMoon)),
+    );
+    let mut server = GameServer::new(setup).unwrap();
+
+    let neutral_err = server
+        .submit_command(p1(), build_command(neutral_base, Unit::Infantry))
+        .unwrap_err();
+    let enemy_err = server
+        .submit_command(p1(), build_command(enemy_base, Unit::Infantry))
+        .unwrap_err();
+
+    assert!(matches!(neutral_err, CommandError::InvalidBuildLocation));
+    assert!(matches!(enemy_err, CommandError::InvalidBuildLocation));
+}
+
+#[test]
+fn build_supports_airport_and_port_domains() {
+    let airport = Position::new(0, 0);
+    let port = Position::new(1, 0);
+    let mut setup = two_player_setup_with_funds(3, 3, 20000);
+    set_property(
+        &mut setup,
+        airport,
+        Property::Airport(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    set_property(
+        &mut setup,
+        port,
+        Property::Port(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    let mut server = GameServer::new(setup).unwrap();
+
+    server
+        .submit_command(p1(), build_command(airport, Unit::TCopter))
+        .unwrap();
+    server.submit_command(p1(), GameCommand::EndTurn).unwrap();
+    server.submit_command(p2(), GameCommand::EndTurn).unwrap();
+    server
+        .submit_command(p1(), build_command(port, Unit::Lander))
+        .unwrap();
+
+    let view = server.player_view(p1());
+    assert!(
+        view.units
+            .iter()
+            .any(|unit| unit.position == airport && unit.unit_type == Unit::TCopter)
+    );
+    assert!(
+        view.units
+            .iter()
+            .any(|unit| unit.position == port && unit.unit_type == Unit::Lander)
+    );
+    assert_eq!(view.my_funds, 3000);
+}
+
+#[test]
+fn build_fog_update_reveals_unit_only_when_opponent_has_vision() {
+    let base = Position::new(0, 0);
+    let mut visible_setup = two_player_setup(5, 1);
+    visible_setup.fog_enabled = true;
+    set_property(
+        &mut visible_setup,
+        base,
+        Property::Base(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    let mut visible_server = GameServer::new(visible_setup).unwrap();
+    visible_server.spawn_unit(Position::new(2, 0), Unit::Infantry, PlayerFaction::BlueMoon);
+
+    let visible_result = visible_server
+        .submit_command(p1(), build_command(base, Unit::Infantry))
+        .unwrap();
+    let p2_visible_update = visible_result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p2())
+        .unwrap()
+        .1
+        .clone();
+    assert!(
+        p2_visible_update
+            .units_revealed
+            .iter()
+            .any(|unit| unit.position == base && unit.unit_type == Unit::Infantry)
+    );
+    assert_eq!(p2_visible_update.my_funds, None);
+
+    let mut hidden_setup = two_player_setup(8, 8);
+    hidden_setup.fog_enabled = true;
+    set_property(
+        &mut hidden_setup,
+        base,
+        Property::Base(TerrainFaction::Player(PlayerFaction::OrangeStar)),
+    );
+    let mut hidden_server = GameServer::new(hidden_setup).unwrap();
+    hidden_server.spawn_unit(Position::new(7, 7), Unit::Infantry, PlayerFaction::BlueMoon);
+
+    let hidden_result = hidden_server
+        .submit_command(p1(), build_command(base, Unit::Infantry))
+        .unwrap();
+    let p2_hidden_update = hidden_result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p2())
+        .unwrap()
+        .1
+        .clone();
+    assert!(p2_hidden_update.units_revealed.is_empty());
+    assert_eq!(p2_hidden_update.my_funds, None);
 }
 
 #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Building units on owned bases, airports, and ports is fully implemented.
  * Newly built units are inactive until the next turn.
  * Player funds are deducted on build and reported to the builder.
  * Fog-of-war visibility for built units is respected per player.

* **Bug Fixes**
  * Build command now processes correctly instead of being unreachable.
  * Validation added for funds, ownership, terrain/domain, and occupancy.

* **Tests**
  * Added unit and integration tests covering build behavior and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->