### PR TITLE
Add other non-combat moves

### DIFF
--- a/crates/awbrn-server/src/adjacency.rs
+++ b/crates/awbrn-server/src/adjacency.rs
@@ -1,0 +1,42 @@
+use awbrn_game::world::{BoardIndex, Faction};
+use awbrn_map::Position;
+use awbrn_types::PlayerFaction;
+use bevy::prelude::*;
+
+pub(crate) fn adjacent_self_owned_units(
+    world: &World,
+    position: Position,
+    owner: PlayerFaction,
+) -> impl Iterator<Item = Entity> + '_ {
+    adjacent_positions(position)
+        .into_iter()
+        .flatten()
+        .filter_map(|pos| {
+            world
+                .resource::<BoardIndex>()
+                .unit_entity(pos)
+                .ok()
+                .flatten()
+        })
+        .filter(move |entity| {
+            world
+                .entity(*entity)
+                .get::<Faction>()
+                .is_some_and(|faction| faction.0 == owner)
+        })
+}
+
+pub(crate) fn adjacent_positions(position: Position) -> [Option<Position>; 4] {
+    [
+        position
+            .x
+            .checked_sub(1)
+            .map(|x| Position::new(x, position.y)),
+        position
+            .y
+            .checked_sub(1)
+            .map(|y| Position::new(position.x, y)),
+        Some(Position::new(position.x + 1, position.y)),
+        Some(Position::new(position.x, position.y + 1)),
+    ]
+}

--- a/crates/awbrn-server/src/apply.rs
+++ b/crates/awbrn-server/src/apply.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 
+use crate::adjacency::adjacent_positions;
 use crate::command::{GameCommand, PostMoveAction};
 use crate::damage::{CombatInput, CombatSide, LuckCap, PercentMod, TerrainStars};
 use crate::player::PlayerRegistry;
@@ -10,10 +11,10 @@ use crate::unit_id::ServerUnitId;
 use awbrn_game::MapPosition;
 use awbrn_game::world::{
     Ammo, BoardIndex, CaptureAction, CaptureActionOutcome, CaptureProgress, CaptureProgressInput,
-    Fuel, GameMap, GraphicalHp, StrongIdMap, UnitActive, UnitHp,
+    CarriedBy, Fuel, GameMap, GraphicalHp, Hiding, StrongIdMap, UnitActive, UnitHp,
 };
 use awbrn_game::world::{Faction, Unit};
-use awbrn_types::{DamagePts, PlayerFaction};
+use awbrn_types::{DamagePts, ExactHp, PlayerFaction};
 
 /// The set of world mutations that occurred from applying a command.
 /// Used by the view layer to build per-player updates.
@@ -72,6 +73,51 @@ pub(crate) enum ApplyOutcome {
         tile: awbrn_map::Position,
         unit_type: awbrn_types::Unit,
         unit_id: ServerUnitId,
+    },
+    UnitSupplied {
+        supplier_id: ServerUnitId,
+        resupplied_unit_ids: Vec<ServerUnitId>,
+    },
+    UnitLoaded {
+        cargo_id: ServerUnitId,
+        cargo_entity: Entity,
+        transport_id: ServerUnitId,
+        transport_entity: Entity,
+        from: awbrn_map::Position,
+        to: awbrn_map::Position,
+        path: Vec<awbrn_map::Position>,
+        cargo_faction: PlayerFaction,
+    },
+    UnitUnloaded {
+        cargo_id: ServerUnitId,
+        cargo_entity: Entity,
+        transport_id: ServerUnitId,
+        transport_entity: Entity,
+        destination_tile: awbrn_map::Position,
+    },
+    UnitHidden {
+        unit_id: ServerUnitId,
+        entity: Entity,
+        position: awbrn_map::Position,
+        faction: PlayerFaction,
+    },
+    UnitUnhidden {
+        unit_id: ServerUnitId,
+        entity: Entity,
+        position: awbrn_map::Position,
+        faction: PlayerFaction,
+    },
+    UnitJoined {
+        source_id: ServerUnitId,
+        source_entity: Entity,
+        source_unit_type: awbrn_types::Unit,
+        target_id: ServerUnitId,
+        target_entity: Entity,
+        from: awbrn_map::Position,
+        to: awbrn_map::Position,
+        path: Vec<awbrn_map::Position>,
+        source_faction: PlayerFaction,
+        funds_refund: u32,
     },
 }
 
@@ -151,11 +197,20 @@ fn apply_move_unit(
         world.entity_mut(entity).insert(Fuel(new_fuel));
     }
 
-    // Update position if it changed.
+    let destination_is_occupied_action = matches!(
+        action,
+        Some(PostMoveAction::Load { .. } | PostMoveAction::Join { .. })
+    );
+
+    // Update position if it changed. Load and Join intentionally end on an
+    // occupied tile, so the acting unit must not be inserted into BoardIndex
+    // at the destination before being loaded/despawned.
     if from != to {
         // Capture progress is tied to the unit staying on the same property.
         world.entity_mut(entity).remove::<CaptureProgress>();
-        world.entity_mut(entity).insert(MapPosition::from(to));
+        if !destination_is_occupied_action {
+            world.entity_mut(entity).insert(MapPosition::from(to));
+        }
     }
 
     // Deactivate the unit (it has acted this turn).
@@ -168,6 +223,25 @@ fn apply_move_unit(
         Some(PostMoveAction::Capture) => {
             apply_capture(world, unit_id, entity, from, to, path, faction)
         }
+        Some(PostMoveAction::Load { transport_id }) => apply_load(
+            world,
+            unit_id,
+            entity,
+            *transport_id,
+            from,
+            to,
+            path,
+            faction,
+        ),
+        Some(PostMoveAction::Unload { cargo_id, position }) => {
+            apply_unload(world, unit_id, entity, *cargo_id, *position)
+        }
+        Some(PostMoveAction::Supply) => apply_supply(world, unit_id, to, faction),
+        Some(PostMoveAction::Hide) => apply_hide(world, unit_id, entity, to, faction),
+        Some(PostMoveAction::Unhide) => apply_unhide(world, unit_id, entity, to, faction),
+        Some(PostMoveAction::Join { target_id }) => {
+            apply_join(world, unit_id, entity, *target_id, from, to, path, faction)
+        }
         _ => ApplyOutcome::UnitMoved {
             unit_id,
             entity,
@@ -176,6 +250,258 @@ fn apply_move_unit(
             path: path.to_vec(),
             faction,
         },
+    }
+}
+
+fn apply_supply(
+    world: &mut World,
+    supplier_id: ServerUnitId,
+    position: awbrn_map::Position,
+    faction: PlayerFaction,
+) -> ApplyOutcome {
+    let mut resupplied_unit_ids = Vec::with_capacity(4);
+
+    for position in adjacent_positions(position).into_iter().flatten() {
+        let Some(entity) = world
+            .resource::<BoardIndex>()
+            .unit_entity(position)
+            .ok()
+            .flatten()
+        else {
+            continue;
+        };
+
+        let Some((unit_type, unit_id, current_fuel, current_ammo)) = ({
+            let entity_ref = world.entity(entity);
+            let is_self_owned = entity_ref
+                .get::<Faction>()
+                .is_some_and(|unit_faction| unit_faction.0 == faction);
+            if !is_self_owned {
+                None
+            } else {
+                let unit_type = entity_ref
+                    .get::<Unit>()
+                    .copied()
+                    .expect("resupplied unit must have Unit component")
+                    .0;
+                let unit_id = entity_ref
+                    .get::<ServerUnitId>()
+                    .copied()
+                    .expect("resupplied unit must have ServerUnitId");
+                let current_fuel = entity_ref.get::<Fuel>().map(|fuel| fuel.0);
+                let current_ammo = entity_ref.get::<Ammo>().map(|ammo| ammo.0);
+                Some((unit_type, unit_id, current_fuel, current_ammo))
+            }
+        }) else {
+            continue;
+        };
+
+        let max_fuel = unit_type.max_fuel();
+        let max_ammo = unit_type.max_ammo();
+        let needs_fuel = current_fuel.is_some_and(|fuel| fuel < max_fuel);
+        let needs_ammo = current_ammo.is_some_and(|ammo| ammo < max_ammo);
+
+        if needs_fuel || needs_ammo {
+            world
+                .entity_mut(entity)
+                .insert((Fuel(max_fuel), Ammo(max_ammo)));
+            resupplied_unit_ids.push(unit_id);
+        }
+    }
+
+    ApplyOutcome::UnitSupplied {
+        supplier_id,
+        resupplied_unit_ids,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_load(
+    world: &mut World,
+    cargo_id: ServerUnitId,
+    cargo_entity: Entity,
+    transport_id: ServerUnitId,
+    from: awbrn_map::Position,
+    to: awbrn_map::Position,
+    path: &[awbrn_map::Position],
+    cargo_faction: PlayerFaction,
+) -> ApplyOutcome {
+    let transport_entity = world
+        .resource::<StrongIdMap<ServerUnitId>>()
+        .get(&transport_id)
+        .expect("validated transport must exist");
+
+    world
+        .entity_mut(cargo_entity)
+        .insert(CarriedBy(transport_entity))
+        .remove::<MapPosition>();
+
+    ApplyOutcome::UnitLoaded {
+        cargo_id,
+        cargo_entity,
+        transport_id,
+        transport_entity,
+        from,
+        to,
+        path: path.to_vec(),
+        cargo_faction,
+    }
+}
+
+fn apply_unload(
+    world: &mut World,
+    transport_id: ServerUnitId,
+    transport_entity: Entity,
+    cargo_id: ServerUnitId,
+    destination_tile: awbrn_map::Position,
+) -> ApplyOutcome {
+    let cargo_entity = world
+        .resource::<StrongIdMap<ServerUnitId>>()
+        .get(&cargo_id)
+        .expect("validated cargo must exist");
+
+    world
+        .entity_mut(cargo_entity)
+        .insert(MapPosition::from(destination_tile))
+        .remove::<CarriedBy>();
+
+    ApplyOutcome::UnitUnloaded {
+        cargo_id,
+        cargo_entity,
+        transport_id,
+        transport_entity,
+        destination_tile,
+    }
+}
+
+fn apply_hide(
+    world: &mut World,
+    unit_id: ServerUnitId,
+    entity: Entity,
+    position: awbrn_map::Position,
+    faction: PlayerFaction,
+) -> ApplyOutcome {
+    world.entity_mut(entity).insert(Hiding);
+    ApplyOutcome::UnitHidden {
+        unit_id,
+        entity,
+        position,
+        faction,
+    }
+}
+
+fn apply_unhide(
+    world: &mut World,
+    unit_id: ServerUnitId,
+    entity: Entity,
+    position: awbrn_map::Position,
+    faction: PlayerFaction,
+) -> ApplyOutcome {
+    world.entity_mut(entity).remove::<Hiding>();
+    ApplyOutcome::UnitUnhidden {
+        unit_id,
+        entity,
+        position,
+        faction,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_join(
+    world: &mut World,
+    source_id: ServerUnitId,
+    source_entity: Entity,
+    target_id: ServerUnitId,
+    from: awbrn_map::Position,
+    to: awbrn_map::Position,
+    path: &[awbrn_map::Position],
+    source_faction: PlayerFaction,
+) -> ApplyOutcome {
+    let target_entity = world
+        .resource::<StrongIdMap<ServerUnitId>>()
+        .get(&target_id)
+        .expect("validated join target must exist");
+
+    let (unit_type, source_hp, source_fuel, source_ammo, target_hp, target_fuel, target_ammo) = {
+        let source = world.entity(source_entity);
+        let target = world.entity(target_entity);
+        let unit_type = source
+            .get::<Unit>()
+            .copied()
+            .expect("source must have Unit component")
+            .0;
+        let source_hp = source
+            .get::<UnitHp>()
+            .copied()
+            .expect("source must have UnitHp")
+            .0;
+        let source_fuel = source.get::<Fuel>().map(|fuel| fuel.0).unwrap_or(0);
+        let source_ammo = source.get::<Ammo>().map(|ammo| ammo.0).unwrap_or(0);
+        let target_hp = target
+            .get::<UnitHp>()
+            .copied()
+            .expect("target must have UnitHp")
+            .0;
+        let target_fuel = target.get::<Fuel>().map(|fuel| fuel.0).unwrap_or(0);
+        let target_ammo = target.get::<Ammo>().map(|ammo| ammo.0).unwrap_or(0);
+
+        (
+            unit_type,
+            source_hp,
+            source_fuel,
+            source_ammo,
+            target_hp,
+            target_fuel,
+            target_ammo,
+        )
+    };
+
+    let combined_hp = u16::from(source_hp.get()) + u16::from(target_hp.get());
+    let overflow_hp = combined_hp.saturating_sub(100);
+    let joined_hp = combined_hp.min(100) as u8;
+    let funds_refund = if overflow_hp > 0 {
+        (unit_type.base_cost() / 100) * u32::from(overflow_hp)
+    } else {
+        0
+    };
+
+    if funds_refund > 0
+        && let Some(owner) = world
+            .resource::<PlayerRegistry>()
+            .player_for_faction(source_faction)
+    {
+        world
+            .resource_mut::<PlayerRegistry>()
+            .get_mut(owner)
+            .expect("join source owner must exist")
+            .funds += funds_refund;
+    }
+
+    let joined_fuel = source_fuel
+        .saturating_add(target_fuel)
+        .min(unit_type.max_fuel());
+    let joined_ammo = source_ammo
+        .saturating_add(target_ammo)
+        .min(unit_type.max_ammo());
+
+    world.entity_mut(target_entity).insert((
+        UnitHp(ExactHp::new(joined_hp)),
+        Fuel(joined_fuel),
+        Ammo(joined_ammo),
+    ));
+    world.entity_mut(source_entity).despawn();
+
+    ApplyOutcome::UnitJoined {
+        source_id,
+        source_entity,
+        source_unit_type: unit_type,
+        target_id,
+        target_entity,
+        from,
+        to,
+        path: path.to_vec(),
+        source_faction,
+        funds_refund,
     }
 }
 

--- a/crates/awbrn-server/src/lib.rs
+++ b/crates/awbrn-server/src/lib.rs
@@ -1,3 +1,4 @@
+mod adjacency;
 mod apply;
 pub mod command;
 mod damage;

--- a/crates/awbrn-server/src/validate.rs
+++ b/crates/awbrn-server/src/validate.rs
@@ -1,8 +1,10 @@
 use std::collections::HashSet;
 
+use bevy::ecs::relationship::RelationshipTarget;
 use bevy::ecs::system::{SystemParam, SystemState};
 use bevy::prelude::*;
 
+use crate::adjacency::adjacent_self_owned_units;
 use crate::command::{GameCommand, PostMoveAction};
 use crate::error::CommandError;
 use crate::player::{PlayerId, PlayerRegistry};
@@ -10,7 +12,10 @@ use crate::state::{ServerGameState, TurnPhase};
 use crate::unit_id::ServerUnitId;
 use awbrn_game::MapPosition;
 use awbrn_game::replay::PowerMovementBoosts;
-use awbrn_game::world::{Ammo, BoardIndex, Faction, Fuel, GameMap, StrongIdMap, Unit, UnitActive};
+use awbrn_game::world::{
+    Ammo, BoardIndex, CarriedBy, Faction, Fuel, GameMap, HasCargo, Hiding, StrongIdMap, Unit,
+    UnitActive,
+};
 use awbrn_map::Position;
 use awbrn_types::{
     Faction as TerrainFaction, GraphicalTerrain, MovementCost, MovementTerrain, PlayerFaction,
@@ -185,70 +190,74 @@ fn validate_move_unit(
         .get::<Unit>()
         .copied()
         .ok_or(CommandError::InvalidUnit(unit_id))?;
-    let mut movement_world_state: SystemState<MovementValidationWorld> = SystemState::new(world);
-    let movement_world = movement_world_state.get(world);
-    let movement_budget = movement_world.movement_budget_for(faction.0, unit.0);
     let fuel_budget = world
         .entity(entity)
         .get::<Fuel>()
         .map_or(u32::MAX, |fuel| fuel.0);
 
+    let destination = *path.last().expect("validated path is non-empty");
     let mut movement_cost = 0u32;
     let mut fuel_cost = 0u32;
     let mut previous = current_position;
-    let destination = *path.last().expect("validated path is non-empty");
 
-    for &step in &path[1..] {
-        if previous.manhattan(&step) != 1 {
-            return Err(invalid_path(format!(
-                "path step {previous:?} -> {step:?} is not adjacent"
-            )));
-        }
+    {
+        let mut movement_world_state: SystemState<MovementValidationWorld> =
+            SystemState::new(world);
+        let movement_world = movement_world_state.get(world);
+        let movement_budget = movement_world.movement_budget_for(faction.0, unit.0);
 
-        let Some(terrain) = movement_world.game_map.terrain_at(step) else {
-            return Err(invalid_path(format!(
-                "path step {step:?} is outside the map bounds"
-            )));
-        };
-        let step_cost = step_movement_cost(unit.0, terrain, step)?;
-        movement_cost += u32::from(step_cost);
-        fuel_cost += 1;
-
-        let occupied_by = movement_world
-            .board_index
-            .unit_entity(step)
-            .map_err(|_| invalid_path(format!("path step {step:?} is outside the map bounds")))?;
-        if let Some(occupant) = occupied_by
-            && occupant != entity
-        {
-            if step == destination {
+        for &step in &path[1..] {
+            if previous.manhattan(&step) != 1 {
                 return Err(invalid_path(format!(
-                    "path destination {step:?} is occupied"
+                    "path step {previous:?} -> {step:?} is not adjacent"
                 )));
             }
 
-            let occupant_faction = movement_world
-                .factions
-                .get(occupant)
-                .map_err(|_| invalid_path(format!("occupant at {step:?} is missing faction")))?;
-
-            // Advance Wars movement allows traversing friendly/allied units,
-            // but any enemy unit blocks the path and no move may end on an
-            // occupied tile.
-            if !friendly_factions.contains(&occupant_faction.0) {
+            let Some(terrain) = movement_world.game_map.terrain_at(step) else {
                 return Err(invalid_path(format!(
-                    "path step {step:?} is blocked by an enemy unit"
+                    "path step {step:?} is outside the map bounds"
                 )));
+            };
+            let step_cost = step_movement_cost(unit.0, terrain, step)?;
+            movement_cost += u32::from(step_cost);
+            fuel_cost += 1;
+
+            let occupied_by = movement_world.board_index.unit_entity(step).map_err(|_| {
+                invalid_path(format!("path step {step:?} is outside the map bounds"))
+            })?;
+            if let Some(occupant) = occupied_by
+                && occupant != entity
+            {
+                if step == destination {
+                    if !action_allows_occupied_destination(action) {
+                        return Err(invalid_path(format!(
+                            "path destination {step:?} is occupied"
+                        )));
+                    }
+                } else {
+                    let occupant_faction = movement_world.factions.get(occupant).map_err(|_| {
+                        invalid_path(format!("occupant at {step:?} is missing faction"))
+                    })?;
+
+                    // Advance Wars movement allows traversing friendly/allied units,
+                    // but any enemy unit blocks the path and no move may end on an
+                    // occupied tile except for validated Load/Join actions.
+                    if !friendly_factions.contains(&occupant_faction.0) {
+                        return Err(invalid_path(format!(
+                            "path step {step:?} is blocked by an enemy unit"
+                        )));
+                    }
+                }
             }
+
+            previous = step;
         }
 
-        previous = step;
-    }
-
-    if movement_cost > movement_budget {
-        return Err(invalid_path(format!(
-            "path costs {movement_cost} movement but unit only has {movement_budget}"
-        )));
+        if movement_cost > movement_budget {
+            return Err(invalid_path(format!(
+                "path costs {movement_cost} movement but unit only has {movement_budget}"
+            )));
+        }
     }
 
     if fuel_cost > fuel_budget {
@@ -264,6 +273,7 @@ fn validate_move_unit(
             entity,
             current_position,
             destination,
+            player_faction,
             &friendly_factions,
             action,
         )?;
@@ -295,10 +305,11 @@ fn invalid_path(reason: impl Into<String>) -> CommandError {
 }
 
 fn validate_post_move_action(
-    world: &World,
+    world: &mut World,
     entity: Entity,
     from: Position,
     destination: Position,
+    player_faction: PlayerFaction,
     friendly_factions: &HashSet<PlayerFaction>,
     action: &PostMoveAction,
 ) -> Result<(), CommandError> {
@@ -308,15 +319,31 @@ fn validate_post_move_action(
             validate_attack(world, entity, from, destination, friendly_factions, *target)
         }
         PostMoveAction::Capture => validate_capture(world, entity, destination, friendly_factions),
-        PostMoveAction::Load { .. }
-        | PostMoveAction::Unload { .. }
-        | PostMoveAction::Supply
-        | PostMoveAction::Hide
-        | PostMoveAction::Unhide
-        | PostMoveAction::Join { .. } => Err(CommandError::InvalidAction {
-            reason: format!("action {action:?} not yet implemented"),
-        }),
+        PostMoveAction::Load { transport_id } => validate_load(
+            world,
+            entity,
+            destination,
+            player_faction,
+            friendly_factions,
+            *transport_id,
+        ),
+        PostMoveAction::Unload { cargo_id, position } => {
+            validate_unload(world, entity, from, destination, *cargo_id, *position)
+        }
+        PostMoveAction::Supply => validate_supply(world, entity, player_faction, destination),
+        PostMoveAction::Hide => validate_hide(world, entity),
+        PostMoveAction::Unhide => validate_unhide(world, entity),
+        PostMoveAction::Join { target_id } => {
+            validate_join(world, entity, destination, player_faction, *target_id)
+        }
     }
+}
+
+fn action_allows_occupied_destination(action: Option<&PostMoveAction>) -> bool {
+    matches!(
+        action,
+        Some(PostMoveAction::Load { .. } | PostMoveAction::Join { .. })
+    )
 }
 
 fn validate_capture(
@@ -435,6 +462,366 @@ fn validate_attack(
     }
 
     Ok(())
+}
+
+fn validate_supply(
+    world: &World,
+    supplier_entity: Entity,
+    player_faction: PlayerFaction,
+    destination: Position,
+) -> Result<(), CommandError> {
+    let supplier_unit = world
+        .entity(supplier_entity)
+        .get::<Unit>()
+        .copied()
+        .expect("validated unit must have Unit component")
+        .0;
+
+    if !matches!(
+        supplier_unit,
+        awbrn_types::Unit::APC | awbrn_types::Unit::BlackBoat
+    ) {
+        return Err(CommandError::InvalidAction {
+            reason: "only APC and Black Boat units can supply".into(),
+        });
+    }
+
+    if adjacent_self_owned_units(world, destination, player_faction)
+        .next()
+        .is_none()
+    {
+        return Err(CommandError::InvalidAction {
+            reason: "no adjacent self-owned units to supply".into(),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_load(
+    world: &mut World,
+    cargo_entity: Entity,
+    destination: Position,
+    player_faction: PlayerFaction,
+    friendly_factions: &HashSet<PlayerFaction>,
+    transport_id: ServerUnitId,
+) -> Result<(), CommandError> {
+    let transport_entity = world
+        .resource::<StrongIdMap<ServerUnitId>>()
+        .get(&transport_id)
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "transport unit does not exist".into(),
+        })?;
+
+    if cargo_entity == transport_entity {
+        return Err(CommandError::InvalidAction {
+            reason: "unit cannot load into itself".into(),
+        });
+    }
+
+    let occupied = world
+        .resource::<BoardIndex>()
+        .unit_entity(destination)
+        .map_err(|_| CommandError::InvalidAction {
+            reason: "load destination is outside the map".into(),
+        })?;
+    if occupied != Some(transport_entity) {
+        return Err(CommandError::InvalidAction {
+            reason: "selected transport is not at the load destination".into(),
+        });
+    }
+
+    let cargo = world.entity(cargo_entity);
+    if cargo.contains::<CarriedBy>() {
+        return Err(CommandError::InvalidAction {
+            reason: "cargo unit is already loaded".into(),
+        });
+    }
+    let cargo_unit = cargo
+        .get::<Unit>()
+        .copied()
+        .expect("validated cargo must have Unit component")
+        .0;
+    let cargo_faction = cargo
+        .get::<Faction>()
+        .copied()
+        .expect("validated cargo must have Faction component")
+        .0;
+
+    let transport = world.entity(transport_entity);
+    let transport_unit = transport
+        .get::<Unit>()
+        .copied()
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "transport entity is missing unit data".into(),
+        })?
+        .0;
+    let transport_faction = transport
+        .get::<Faction>()
+        .copied()
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "transport entity is missing faction".into(),
+        })?
+        .0;
+
+    if cargo_faction != player_faction || !friendly_factions.contains(&transport_faction) {
+        return Err(CommandError::InvalidAction {
+            reason: "cargo and transport must be friendly units".into(),
+        });
+    }
+
+    if !can_transport(transport_unit, cargo_unit) {
+        return Err(CommandError::InvalidAction {
+            reason: format!(
+                "{} cannot transport {}",
+                transport_unit.name(),
+                cargo_unit.name()
+            ),
+        });
+    }
+
+    let capacity =
+        transport_capacity(transport_unit).ok_or_else(|| CommandError::InvalidAction {
+            reason: "selected unit is not a transport".into(),
+        })?;
+    if transport
+        .get::<HasCargo>()
+        .is_some_and(|cargo| cargo.len() >= capacity)
+    {
+        return Err(CommandError::InvalidAction {
+            reason: "transport is full".into(),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_unload(
+    world: &World,
+    transport_entity: Entity,
+    from: Position,
+    destination: Position,
+    cargo_id: ServerUnitId,
+    target: Position,
+) -> Result<(), CommandError> {
+    let transport_unit = world
+        .entity(transport_entity)
+        .get::<Unit>()
+        .copied()
+        .expect("validated transport must have Unit component")
+        .0;
+
+    if transport_capacity(transport_unit).is_none() {
+        return Err(CommandError::InvalidAction {
+            reason: "acting unit is not a transport".into(),
+        });
+    }
+
+    let cargo_entity = world
+        .resource::<StrongIdMap<ServerUnitId>>()
+        .get(&cargo_id)
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "cargo unit does not exist".into(),
+        })?;
+    let carried_by = world
+        .entity(cargo_entity)
+        .get::<CarriedBy>()
+        .copied()
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "cargo unit is not loaded".into(),
+        })?;
+    if carried_by.0 != transport_entity {
+        return Err(CommandError::InvalidAction {
+            reason: "cargo unit is not carried by this transport".into(),
+        });
+    }
+
+    if destination.manhattan(&target) != 1 {
+        return Err(CommandError::InvalidAction {
+            reason: "unload target is not adjacent to the transport".into(),
+        });
+    }
+
+    let cargo_unit = world
+        .entity(cargo_entity)
+        .get::<Unit>()
+        .copied()
+        .expect("cargo must have Unit component")
+        .0;
+    let terrain = world
+        .resource::<GameMap>()
+        .terrain_at(target)
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "unload target is outside the map".into(),
+        })?;
+    step_movement_cost(cargo_unit, terrain, target)?;
+
+    let occupied = world
+        .resource::<BoardIndex>()
+        .unit_entity(target)
+        .map_err(|_| CommandError::InvalidAction {
+            reason: "unload target is outside the map".into(),
+        })?;
+    let transport_leaves_target = target == from && from != destination;
+    if occupied.is_some() && !(occupied == Some(transport_entity) && transport_leaves_target) {
+        return Err(CommandError::InvalidAction {
+            reason: "unload target is occupied".into(),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_hide(world: &World, entity: Entity) -> Result<(), CommandError> {
+    let unit = world
+        .entity(entity)
+        .get::<Unit>()
+        .copied()
+        .expect("validated unit must have Unit component")
+        .0;
+
+    if !matches!(unit, awbrn_types::Unit::Sub | awbrn_types::Unit::Stealth) {
+        return Err(CommandError::InvalidAction {
+            reason: "only Sub and Stealth units can hide".into(),
+        });
+    }
+
+    if world.entity(entity).contains::<Hiding>() {
+        return Err(CommandError::InvalidAction {
+            reason: "unit is already hidden".into(),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_unhide(world: &World, entity: Entity) -> Result<(), CommandError> {
+    let unit = world
+        .entity(entity)
+        .get::<Unit>()
+        .copied()
+        .expect("validated unit must have Unit component")
+        .0;
+
+    if !matches!(unit, awbrn_types::Unit::Sub | awbrn_types::Unit::Stealth) {
+        return Err(CommandError::InvalidAction {
+            reason: "only Sub and Stealth units can unhide".into(),
+        });
+    }
+
+    if !world.entity(entity).contains::<Hiding>() {
+        return Err(CommandError::InvalidAction {
+            reason: "unit is not hidden".into(),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_join(
+    world: &World,
+    source_entity: Entity,
+    destination: Position,
+    player_faction: PlayerFaction,
+    target_id: ServerUnitId,
+) -> Result<(), CommandError> {
+    let target_entity = world
+        .resource::<StrongIdMap<ServerUnitId>>()
+        .get(&target_id)
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "join target does not exist".into(),
+        })?;
+
+    if source_entity == target_entity {
+        return Err(CommandError::InvalidAction {
+            reason: "unit cannot join into itself".into(),
+        });
+    }
+
+    let occupied = world
+        .resource::<BoardIndex>()
+        .unit_entity(destination)
+        .map_err(|_| CommandError::InvalidAction {
+            reason: "join destination is outside the map".into(),
+        })?;
+    if occupied != Some(target_entity) {
+        return Err(CommandError::InvalidAction {
+            reason: "join target is not at the destination".into(),
+        });
+    }
+
+    let source = world.entity(source_entity);
+    let target = world.entity(target_entity);
+
+    if source.contains::<CarriedBy>() || target.contains::<CarriedBy>() {
+        return Err(CommandError::InvalidAction {
+            reason: "carried units cannot join".into(),
+        });
+    }
+    if source.contains::<HasCargo>() || target.contains::<HasCargo>() {
+        return Err(CommandError::InvalidAction {
+            reason: "transport carrying cargo cannot join".into(),
+        });
+    }
+
+    let source_unit = source
+        .get::<Unit>()
+        .copied()
+        .expect("source must have Unit component")
+        .0;
+    let target_unit = target
+        .get::<Unit>()
+        .copied()
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "join target is missing unit data".into(),
+        })?
+        .0;
+    if source_unit != target_unit {
+        return Err(CommandError::InvalidAction {
+            reason: "joined units must have the same type".into(),
+        });
+    }
+
+    let source_faction = source
+        .get::<Faction>()
+        .copied()
+        .expect("source must have Faction component")
+        .0;
+    let target_faction = target
+        .get::<Faction>()
+        .copied()
+        .ok_or_else(|| CommandError::InvalidAction {
+            reason: "join target is missing faction".into(),
+        })?
+        .0;
+    if source_faction != player_faction || target_faction != player_faction {
+        return Err(CommandError::InvalidAction {
+            reason: "joined units must have the same owner".into(),
+        });
+    }
+
+    Ok(())
+}
+
+fn transport_capacity(unit: awbrn_types::Unit) -> Option<usize> {
+    match unit {
+        awbrn_types::Unit::APC | awbrn_types::Unit::TCopter => Some(1),
+        awbrn_types::Unit::BlackBoat | awbrn_types::Unit::Cruiser | awbrn_types::Unit::Lander => {
+            Some(2)
+        }
+        _ => None,
+    }
+}
+
+fn can_transport(transport: awbrn_types::Unit, cargo: awbrn_types::Unit) -> bool {
+    match transport {
+        awbrn_types::Unit::APC | awbrn_types::Unit::TCopter | awbrn_types::Unit::BlackBoat => {
+            matches!(cargo, awbrn_types::Unit::Infantry | awbrn_types::Unit::Mech)
+        }
+        awbrn_types::Unit::Lander => cargo.domain() == UnitDomain::Ground,
+        awbrn_types::Unit::Cruiser => cargo.domain() == UnitDomain::Air,
+        _ => false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/awbrn-server/src/view.rs
+++ b/crates/awbrn-server/src/view.rs
@@ -8,7 +8,7 @@ use awbrn_game::MapPosition;
 use awbrn_game::replay::{PowerVisionBoosts, range_modifier_for_weather};
 use awbrn_game::world::{
     Ammo, CaptureProgress, CarriedBy, CurrentWeather, Faction, FogOfWarMap, Fuel, GameMap,
-    GraphicalHp, StrongIdMap, Unit, VisionRange, collect_friendly_units, rebuild_fog_map,
+    GraphicalHp, Hiding, StrongIdMap, Unit, VisionRange, collect_friendly_units, rebuild_fog_map,
 };
 use awbrn_map::Position;
 use awbrn_types::PlayerFaction;
@@ -36,6 +36,7 @@ pub struct VisibleUnit {
     pub ammo: Option<u32>,
     pub capturing: bool,
     pub capture_progress: Option<u8>,
+    pub hiding: bool,
 }
 
 /// A terrain tile as visible to a specific player.
@@ -387,6 +388,344 @@ fn build_player_update(
                 units_moved: Vec::new(),
                 units_removed,
                 terrain_revealed,
+                terrain_changed: Vec::new(),
+                turn_change: None,
+                combat_event: None,
+                capture_event: None,
+                my_funds,
+                state: header.clone(),
+            }
+        }
+        ApplyOutcome::UnitSupplied {
+            supplier_id,
+            resupplied_unit_ids,
+        } => {
+            let mut units_revealed = Vec::new();
+            let mut seen = HashSet::new();
+
+            for unit_id in std::iter::once(supplier_id).chain(resupplied_unit_ids.iter()) {
+                if !seen.insert(*unit_id) {
+                    continue;
+                }
+                let Some(entity) = world.resource::<StrongIdMap<ServerUnitId>>().get(unit_id)
+                else {
+                    continue;
+                };
+                if entity_visible_to_factions(world, entity, &friendly_factions, post_fog)
+                    && let Some(visible) = entity_to_visible_unit(world, entity, &friendly_factions)
+                {
+                    units_revealed.push(visible);
+                }
+            }
+
+            PlayerUpdate {
+                units_revealed,
+                units_moved: Vec::new(),
+                units_removed: Vec::new(),
+                terrain_revealed: Vec::new(),
+                terrain_changed: Vec::new(),
+                turn_change: None,
+                combat_event: None,
+                capture_event: None,
+                my_funds: None,
+                state: header.clone(),
+            }
+        }
+        ApplyOutcome::UnitLoaded {
+            cargo_id,
+            cargo_entity,
+            transport_id,
+            transport_entity,
+            from,
+            to,
+            path,
+            cargo_faction,
+        } => {
+            let cargo_unit_type = world
+                .entity(*cargo_entity)
+                .get::<Unit>()
+                .map(|unit| unit.0)
+                .unwrap_or(awbrn_types::Unit::Infantry);
+            let detectors = detector_positions(world, &friendly_factions);
+            let from_was_visible = unit_would_be_visible_to_factions(
+                *from,
+                cargo_unit_type,
+                *cargo_faction,
+                false,
+                &friendly_factions,
+                pre_fog,
+                &detectors,
+            );
+            let to_is_visible = unit_would_be_visible_to_factions(
+                *to,
+                cargo_unit_type,
+                *cargo_faction,
+                false,
+                &friendly_factions,
+                post_fog,
+                &detectors,
+            );
+            let mut units_moved = Vec::new();
+            let mut units_removed = Vec::new();
+
+            if from_was_visible && to_is_visible {
+                units_moved.push(UnitMoved {
+                    id: *cargo_id,
+                    path: path.clone(),
+                    from: *from,
+                    to: *to,
+                });
+                units_removed.push(*cargo_id);
+            } else if from_was_visible && !to_is_visible {
+                units_removed.push(*cargo_id);
+            }
+
+            let mut units_revealed = Vec::new();
+            if entity_visible_to_factions_with_detectors(
+                world,
+                *transport_entity,
+                &friendly_factions,
+                post_fog,
+                &detectors,
+            ) && let Some(transport) =
+                entity_to_visible_unit(world, *transport_entity, &friendly_factions)
+            {
+                units_revealed.push(transport);
+            }
+
+            let _ = transport_id;
+
+            PlayerUpdate {
+                units_revealed,
+                units_moved,
+                units_removed,
+                terrain_revealed: Vec::new(),
+                terrain_changed: Vec::new(),
+                turn_change: None,
+                combat_event: None,
+                capture_event: None,
+                my_funds: None,
+                state: header.clone(),
+            }
+        }
+        ApplyOutcome::UnitUnloaded {
+            cargo_id,
+            cargo_entity,
+            transport_id,
+            transport_entity,
+            destination_tile,
+        } => {
+            let mut units_revealed = Vec::new();
+            let detectors = detector_positions(world, &friendly_factions);
+            if entity_visible_to_factions_with_detectors(
+                world,
+                *cargo_entity,
+                &friendly_factions,
+                post_fog,
+                &detectors,
+            ) && let Some(visible) =
+                entity_to_visible_unit(world, *cargo_entity, &friendly_factions)
+            {
+                units_revealed.push(visible);
+            }
+            if entity_visible_to_factions_with_detectors(
+                world,
+                *transport_entity,
+                &friendly_factions,
+                post_fog,
+                &detectors,
+            ) && let Some(transport) =
+                entity_to_visible_unit(world, *transport_entity, &friendly_factions)
+            {
+                units_revealed.push(transport);
+            }
+
+            let _ = (cargo_id, transport_id, destination_tile);
+
+            PlayerUpdate {
+                units_revealed,
+                units_moved: Vec::new(),
+                units_removed: Vec::new(),
+                terrain_revealed: Vec::new(),
+                terrain_changed: Vec::new(),
+                turn_change: None,
+                combat_event: None,
+                capture_event: None,
+                my_funds: None,
+                state: header.clone(),
+            }
+        }
+        ApplyOutcome::UnitHidden {
+            unit_id,
+            entity,
+            position,
+            faction,
+        } => {
+            let unit_type = world
+                .entity(*entity)
+                .get::<Unit>()
+                .map(|unit| unit.0)
+                .unwrap_or(awbrn_types::Unit::Infantry);
+            let detectors = detector_positions(world, &friendly_factions);
+            let was_visible = unit_would_be_visible_to_factions(
+                *position,
+                unit_type,
+                *faction,
+                false,
+                &friendly_factions,
+                pre_fog,
+                &detectors,
+            );
+            let is_visible = unit_would_be_visible_to_factions(
+                *position,
+                unit_type,
+                *faction,
+                true,
+                &friendly_factions,
+                post_fog,
+                &detectors,
+            );
+
+            let mut units_revealed = Vec::new();
+            if (friendly_factions.contains(faction) || (was_visible && is_visible))
+                && let Some(visible) = entity_to_visible_unit(world, *entity, &friendly_factions)
+            {
+                units_revealed.push(visible);
+            }
+
+            PlayerUpdate {
+                units_revealed,
+                units_moved: Vec::new(),
+                units_removed: if was_visible && !is_visible {
+                    vec![*unit_id]
+                } else {
+                    Vec::new()
+                },
+                terrain_revealed: Vec::new(),
+                terrain_changed: Vec::new(),
+                turn_change: None,
+                combat_event: None,
+                capture_event: None,
+                my_funds: None,
+                state: header.clone(),
+            }
+        }
+        ApplyOutcome::UnitUnhidden {
+            unit_id,
+            entity,
+            position,
+            faction,
+        } => {
+            let unit_type = world
+                .entity(*entity)
+                .get::<Unit>()
+                .map(|unit| unit.0)
+                .unwrap_or(awbrn_types::Unit::Infantry);
+            let detectors = detector_positions(world, &friendly_factions);
+            let is_visible = unit_would_be_visible_to_factions(
+                *position,
+                unit_type,
+                *faction,
+                false,
+                &friendly_factions,
+                post_fog,
+                &detectors,
+            );
+
+            let mut units_revealed = Vec::new();
+            if (friendly_factions.contains(faction) || is_visible)
+                && let Some(visible) = entity_to_visible_unit(world, *entity, &friendly_factions)
+            {
+                units_revealed.push(visible);
+            }
+
+            let _ = unit_id;
+
+            PlayerUpdate {
+                units_revealed,
+                units_moved: Vec::new(),
+                units_removed: Vec::new(),
+                terrain_revealed: Vec::new(),
+                terrain_changed: Vec::new(),
+                turn_change: None,
+                combat_event: None,
+                capture_event: None,
+                my_funds: None,
+                state: header.clone(),
+            }
+        }
+        ApplyOutcome::UnitJoined {
+            source_id,
+            source_entity,
+            source_unit_type,
+            target_id,
+            target_entity,
+            from,
+            to,
+            path,
+            source_faction,
+            funds_refund,
+        } => {
+            let detectors = detector_positions(world, &friendly_factions);
+            let source_was_visible = unit_would_be_visible_to_factions(
+                *from,
+                *source_unit_type,
+                *source_faction,
+                false,
+                &friendly_factions,
+                pre_fog,
+                &detectors,
+            );
+            let target_is_visible = entity_visible_to_factions_with_detectors(
+                world,
+                *target_entity,
+                &friendly_factions,
+                post_fog,
+                &detectors,
+            );
+            let mut units_moved = Vec::new();
+            let mut units_removed = Vec::new();
+            if source_was_visible && target_is_visible {
+                units_moved.push(UnitMoved {
+                    id: *source_id,
+                    path: path.clone(),
+                    from: *from,
+                    to: *to,
+                });
+                units_removed.push(*source_id);
+            } else if source_was_visible && !target_is_visible {
+                units_removed.push(*source_id);
+            }
+
+            let mut units_revealed = Vec::new();
+            if target_is_visible
+                && let Some(visible) =
+                    entity_to_visible_unit(world, *target_entity, &friendly_factions)
+            {
+                units_revealed.push(visible);
+            }
+
+            let _ = (source_entity, target_id);
+            let my_funds = if *funds_refund > 0 {
+                world
+                    .resource::<PlayerRegistry>()
+                    .player_for_faction(*source_faction)
+                    .filter(|owner| *owner == player)
+                    .and_then(|owner| {
+                        world
+                            .resource::<PlayerRegistry>()
+                            .get(owner)
+                            .map(|slot| slot.funds)
+                    })
+            } else {
+                None
+            };
+
+            PlayerUpdate {
+                units_revealed,
+                units_moved,
+                units_removed,
+                terrain_revealed: Vec::new(),
                 terrain_changed: Vec::new(),
                 turn_change: None,
                 combat_event: None,
@@ -788,6 +1127,7 @@ fn collect_visible_units(
     friendly_factions: &HashSet<PlayerFaction>,
     fog_map: Option<&FogOfWarMap>,
 ) -> Vec<VisibleUnit> {
+    let detectors = detector_positions(world, friendly_factions);
     // Include ServerUnitId, Fuel, Ammo, CaptureProgress in the query to avoid separate entity lookups.
     let mut query = world.query_filtered::<(
         Entity,
@@ -799,20 +1139,24 @@ fn collect_visible_units(
         Option<&Fuel>,
         Option<&Ammo>,
         Option<&CaptureProgress>,
+        Option<&Hiding>,
     ), Without<CarriedBy>>();
 
     query
         .iter(world)
-        .filter(|(_, pos, unit, _, _, _, _, _, _)| {
-            if let Some(fog) = fog_map {
-                let is_air = unit.0.domain() == awbrn_types::UnitDomain::Air;
-                fog.is_unit_visible(pos.position(), is_air)
-            } else {
-                true
-            }
+        .filter(|(_, pos, unit, faction, _, _, _, _, _, hiding)| {
+            unit_would_be_visible_to_factions(
+                pos.position(),
+                unit.0,
+                faction.0,
+                hiding.is_some(),
+                friendly_factions,
+                fog_map,
+                &detectors,
+            )
         })
         .map(
-            |(_, pos, unit, faction, hp, unit_id, fuel, ammo, capture_progress)| {
+            |(_, pos, unit, faction, hp, unit_id, fuel, ammo, capture_progress, hiding)| {
                 let include_private_stats = friendly_factions.contains(&faction.0);
                 let capture_progress = capture_progress.map(|progress| progress.value());
                 VisibleUnit {
@@ -833,6 +1177,7 @@ fn collect_visible_units(
                     },
                     capturing: capture_progress.is_some(),
                     capture_progress,
+                    hiding: hiding.is_some(),
                 }
             },
         )
@@ -869,24 +1214,118 @@ fn visible_enemy_units(
     friendly_factions: &HashSet<PlayerFaction>,
     fog_map: Option<&FogOfWarMap>,
 ) -> HashMap<ServerUnitId, Entity> {
-    let mut query = world.query_filtered::<
-        (Entity, &MapPosition, &Faction, &Unit, &ServerUnitId),
-        Without<CarriedBy>,
-    >();
+    let detectors = detector_positions(world, friendly_factions);
+    let mut query = world.query_filtered::<(
+        Entity,
+        &MapPosition,
+        &Faction,
+        &Unit,
+        &ServerUnitId,
+        Option<&Hiding>,
+    ), Without<CarriedBy>>();
 
     query
         .iter(world)
-        .filter(|(_, _, faction, _, _)| !friendly_factions.contains(&faction.0))
-        .filter(|(_, pos, _, unit, _)| {
-            if let Some(fog) = fog_map {
-                let is_air = unit.0.domain() == awbrn_types::UnitDomain::Air;
-                fog.is_unit_visible(pos.position(), is_air)
-            } else {
-                true
-            }
+        .filter(|(_, _, faction, _, _, _)| !friendly_factions.contains(&faction.0))
+        .filter(|(_, pos, faction, unit, _, hiding)| {
+            unit_would_be_visible_to_factions(
+                pos.position(),
+                unit.0,
+                faction.0,
+                hiding.is_some(),
+                friendly_factions,
+                fog_map,
+                &detectors,
+            )
         })
-        .map(|(entity, _, _, _, uid)| (*uid, entity))
+        .map(|(entity, _, _, _, uid, _)| (*uid, entity))
         .collect()
+}
+
+fn entity_visible_to_factions(
+    world: &mut World,
+    entity: Entity,
+    friendly_factions: &HashSet<PlayerFaction>,
+    fog_map: Option<&FogOfWarMap>,
+) -> bool {
+    let detectors = detector_positions(world, friendly_factions);
+    entity_visible_to_factions_with_detectors(world, entity, friendly_factions, fog_map, &detectors)
+}
+
+fn entity_visible_to_factions_with_detectors(
+    world: &World,
+    entity: Entity,
+    friendly_factions: &HashSet<PlayerFaction>,
+    fog_map: Option<&FogOfWarMap>,
+    detectors: &[Position],
+) -> bool {
+    let entity_ref = world.entity(entity);
+    if entity_ref.contains::<CarriedBy>() {
+        return false;
+    }
+    let Some(pos) = entity_ref.get::<MapPosition>() else {
+        return false;
+    };
+    let Some(unit) = entity_ref.get::<Unit>() else {
+        return false;
+    };
+    let Some(faction) = entity_ref.get::<Faction>() else {
+        return false;
+    };
+
+    unit_would_be_visible_to_factions(
+        pos.position(),
+        unit.0,
+        faction.0,
+        entity_ref.contains::<Hiding>(),
+        friendly_factions,
+        fog_map,
+        detectors,
+    )
+}
+
+fn detector_positions(
+    world: &mut World,
+    friendly_factions: &HashSet<PlayerFaction>,
+) -> Vec<Position> {
+    let mut query =
+        world.query_filtered::<(&MapPosition, &Faction), (With<Unit>, Without<CarriedBy>)>();
+
+    query
+        .iter(world)
+        .filter_map(|(pos, faction)| {
+            friendly_factions
+                .contains(&faction.0)
+                .then_some(pos.position())
+        })
+        .collect()
+}
+
+fn unit_would_be_visible_to_factions(
+    position: Position,
+    unit_type: awbrn_types::Unit,
+    faction: PlayerFaction,
+    is_hiding: bool,
+    friendly_factions: &HashSet<PlayerFaction>,
+    fog_map: Option<&FogOfWarMap>,
+    detector_positions: &[Position],
+) -> bool {
+    if friendly_factions.contains(&faction) {
+        return true;
+    }
+
+    let is_air = unit_type.domain() == awbrn_types::UnitDomain::Air;
+    let fog_visible = fog_map
+        .map(|fog| fog.is_unit_visible(position, is_air))
+        .unwrap_or(true);
+    if !fog_visible {
+        return false;
+    }
+
+    !is_hiding
+        || detector_positions
+            .iter()
+            .any(|detector| detector.manhattan(&position) == 1)
 }
 
 /// Returns terrain tiles that transitioned from fogged to visible between pre and post fog.
@@ -957,6 +1396,7 @@ fn entity_to_visible_unit(
         capture_progress: entity_ref
             .get::<CaptureProgress>()
             .map(|progress| progress.value()),
+        hiding: entity_ref.contains::<Hiding>(),
     })
 }
 

--- a/crates/awbrn-server/tests/server.rs
+++ b/crates/awbrn-server/tests/server.rs
@@ -1,7 +1,9 @@
 use std::num::NonZeroU8;
 
 use awbrn_map::{AwbrnMap, Position};
-use awbrn_types::{Faction as TerrainFaction, GraphicalTerrain, PlayerFaction, Property, Unit};
+use awbrn_types::{
+    Faction as TerrainFaction, GraphicalTerrain, PlayerFaction, Property, SeaDirection, Unit,
+};
 
 use awbrn_server::{
     CaptureEvent, Co, CommandError, GameCommand, GameServer, GameSetup, PlayerId, PlayerSetup,
@@ -21,6 +23,18 @@ fn capture_command(unit_id: ServerUnitId, position: Position) -> GameCommand {
         unit_id,
         path: vec![position],
         action: Some(PostMoveAction::Capture),
+    }
+}
+
+fn action_command(
+    unit_id: ServerUnitId,
+    path: Vec<Position>,
+    action: PostMoveAction,
+) -> GameCommand {
+    GameCommand::MoveUnit {
+        unit_id,
+        path,
+        action: Some(action),
     }
 }
 
@@ -1132,6 +1146,602 @@ fn primary_weapon_attack_consumes_ammo() {
         initial_ammo - 1,
         "primary weapon should consume 1 ammo"
     );
+}
+
+// ── Non-combat post-move action integration tests ────────────────────────────
+
+#[test]
+fn supply_restores_self_owned_adjacent_fuel_and_ammo() {
+    let mut server = GameServer::new(two_player_setup(5, 3)).unwrap();
+    let apc = server.spawn_unit(Position::new(1, 1), Unit::APC, PlayerFaction::OrangeStar);
+    let infantry = server.spawn_unit(
+        Position::new(0, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let mech = server.spawn_unit(Position::new(2, 1), Unit::Mech, PlayerFaction::OrangeStar);
+    server.spawn_unit(Position::new(3, 1), Unit::Tank, PlayerFaction::BlueMoon);
+
+    server
+        .submit_command(
+            p1(),
+            action_command(
+                infantry,
+                vec![Position::new(0, 0), Position::new(0, 1)],
+                PostMoveAction::Wait,
+            ),
+        )
+        .unwrap();
+    server.submit_command(p1(), GameCommand::EndTurn).unwrap();
+    server.submit_command(p2(), GameCommand::EndTurn).unwrap();
+
+    server
+        .submit_command(
+            p1(),
+            attack_command(mech, vec![Position::new(2, 1)], Position::new(3, 1)),
+        )
+        .unwrap();
+
+    let before = server.player_view(p1());
+    let low_fuel = before
+        .units
+        .iter()
+        .find(|unit| unit.id == infantry)
+        .unwrap();
+    assert!(low_fuel.fuel.unwrap() < Unit::Infantry.max_fuel());
+    let low_ammo = before.units.iter().find(|unit| unit.id == mech).unwrap();
+    assert!(low_ammo.ammo.unwrap() < Unit::Mech.max_ammo());
+
+    server
+        .submit_command(
+            p1(),
+            action_command(apc, vec![Position::new(1, 1)], PostMoveAction::Supply),
+        )
+        .unwrap();
+
+    let after = server.player_view(p1());
+    let supplied_infantry = after.units.iter().find(|unit| unit.id == infantry).unwrap();
+    assert_eq!(supplied_infantry.fuel, Some(Unit::Infantry.max_fuel()));
+    let supplied_mech = after.units.iter().find(|unit| unit.id == mech).unwrap();
+    assert_eq!(supplied_mech.ammo, Some(Unit::Mech.max_ammo()));
+}
+
+#[test]
+fn supply_rejects_when_no_adjacent_self_owned_units_exist() {
+    let mut server = GameServer::new(allied_player_setup(3, 1)).unwrap();
+    let apc = server.spawn_unit(Position::new(0, 0), Unit::APC, PlayerFaction::OrangeStar);
+    server.spawn_unit(Position::new(1, 0), Unit::Infantry, PlayerFaction::BlueMoon);
+
+    let err = server
+        .submit_command(
+            p1(),
+            action_command(apc, vec![Position::new(0, 0)], PostMoveAction::Supply),
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, CommandError::InvalidAction { .. }));
+}
+
+#[test]
+fn supply_does_not_restore_allied_teammate_units() {
+    let mut server = GameServer::new(allied_player_setup(4, 2)).unwrap();
+    let apc = server.spawn_unit(Position::new(0, 0), Unit::APC, PlayerFaction::OrangeStar);
+    server.spawn_unit(
+        Position::new(0, 1),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let allied_infantry =
+        server.spawn_unit(Position::new(2, 0), Unit::Infantry, PlayerFaction::BlueMoon);
+
+    server.submit_command(p1(), GameCommand::EndTurn).unwrap();
+    server
+        .submit_command(
+            p2(),
+            action_command(
+                allied_infantry,
+                vec![Position::new(2, 0), Position::new(1, 0)],
+                PostMoveAction::Wait,
+            ),
+        )
+        .unwrap();
+    server.submit_command(p2(), GameCommand::EndTurn).unwrap();
+
+    let fuel_before = server
+        .player_view(p1())
+        .units
+        .iter()
+        .find(|unit| unit.id == allied_infantry)
+        .unwrap()
+        .fuel;
+    assert_eq!(fuel_before, Some(Unit::Infantry.max_fuel() - 1));
+
+    server
+        .submit_command(
+            p1(),
+            action_command(apc, vec![Position::new(0, 0)], PostMoveAction::Supply),
+        )
+        .unwrap();
+
+    let fuel_after = server
+        .player_view(p1())
+        .units
+        .iter()
+        .find(|unit| unit.id == allied_infantry)
+        .unwrap()
+        .fuel;
+    assert_eq!(fuel_after, fuel_before);
+}
+
+#[test]
+fn load_removes_cargo_from_map_and_unload_restores_it() {
+    let mut server = GameServer::new(two_player_setup(5, 1)).unwrap();
+    let cargo = server.spawn_unit(
+        Position::new(0, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let apc = server.spawn_unit(Position::new(1, 0), Unit::APC, PlayerFaction::OrangeStar);
+
+    server
+        .submit_command(
+            p1(),
+            action_command(
+                cargo,
+                vec![Position::new(0, 0), Position::new(1, 0)],
+                PostMoveAction::Load { transport_id: apc },
+            ),
+        )
+        .unwrap();
+
+    assert!(
+        !server
+            .player_view(p1())
+            .units
+            .iter()
+            .any(|unit| unit.id == cargo),
+        "loaded cargo should not occupy a map tile"
+    );
+
+    server
+        .submit_command(
+            p1(),
+            action_command(
+                apc,
+                vec![Position::new(1, 0)],
+                PostMoveAction::Unload {
+                    cargo_id: cargo,
+                    position: Position::new(2, 0),
+                },
+            ),
+        )
+        .unwrap();
+
+    let view = server.player_view(p1());
+    assert_eq!(
+        view.units
+            .iter()
+            .find(|unit| unit.id == cargo)
+            .map(|unit| unit.position),
+        Some(Position::new(2, 0))
+    );
+
+    server.submit_command(p1(), GameCommand::EndTurn).unwrap();
+    server.submit_command(p2(), GameCommand::EndTurn).unwrap();
+    server
+        .submit_command(
+            p1(),
+            action_command(
+                cargo,
+                vec![Position::new(2, 0), Position::new(3, 0)],
+                PostMoveAction::Wait,
+            ),
+        )
+        .expect("unloaded cargo id should remain registered");
+}
+
+#[test]
+fn load_rejects_full_transport() {
+    let mut server = GameServer::new(two_player_setup(5, 1)).unwrap();
+    let first = server.spawn_unit(
+        Position::new(0, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let apc = server.spawn_unit(Position::new(1, 0), Unit::APC, PlayerFaction::OrangeStar);
+    let second = server.spawn_unit(Position::new(2, 0), Unit::Mech, PlayerFaction::OrangeStar);
+
+    server
+        .submit_command(
+            p1(),
+            action_command(
+                first,
+                vec![Position::new(0, 0), Position::new(1, 0)],
+                PostMoveAction::Load { transport_id: apc },
+            ),
+        )
+        .unwrap();
+
+    let err = server
+        .submit_command(
+            p1(),
+            action_command(
+                second,
+                vec![Position::new(2, 0), Position::new(1, 0)],
+                PostMoveAction::Load { transport_id: apc },
+            ),
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, CommandError::InvalidAction { .. }));
+}
+
+#[test]
+fn load_does_not_leak_fogged_destination_coordinates() {
+    let mut setup = two_player_setup(4, 1);
+    setup.fog_enabled = true;
+    let mut server = GameServer::new(setup).unwrap();
+    let cargo = server.spawn_unit(
+        Position::new(1, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let transport = server.spawn_unit(Position::new(2, 0), Unit::APC, PlayerFaction::OrangeStar);
+    server.spawn_unit(Position::new(0, 0), Unit::APC, PlayerFaction::BlueMoon);
+
+    let result = server
+        .submit_command(
+            p1(),
+            action_command(
+                cargo,
+                vec![Position::new(1, 0), Position::new(2, 0)],
+                PostMoveAction::Load {
+                    transport_id: transport,
+                },
+            ),
+        )
+        .unwrap();
+
+    let p2_update = result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p2())
+        .unwrap()
+        .1
+        .clone();
+
+    assert!(p2_update.units_removed.contains(&cargo));
+    assert!(
+        p2_update.units_moved.is_empty(),
+        "load should not serialize a hidden destination coordinate"
+    );
+}
+
+#[test]
+fn unload_rejects_occupied_or_impassable_target() {
+    let mut setup = two_player_setup(4, 3);
+    setup.map.set_terrain(
+        Position::new(1, 0),
+        GraphicalTerrain::Sea(SeaDirection::Sea),
+    );
+    let mut server = GameServer::new(setup).unwrap();
+    let cargo = server.spawn_unit(
+        Position::new(0, 1),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let apc = server.spawn_unit(Position::new(1, 1), Unit::APC, PlayerFaction::OrangeStar);
+    server.spawn_unit(Position::new(2, 1), Unit::Tank, PlayerFaction::OrangeStar);
+
+    server
+        .submit_command(
+            p1(),
+            action_command(
+                cargo,
+                vec![Position::new(0, 1), Position::new(1, 1)],
+                PostMoveAction::Load { transport_id: apc },
+            ),
+        )
+        .unwrap();
+
+    let occupied_err = server
+        .submit_command(
+            p1(),
+            action_command(
+                apc,
+                vec![Position::new(1, 1)],
+                PostMoveAction::Unload {
+                    cargo_id: cargo,
+                    position: Position::new(2, 1),
+                },
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(occupied_err, CommandError::InvalidAction { .. }));
+
+    let impassable_err = server
+        .submit_command(
+            p1(),
+            action_command(
+                apc,
+                vec![Position::new(1, 1)],
+                PostMoveAction::Unload {
+                    cargo_id: cargo,
+                    position: Position::new(1, 0),
+                },
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(impassable_err, CommandError::InvalidPath { .. }));
+}
+
+#[test]
+fn hide_and_unhide_change_enemy_player_view() {
+    let mut server = GameServer::new(two_player_setup(5, 1)).unwrap();
+    let sub = server.spawn_unit(Position::new(0, 0), Unit::Sub, PlayerFaction::OrangeStar);
+    server.spawn_unit(Position::new(4, 0), Unit::Infantry, PlayerFaction::BlueMoon);
+
+    assert!(
+        server
+            .player_view(p2())
+            .units
+            .iter()
+            .any(|unit| unit.id == sub)
+    );
+
+    let hide_result = server
+        .submit_command(
+            p1(),
+            action_command(sub, vec![Position::new(0, 0)], PostMoveAction::Hide),
+        )
+        .unwrap();
+    let p1_hide_update = hide_result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p1())
+        .unwrap()
+        .1
+        .clone();
+    assert!(
+        p1_hide_update
+            .units_revealed
+            .iter()
+            .any(|unit| unit.id == sub && unit.hiding),
+        "owner update should include the hidden state"
+    );
+    assert!(
+        server
+            .player_view(p1())
+            .units
+            .iter()
+            .any(|unit| unit.id == sub && unit.hiding),
+        "owner view should keep hidden unit visible with hiding=true"
+    );
+    assert!(
+        !server
+            .player_view(p2())
+            .units
+            .iter()
+            .any(|unit| unit.id == sub),
+        "hidden sub should disappear from enemy view when not detected"
+    );
+
+    server.submit_command(p1(), GameCommand::EndTurn).unwrap();
+    server.submit_command(p2(), GameCommand::EndTurn).unwrap();
+    let unhide_result = server
+        .submit_command(
+            p1(),
+            action_command(sub, vec![Position::new(0, 0)], PostMoveAction::Unhide),
+        )
+        .unwrap();
+    let p1_unhide_update = unhide_result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p1())
+        .unwrap()
+        .1
+        .clone();
+    assert!(
+        p1_unhide_update
+            .units_revealed
+            .iter()
+            .any(|unit| unit.id == sub && !unit.hiding),
+        "owner update should include the unhidden state"
+    );
+    assert!(
+        server
+            .player_view(p1())
+            .units
+            .iter()
+            .any(|unit| unit.id == sub && !unit.hiding),
+        "owner view should keep unit visible with hiding=false"
+    );
+
+    assert!(
+        server
+            .player_view(p2())
+            .units
+            .iter()
+            .any(|unit| unit.id == sub),
+        "unhidden sub should reappear"
+    );
+}
+
+#[test]
+fn hide_and_unhide_refresh_detecting_enemy_visible_unit() {
+    let mut server = GameServer::new(two_player_setup(3, 1)).unwrap();
+    let sub = server.spawn_unit(Position::new(0, 0), Unit::Sub, PlayerFaction::OrangeStar);
+    server.spawn_unit(Position::new(1, 0), Unit::Infantry, PlayerFaction::BlueMoon);
+
+    let hide_result = server
+        .submit_command(
+            p1(),
+            action_command(sub, vec![Position::new(0, 0)], PostMoveAction::Hide),
+        )
+        .unwrap();
+    let p2_hide_update = hide_result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p2())
+        .unwrap()
+        .1
+        .clone();
+    assert!(
+        p2_hide_update
+            .units_revealed
+            .iter()
+            .any(|unit| unit.id == sub && unit.hiding),
+        "detected hidden unit should refresh hiding=true for enemy viewer"
+    );
+    assert!(
+        server
+            .player_view(p2())
+            .units
+            .iter()
+            .any(|unit| unit.id == sub && unit.hiding)
+    );
+
+    server.submit_command(p1(), GameCommand::EndTurn).unwrap();
+    server.submit_command(p2(), GameCommand::EndTurn).unwrap();
+
+    let unhide_result = server
+        .submit_command(
+            p1(),
+            action_command(sub, vec![Position::new(0, 0)], PostMoveAction::Unhide),
+        )
+        .unwrap();
+    let p2_unhide_update = unhide_result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p2())
+        .unwrap()
+        .1
+        .clone();
+    assert!(
+        p2_unhide_update
+            .units_revealed
+            .iter()
+            .any(|unit| unit.id == sub && !unit.hiding),
+        "detected unhidden unit should refresh hiding=false for enemy viewer"
+    );
+}
+
+#[test]
+fn hide_rejects_non_hidden_capable_units() {
+    let mut server = GameServer::new(two_player_setup(3, 1)).unwrap();
+    let tank = server.spawn_unit(Position::new(0, 0), Unit::Tank, PlayerFaction::OrangeStar);
+
+    let err = server
+        .submit_command(
+            p1(),
+            action_command(tank, vec![Position::new(0, 0)], PostMoveAction::Hide),
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, CommandError::InvalidAction { .. }));
+}
+
+#[test]
+fn join_caps_target_hp_and_removes_source_id() {
+    let mut server = GameServer::new(two_player_setup(4, 1)).unwrap();
+    let source = server.spawn_unit(
+        Position::new(0, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let target = server.spawn_unit(
+        Position::new(1, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+
+    let starting_funds = server.player_view(p1()).my_funds;
+    let result = server
+        .submit_command(
+            p1(),
+            action_command(
+                source,
+                vec![Position::new(0, 0), Position::new(1, 0)],
+                PostMoveAction::Join { target_id: target },
+            ),
+        )
+        .unwrap();
+    let expected_refund = Unit::Infantry.base_cost();
+
+    let view = server.player_view(p1());
+    assert!(!view.units.iter().any(|unit| unit.id == source));
+    let joined = view.units.iter().find(|unit| unit.id == target).unwrap();
+    assert_eq!(joined.hp, 10);
+    assert_eq!(view.my_funds, starting_funds + expected_refund);
+    let p1_update = result
+        .updates
+        .iter()
+        .find(|(player, _)| *player == p1())
+        .unwrap()
+        .1
+        .clone();
+    assert_eq!(p1_update.my_funds, Some(starting_funds + expected_refund));
+
+    let err = server
+        .submit_command(
+            p1(),
+            action_command(
+                source,
+                vec![Position::new(1, 0), Position::new(2, 0)],
+                PostMoveAction::Wait,
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(err, CommandError::InvalidUnit(id) if id == source));
+}
+
+#[test]
+fn join_rejects_different_type_or_owner() {
+    let mut server = GameServer::new(two_player_setup(5, 1)).unwrap();
+    let source = server.spawn_unit(
+        Position::new(0, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let tank = server.spawn_unit(Position::new(1, 0), Unit::Tank, PlayerFaction::OrangeStar);
+    let enemy_infantry =
+        server.spawn_unit(Position::new(2, 0), Unit::Infantry, PlayerFaction::BlueMoon);
+
+    let different_type_err = server
+        .submit_command(
+            p1(),
+            action_command(
+                source,
+                vec![Position::new(0, 0), Position::new(1, 0)],
+                PostMoveAction::Join { target_id: tank },
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        different_type_err,
+        CommandError::InvalidAction { .. }
+    ));
+
+    let different_owner_err = server
+        .submit_command(
+            p1(),
+            action_command(
+                source,
+                vec![
+                    Position::new(0, 0),
+                    Position::new(1, 0),
+                    Position::new(2, 0),
+                ],
+                PostMoveAction::Join {
+                    target_id: enemy_infantry,
+                },
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        different_owner_err,
+        CommandError::InvalidAction { .. }
+    ));
 }
 
 // ── Capture integration tests ─────────────────────────────────────────────────


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-move actions: Supply, Load/Unload, Hide/Unhide, and Join with corresponding player-facing outcomes (resupply, cargo transitions, hiding state, unit merges).

* **Validation**
  * Implemented concrete validation rules for all new post-move actions (capacity, adjacency, faction/type constraints, terrain/occupancy rules).

* **Visibility**
  * Units now include hiding state; detection logic reveals hidden units and drives update events.

* **Tests**
  * Expanded integration tests covering all behaviors and fog-safety.

* **Chores**
  * Added adjacency helpers to support adjacent-unit checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->