### PR TITLE
Add text output to awbrn-image

### DIFF
--- a/crates/awbrn-image/src/main.rs
+++ b/crates/awbrn-image/src/main.rs
@@ -1,7 +1,7 @@
-//! CLI: render an AWBW text or JSON map to a PNG.
+//! CLI: render an AWBW text or JSON map to a PNG or a text grid.
 //!
 //! Usage:
-//!   awbrn-image <input.(txt|json)> [-o <output.png>] [--assets-dir <dir>]
+//!   awbrn-image <input.(txt|json)> [-o <output>] [--format png|text|awbw] [--assets-dir <dir>]
 
 use std::path::{Path, PathBuf};
 
@@ -9,19 +9,47 @@ use anyhow::{Context, Result, bail};
 use awbrn_image::{Tilesets, render_map};
 use awbrn_map::{AwbwMap, AwbwMapData, PredeployedUnit};
 
+/// Output representation for a parsed map.
+#[derive(Debug, Clone, Copy)]
+enum Format {
+    /// Rendered PNG image.
+    Png,
+    /// Lossless Unicode glyph grid (every tile a unique character) plus a legend.
+    Text,
+    /// AWBW text-format ASCII grid, with factions collapsed to the canonical set.
+    Awbw,
+}
+
+impl std::str::FromStr for Format {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "png" => Ok(Format::Png),
+            "text" => Ok(Format::Text),
+            "awbw" => Ok(Format::Awbw),
+            other => bail!("unknown format: {other} (expected png, text, or awbw)"),
+        }
+    }
+}
+
 fn main() -> Result<()> {
     let mut input: Option<PathBuf> = None;
     let mut output: Option<PathBuf> = None;
     let mut assets_dir: Option<PathBuf> = None;
+    let mut format: Option<Format> = None;
 
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "-o" | "--output" => {
-                output = Some(next_value(&mut args, &arg)?);
+                output = Some(next_value(&mut args, &arg)?.into());
+            }
+            "-f" | "--format" => {
+                format = Some(next_value(&mut args, &arg)?.parse()?);
             }
             "--assets-dir" => {
-                assets_dir = Some(next_value(&mut args, &arg)?);
+                assets_dir = Some(next_value(&mut args, &arg)?.into());
             }
             "-h" | "--help" => {
                 print_usage();
@@ -38,11 +66,8 @@ fn main() -> Result<()> {
     }
 
     let input = input.context("missing <input> map file (.txt or .json)\n\n(run with --help)")?;
-    let output = output.unwrap_or_else(|| input.with_extension("png"));
-    let assets_dir = assets_dir.unwrap_or_else(default_assets_dir);
 
     let data = std::fs::read(&input).with_context(|| format!("reading {}", input.display()))?;
-
     let (map, units) = if is_json(&input) {
         let map_data: AwbwMapData = serde_json::from_slice(&data)
             .with_context(|| format!("parsing JSON map {}", input.display()))?;
@@ -55,36 +80,82 @@ fn main() -> Result<()> {
         (map, Vec::<PredeployedUnit>::new())
     };
 
-    let tilesets = Tilesets::load_from_dir(&assets_dir).with_context(|| {
-        format!(
-            "loading tiles.png / units.png from {} (override with --assets-dir)",
-            assets_dir.display()
-        )
-    })?;
+    // Default to PNG, but infer text output from a `.txt` output path.
+    let format = format.unwrap_or_else(|| infer_format(output.as_deref()));
 
-    let image = render_map(&map, &units, &tilesets);
-    image
-        .save(&output)
-        .with_context(|| format!("writing {}", output.display()))?;
+    match format {
+        Format::Png => {
+            let output = output.unwrap_or_else(|| input.with_extension("png"));
+            let assets_dir = assets_dir.unwrap_or_else(default_assets_dir);
+            let tilesets = Tilesets::load_from_dir(&assets_dir).with_context(|| {
+                format!(
+                    "loading tiles.png / units.png from {} (override with --assets-dir)",
+                    assets_dir.display()
+                )
+            })?;
 
-    eprintln!(
-        "wrote {} ({}x{})",
-        output.display(),
-        image.width(),
-        image.height()
-    );
+            let image = render_map(&map, &units, &tilesets);
+            image
+                .save(&output)
+                .with_context(|| format!("writing {}", output.display()))?;
+            eprintln!(
+                "wrote {} ({}x{})",
+                output.display(),
+                image.width(),
+                image.height()
+            );
+        }
+        Format::Text => {
+            let map = map.collapse_factions();
+            let mut content = map.lossless().to_string();
+            let legend = map.legend().to_string();
+            if !legend.is_empty() {
+                content.push_str("\n\nLegend:\n");
+                content.push_str(&legend);
+            }
+            write_text(content, output)?;
+        }
+        Format::Awbw => {
+            write_text(map.collapse_factions().awbw().to_string(), output)?;
+        }
+    }
+
     Ok(())
 }
 
-fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<PathBuf> {
+/// Write a text rendering (with a trailing newline) to `output` if given, else
+/// to stdout.
+fn write_text(mut content: String, output: Option<PathBuf>) -> Result<()> {
+    // Append the trailing newline in place rather than reallocating the whole
+    // (potentially map-sized) buffer with `format!`.
+    content.push('\n');
+    match output {
+        Some(path) => {
+            std::fs::write(&path, &content)
+                .with_context(|| format!("writing {}", path.display()))?;
+            eprintln!("wrote {}", path.display());
+        }
+        None => print!("{content}"),
+    }
+    Ok(())
+}
+
+fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
     args.next()
-        .map(PathBuf::from)
         .with_context(|| format!("missing value for {flag}"))
 }
 
 fn is_json(path: &Path) -> bool {
     path.extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+}
+
+/// Infer the output format from the output path's extension (`.txt` → text).
+fn infer_format(output: Option<&Path>) -> Format {
+    match output.and_then(|path| path.extension()) {
+        Some(ext) if ext.eq_ignore_ascii_case("txt") => Format::Text,
+        _ => Format::Png,
+    }
 }
 
 /// Default to the workspace's bundled textures, resolved relative to this crate.
@@ -98,10 +169,12 @@ fn default_assets_dir() -> PathBuf {
 
 fn print_usage() {
     eprintln!(
-        "awbrn-image — render an AWBW map to PNG\n\n\
-         USAGE:\n    awbrn-image <input.(txt|json)> [-o <output.png>] [--assets-dir <dir>]\n\n\
+        "awbrn-image — render an AWBW map to PNG or text\n\n\
+         USAGE:\n    awbrn-image <input.(txt|json)> [-o <output>] [--format png|text|awbw] [--assets-dir <dir>]\n\n\
          ARGS:\n    <input>            AWBW text (.txt) or map_info JSON (.json) map\n\n\
-         OPTIONS:\n    -o, --output <file>    Output PNG path (default: input with .png)\n    \
+         OPTIONS:\n    -o, --output <file>    Output path (default: input with .png; stdout for text)\n    \
+         -f, --format <fmt>     png (default), text (lossless Unicode + legend), or awbw\n                           \
+         (collapsed ASCII). Inferred as text when --output ends in .txt\n    \
          --assets-dir <dir>     Directory containing tiles.png and units.png\n                           \
          (default: bundled assets/textures)\n    -h, --help             Print this help"
     );

--- a/crates/awbrn-map/src/awbw_map.rs
+++ b/crates/awbrn-map/src/awbw_map.rs
@@ -2,8 +2,9 @@ use crate::{
     MapError, Position,
     pathfinding::{MovementMap, PathFinder},
 };
-use awbrn_types::{AwbwTerrain, MovementTerrain};
+use awbrn_types::{AwbwTerrain, Faction, MovementTerrain, PLAYER_FACTION_METADATA, PlayerFaction};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt;
 
 /// Represents a game map with terrain data
@@ -107,6 +108,60 @@ impl AwbwMap {
         self.height
     }
 
+    /// Render every tile as a unique glyph (never a space), preserving full
+    /// faction identity. See [`AwbwTerrain::symbol`]. Pair with [`Self::legend`]
+    /// to decode the non-ASCII glyphs.
+    pub fn lossless(&self) -> LosslessSymbols<'_> {
+        LosslessSymbols(self)
+    }
+
+    /// Render using the AWBW text-format ASCII symbols, with a space for any
+    /// terrain the format can't represent. Combine with [`Self::collapse_factions`]
+    /// for a faithful AWBW grid.
+    pub fn awbw(&self) -> AwbwSymbols<'_> {
+        AwbwSymbols(self)
+    }
+
+    /// A key naming every non-ASCII glyph used by [`Self::lossless`].
+    pub fn legend(&self) -> Legend<'_> {
+        Legend(self)
+    }
+
+    /// Collapse this map's player factions onto the canonical (AWBW-id) faction
+    /// order in first-appearance order, so the map uses its minimal set (e.g. a
+    /// 1v1 becomes Orange Star / Blue Moon). Neutral tiles are unchanged. The
+    /// canonical order is taken from [`PLAYER_FACTION_METADATA`], which lists every
+    /// player faction exactly once, so each distinct faction keeps its own slot.
+    pub fn collapse_factions(&self) -> AwbwMap {
+        // `seen` records distinct player factions in first-appearance order; a
+        // faction's slot in `seen` indexes its canonical replacement.
+        let mut seen: Vec<PlayerFaction> = Vec::new();
+        let terrain = self
+            .terrain
+            .iter()
+            .map(|terrain| match terrain {
+                AwbwTerrain::Property(property) => match property.faction() {
+                    Faction::Player(old) => {
+                        let slot = seen.iter().position(|f| *f == old).unwrap_or_else(|| {
+                            seen.push(old);
+                            seen.len() - 1
+                        });
+                        let new = PLAYER_FACTION_METADATA[slot].faction();
+                        AwbwTerrain::Property(property.with_owner(Faction::Player(new)))
+                    }
+                    Faction::Neutral => *terrain,
+                },
+                _ => *terrain,
+            })
+            .collect();
+
+        AwbwMap {
+            width: self.width,
+            height: self.height,
+            terrain,
+        }
+    }
+
     /// Get the terrain at the specified position
     pub fn terrain_at(&self, pos: Position) -> Option<AwbwTerrain> {
         if pos.x >= self.width || pos.y >= self.height() {
@@ -154,29 +209,78 @@ impl MovementMap for AwbwMap {
     }
 }
 
-impl fmt::Display for AwbwMap {
+/// Writes the map as a grid, one `glyph` per tile, rows separated by newlines.
+fn write_grid(
+    f: &mut fmt::Formatter<'_>,
+    map: &AwbwMap,
+    glyph: impl Fn(&AwbwTerrain) -> char,
+) -> fmt::Result {
+    let height = map.height();
+    for y in 0..height {
+        for x in 0..map.width {
+            write!(f, "{}", glyph(&map.terrain[y * map.width + x]))?;
+        }
+
+        // Add a newline after each row unless it's the last row
+        if y < height - 1 {
+            writeln!(f)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Lossless map rendering: every tile is a unique glyph, never a space. The
+/// default [`fmt::Display`] for [`AwbwMap`]. See [`AwbwMap::lossless`].
+pub struct LosslessSymbols<'a>(&'a AwbwMap);
+
+impl fmt::Display for LosslessSymbols<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let height = self.height();
+        write_grid(f, self.0, AwbwTerrain::symbol)
+    }
+}
 
-        for y in 0..height {
-            for x in 0..self.width {
-                let idx = y * self.width + x;
-                let terrain = &self.terrain[idx];
+/// AWBW text-format rendering: ASCII symbols, with a space for any terrain the
+/// AWBW format can't represent. See [`AwbwMap::awbw`].
+pub struct AwbwSymbols<'a>(&'a AwbwMap);
 
-                // Use the terrain's symbol or a space if none exists
-                match terrain.symbol() {
-                    Some(symbol) => write!(f, "{}", symbol)?,
-                    None => write!(f, " ")?,
-                }
-            }
+impl fmt::Display for AwbwSymbols<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_grid(f, self.0, |terrain| terrain.awbw_symbol().unwrap_or(' '))
+    }
+}
 
-            // Add a newline after each row unless it's the last row
-            if y < height - 1 {
-                writeln!(f)?;
+/// A key for the non-ASCII glyphs used by [`AwbwMap::lossless`], mapping each to
+/// its terrain name. See [`AwbwMap::legend`].
+pub struct Legend<'a>(&'a AwbwMap);
+
+impl fmt::Display for Legend<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // A terrain needs a legend entry exactly when it has no AWBW symbol, i.e.
+        // its lossless glyph is the non-ASCII fallback rather than an ASCII symbol.
+        let mut entries: BTreeMap<char, &'static str> = BTreeMap::new();
+        for terrain in &self.0.terrain {
+            if terrain.awbw_symbol().is_none() {
+                entries.insert(terrain.symbol(), terrain.name());
             }
         }
 
+        for (i, (glyph, name)) in entries.iter().enumerate() {
+            if i > 0 {
+                writeln!(f)?;
+            }
+            write!(f, "{glyph}  {name}")?;
+        }
+
         Ok(())
+    }
+}
+
+/// The default rendering is the lossless glyph grid; use [`AwbwMap::awbw`] for the
+/// ASCII AWBW text format.
+impl fmt::Display for AwbwMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.lossless().fmt(f)
     }
 }
 
@@ -364,5 +468,46 @@ mod tests {
         let expected = ".^@\n,ai";
 
         assert_eq!(map.to_string(), expected);
+    }
+
+    #[test]
+    fn collapse_factions_normalizes_to_canonical_order() {
+        // Black Hole HQ (95) then Teal Galaxy HQ (167): two distinct player factions.
+        let map = AwbwMap::parse_txt("95,167").unwrap();
+        let collapsed = map.collapse_factions();
+
+        // First-seen faction -> Orange Star (HQ 'i'), second -> Blue Moon (HQ 'o').
+        assert_eq!(collapsed.awbw().to_string(), "io");
+    }
+
+    #[test]
+    fn lossless_renders_exotic_faction_with_legend() {
+        // Teal Galaxy HQ (167) has no AWBW symbol, so `awbw()` leaves a space, but
+        // `lossless()` emits a unique non-ASCII glyph that the legend names.
+        let map = AwbwMap::parse_txt("167").unwrap();
+
+        let rendered = map.lossless().to_string();
+        let glyph = rendered.chars().next().unwrap();
+        assert_eq!(rendered.chars().count(), 1);
+        assert!(!glyph.is_ascii());
+
+        assert_eq!(map.awbw().to_string(), " ");
+        assert_eq!(map.legend().to_string(), format!("{glyph}  Teal Galaxy HQ"));
+    }
+
+    #[test]
+    fn collapse_handles_more_than_seven_factions() {
+        // 9 distinct player HQs — more than the 7 ASCII-symbol factions — must not
+        // panic, and every tile still renders to a unique non-space lossless glyph.
+        let map = AwbwMap::parse_txt("42,47,52,57,85,90,95,100,120").unwrap();
+        let glyphs: Vec<char> = map
+            .collapse_factions()
+            .lossless()
+            .to_string()
+            .chars()
+            .collect();
+
+        assert_eq!(glyphs.len(), 9);
+        assert!(glyphs.iter().all(|glyph| *glyph != ' '));
     }
 }

--- a/crates/awbrn-map/src/lib.rs
+++ b/crates/awbrn-map/src/lib.rs
@@ -5,7 +5,7 @@ mod pathfinding;
 mod position;
 
 pub use awbrn_map::AwbrnMap;
-pub use awbw_map::{AwbwMap, AwbwMapData, PredeployedUnit};
+pub use awbw_map::{AwbwMap, AwbwMapData, AwbwSymbols, Legend, LosslessSymbols, PredeployedUnit};
 pub use map_error::MapError;
 pub use pathfinding::{MovementMap, PathFinder, TerrainCosts};
 pub use position::Position;

--- a/crates/awbrn-types/src/awbw_terrain.rs
+++ b/crates/awbrn-types/src/awbw_terrain.rs
@@ -29,9 +29,20 @@ pub enum AwbwTerrain {
     Teleporter,
 }
 
+/// Base code point for lossless fallback glyphs (start of Latin Extended-A,
+/// `U+0100`). Terrain ids are `1..=223`, so glyphs land in `U+0101..=U+01DF` — all
+/// assigned, letter-like, and disjoint from the ASCII [`AwbwTerrain::awbw_symbol`]
+/// range, keeping [`AwbwTerrain::symbol`] injective.
+const LOSSLESS_SYMBOL_BASE: u32 = 0x0100;
+
 impl AwbwTerrain {
-    /// Get the symbol character for this terrain
-    pub fn symbol(&self) -> Option<char> {
+    /// Get the AWBW text-format symbol character for this terrain, if one exists.
+    ///
+    /// Only a subset of terrains have an AWBW symbol — notably just the 7 classic
+    /// symbol-capable factions (Orange Star, Blue Moon, Green Earth, Yellow Comet,
+    /// Red Fire, Grey Sky, Black Hole) plus Neutral; everything else returns
+    /// `None`. For a total, lossless glyph use [`Self::symbol`].
+    pub fn awbw_symbol(&self) -> Option<char> {
         match self {
             AwbwTerrain::Plain => Some('.'),
             AwbwTerrain::Mountain => Some('^'),
@@ -180,6 +191,38 @@ impl AwbwTerrain {
             AwbwTerrain::Property(Property::ComTower(Faction::Neutral)) => Some('_'),
             AwbwTerrain::Property(Property::Lab(Faction::Neutral)) => Some('6'),
             _ => None,
+        }
+    }
+
+    /// Get a unique, lossless glyph for this terrain.
+    ///
+    /// Reuses [`Self::awbw_symbol`] where the AWBW text format defines one (so
+    /// common maps stay readable in ASCII); every other terrain — exotic faction
+    /// properties, player-owned com towers/labs, teleporters — maps to a distinct
+    /// glyph in the Latin Extended range, derived from its unique terrain id. The
+    /// mapping is total and injective, so a rendered grid round-trips through
+    /// [`Self::from_symbol`].
+    pub fn symbol(&self) -> char {
+        self.awbw_symbol().unwrap_or_else(|| {
+            char::from_u32(LOSSLESS_SYMBOL_BASE + self.id().0 as u32)
+                .expect("terrain id maps into the Latin Extended block")
+        })
+    }
+
+    /// Inverse of [`Self::symbol`]: recover the terrain from a lossless glyph.
+    pub fn from_symbol(c: char) -> Option<AwbwTerrain> {
+        if c.is_ascii() {
+            // ASCII glyphs come from `awbw_symbol`; reverse that small mapping.
+            (1u8..=u8::MAX)
+                .filter_map(|id| AwbwTerrain::try_from(id).ok())
+                .find(|terrain| terrain.awbw_symbol() == Some(c))
+        } else {
+            // Non-ASCII glyphs are `LOSSLESS_SYMBOL_BASE + id`; invert directly.
+            let id = u8::try_from((c as u32).checked_sub(LOSSLESS_SYMBOL_BASE)?).ok()?;
+            let terrain = AwbwTerrain::try_from(id).ok()?;
+            // Confirm this terrain actually uses the fallback glyph (no AWBW symbol),
+            // so the inverse stays exact.
+            (terrain.symbol() == c).then_some(terrain)
         }
     }
 
@@ -1506,20 +1549,52 @@ mod tests {
     #[test]
     fn test_terrain_symbol() {
         // Test symbols for various terrain types
-        assert_eq!(AwbwTerrain::Plain.symbol(), Some('.'));
-        assert_eq!(AwbwTerrain::Mountain.symbol(), Some('^'));
-        assert_eq!(AwbwTerrain::Wood.symbol(), Some('@'));
-        assert_eq!(AwbwTerrain::Sea.symbol(), Some(','));
+        assert_eq!(AwbwTerrain::Plain.awbw_symbol(), Some('.'));
+        assert_eq!(AwbwTerrain::Mountain.awbw_symbol(), Some('^'));
+        assert_eq!(AwbwTerrain::Wood.awbw_symbol(), Some('@'));
+        assert_eq!(AwbwTerrain::Sea.awbw_symbol(), Some(','));
 
         // Test symbols for properties
         assert_eq!(
-            AwbwTerrain::Property(Property::City(Faction::Neutral)).symbol(),
+            AwbwTerrain::Property(Property::City(Faction::Neutral)).awbw_symbol(),
             Some('a')
         );
         assert_eq!(
-            AwbwTerrain::Property(Property::HQ(PlayerFaction::OrangeStar)).symbol(),
+            AwbwTerrain::Property(Property::HQ(PlayerFaction::OrangeStar)).awbw_symbol(),
             Some('i')
         );
+
+        // Factions without an AWBW symbol fall through to None.
+        assert_eq!(
+            AwbwTerrain::Property(Property::City(Faction::Player(PlayerFaction::TealGalaxy)))
+                .awbw_symbol(),
+            None
+        );
+    }
+
+    #[test]
+    fn lossless_symbol_is_total_and_injective() {
+        let mut seen = std::collections::HashMap::new();
+        for id in 1..=u8::MAX {
+            let Ok(terrain) = AwbwTerrain::try_from(id) else {
+                continue;
+            };
+            let glyph = terrain.symbol();
+            assert_ne!(glyph, ' ', "{terrain:?} rendered as a space");
+
+            // Reuses the ASCII symbol when one exists, otherwise a Latin Extended glyph.
+            match terrain.awbw_symbol() {
+                Some(ascii) => assert_eq!(glyph, ascii),
+                None => assert!((glyph as u32) >= LOSSLESS_SYMBOL_BASE),
+            }
+
+            if let Some(prev) = seen.insert(glyph, terrain) {
+                panic!("{glyph:?} used by both {prev:?} and {terrain:?}");
+            }
+
+            // Round-trips back to the same terrain.
+            assert_eq!(AwbwTerrain::from_symbol(glyph), Some(terrain));
+        }
     }
 
     #[test]

--- a/crates/awbrn-types/src/terrain.rs
+++ b/crates/awbrn-types/src/terrain.rs
@@ -264,6 +264,25 @@ impl Property {
         }
     }
 
+    /// Return this property owned by `faction`, preserving the building kind.
+    ///
+    /// An HQ can never be neutral, so remapping an HQ to [`Faction::Neutral`]
+    /// leaves its owner unchanged.
+    pub const fn with_owner(&self, faction: Faction) -> Property {
+        match self {
+            Property::City(_) => Property::City(faction),
+            Property::Base(_) => Property::Base(faction),
+            Property::Airport(_) => Property::Airport(faction),
+            Property::Port(_) => Property::Port(faction),
+            Property::ComTower(_) => Property::ComTower(faction),
+            Property::Lab(_) => Property::Lab(faction),
+            Property::HQ(existing) => match faction {
+                Faction::Player(player) => Property::HQ(player),
+                Faction::Neutral => Property::HQ(*existing),
+            },
+        }
+    }
+
     pub const fn kind(&self) -> PropertyKind {
         match self {
             Property::Airport(_) => PropertyKind::Airport,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiple output formats: PNG images, lossless Unicode text with symbol legend, or AWBW-style ASCII notation.
  * Flexible input support: Load maps from JSON or UTF-8 text grid format.
  * Automatic format detection: Output format inferred from file extension (`.txt` defaults to text format).
  * Faction collapsing: Normalize factions to canonical AWBW ordering for compact text representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->