### PR TITLE
Update rawzip to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,9 +4819,9 @@ dependencies = [
 
 [[package]]
 name = "rawzip"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9575f44c8cf85bc843ad666dcdf20d05a7753772bef56eb2a5140282b32150"
+checksum = "d661184e2add3106911b7c17e76b49328db021428c242ce0e577c3e8744d8130"
 
 [[package]]
 name = "rayon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ js-sys = "0.3.91"
 oxipng = "10.0.0"
 phpserz = "0.3.0"
 raw-window-handle = { version = "0.6.2", features = ["wasm-bindgen-0-2"] }
-rawzip = "0.4.4"
+rawzip = "0.5"
 rectangle-pack = "0.4.2"
 rstest = "0.25.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/awbw-replay/src/replay.rs
+++ b/crates/awbw-replay/src/replay.rs
@@ -38,7 +38,7 @@ impl<R: AsRef<[u8]>> ReplayFile<R> {
                 continue;
             }
 
-            if entry.compression_method() != rawzip::CompressionMethod::Deflate {
+            if entry.compression_method() != rawzip::CompressionMethod::DEFLATE {
                 continue;
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay file compatibility by correctly recognizing DEFLATE-compressed archive entries.
  * Continued to safely skip unsupported compression formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->