### PR TITLE
Correct replay-backed AWVM rules

### DIFF
--- a/crates/awvm/src/query.rs
+++ b/crates/awvm/src/query.rs
@@ -283,10 +283,9 @@ pub fn reachable(state: &State, unit: UnitId) -> Result<MoveField, QueryError> {
         if steps[index_of(position)].is_some_and(|step| step.cost < cost) {
             continue;
         }
-        // A tile whose occupant the mover can see blocks the route *through*
-        // it, for an ally as much as an enemy (`spec/semantics/movement.md`,
-        // occupancy). It remains reachable as a terminal.
-        if position != origin && occupancy.blocks(position) {
+        // A disclosed enemy blocks the route through its tile. Allied units
+        // may be crossed but remain invalid destinations.
+        if position != origin && occupancy.blocks_route(position) {
             continue;
         }
         for next in position.orthogonal() {
@@ -304,7 +303,7 @@ pub fn reachable(state: &State, unit: UnitId) -> Result<MoveField, QueryError> {
             }
             steps[index_of(next)] = Some(Step {
                 cost: total,
-                can_stop: !is_teleporter(state, next) && !occupancy.blocks(next),
+                can_stop: !is_teleporter(state, next) && !occupancy.blocks_stop(next),
                 previous: Some(position),
             });
             frontier.push(Frontier {
@@ -589,17 +588,19 @@ pub fn production_options(state: &State, player: &PlayerId, position: Pos) -> Ve
         .collect()
 }
 
-/// Which tiles hold a unit whose occupancy is disclosed to the moving team,
-/// which is what makes one a blocker.
+/// Which tiles have disclosed occupants that block stopping or traversal.
 struct Occupancy {
-    blocked: Vec<bool>,
+    stop: Vec<bool>,
+    route: Vec<bool>,
     width: u8,
 }
 
 impl Occupancy {
     fn new(state: &State, mover: &Unit, team: &TeamId) -> Self {
         let width = state.board.width();
-        let mut blocked = vec![false; usize::from(width) * usize::from(state.board.height())];
+        let size = usize::from(width) * usize::from(state.board.height());
+        let mut stop = vec![false; size];
+        let mut route = vec![false; size];
         let view = AwbwVisibility.view(state, team);
         for unit in state.units.iter() {
             if unit.id == mover.id {
@@ -609,15 +610,26 @@ impl Occupancy {
                 continue;
             };
             if state.board.contains(position) && view.unit(unit) {
-                blocked[usize::from(position.y) * usize::from(width) + usize::from(position.x)] =
-                    true;
+                let index = usize::from(position.y) * usize::from(width) + usize::from(position.x);
+                stop[index] = true;
+                route[index] = state
+                    .find_player(&unit.owner)
+                    .is_some_and(|owner| owner.team != *team);
             }
         }
-        Self { blocked, width }
+        Self { stop, route, width }
     }
 
-    fn blocks(&self, position: Pos) -> bool {
-        self.blocked[usize::from(position.y) * usize::from(self.width) + usize::from(position.x)]
+    fn index(&self, position: Pos) -> usize {
+        usize::from(position.y) * usize::from(self.width) + usize::from(position.x)
+    }
+
+    fn blocks_stop(&self, position: Pos) -> bool {
+        self.stop[self.index(position)]
+    }
+
+    fn blocks_route(&self, position: Pos) -> bool {
+        self.route[self.index(position)]
     }
 }
 

--- a/crates/awvm/src/transition/attack.rs
+++ b/crates/awvm/src/transition/attack.rs
@@ -842,6 +842,7 @@ fn resolve_exchange(
     if defender_remaining > 0 {
         next.units[defender_index].hp = defender_remaining;
     }
+    let mut attacker_removed = false;
     if let Some(hit) = counter {
         let attacker_remaining = attacker.hp.saturating_sub(hit.damage);
         apply_hit(
@@ -854,16 +855,34 @@ fn resolve_exchange(
             attacker_remaining,
             KnownReason::CombatCounter,
         )?;
-        next.units[attacker_index].hp = attacker_remaining;
+        if attacker_remaining == 0 {
+            let Location::Board { position } = attacker.location else {
+                unreachable!("an attacking unit is on the board");
+            };
+            movement::reset_capture_on_removal(&mut next, position, &mut events);
+            remove_combatant_and_cargo(
+                &mut next,
+                attacker.id,
+                KnownReason::CombatCounter,
+                &mut events,
+            );
+            attacker_removed = true;
+        } else {
+            next.units[attacker_index].hp = attacker_remaining;
+        }
     }
     if defender_remaining == 0 {
-        events.push(Event::UnitRemoved {
-            unit: defender.id,
-            reason: KnownReason::Combat.into(),
-        });
-        next.units.remove(defender_index);
+        let Location::Board { position } = defender.location else {
+            unreachable!("a defending unit is on the board");
+        };
+        movement::reset_capture_on_removal(&mut next, position, &mut events);
+        remove_combatant_and_cargo(&mut next, defender.id, KnownReason::Combat, &mut events);
     }
-    spend_attacker(&mut next, &mut events, attacker.id);
+    if !attacker_removed {
+        spend_attacker(&mut next, &mut events, attacker.id);
+    } else {
+        rout_if_last_unit(&mut next, &attacker.owner, &mut events)?;
+    }
     if defender_remaining == 0 {
         rout_if_last_unit(&mut next, &defender.owner, &mut events)?;
     }
@@ -923,11 +942,16 @@ fn resolve_counter_first(
         KnownReason::CombatCounter,
     )?;
     if attacker_remaining == 0 {
-        events.push(Event::UnitRemoved {
-            unit: attacker.id,
-            reason: KnownReason::CombatCounter.into(),
-        });
-        next.units.remove(engagement.attacker_index);
+        let Location::Board { position } = attacker.location else {
+            unreachable!("an attacking unit is on the board");
+        };
+        movement::reset_capture_on_removal(&mut next, position, &mut events);
+        remove_combatant_and_cargo(
+            &mut next,
+            attacker.id,
+            KnownReason::CombatCounter,
+            &mut events,
+        );
         rout_if_last_unit(&mut next, &attacker.owner, &mut events)?;
         return Ok(Execution {
             state: next,
@@ -949,17 +973,17 @@ fn resolve_counter_first(
         defender_remaining,
         KnownReason::Combat,
     )?;
-    let defender_index = next
-        .units
-        .index_of(defender.id)
-        .expect("the target remains present until it is removed");
     if defender_remaining == 0 {
-        events.push(Event::UnitRemoved {
-            unit: defender.id,
-            reason: KnownReason::Combat.into(),
-        });
-        next.units.remove(defender_index);
+        let Location::Board { position } = defender.location else {
+            unreachable!("a defending unit is on the board");
+        };
+        movement::reset_capture_on_removal(&mut next, position, &mut events);
+        remove_combatant_and_cargo(&mut next, defender.id, KnownReason::Combat, &mut events);
     } else {
+        let defender_index = next
+            .units
+            .index_of(defender.id)
+            .expect("the target remains present until it is removed");
         next.units[defender_index].hp = defender_remaining;
     }
     spend_attacker(&mut next, &mut events, attacker.id);
@@ -971,6 +995,44 @@ fn resolve_counter_first(
         events,
         random_consumed: draws.drawn(),
     })
+}
+
+/// Remove a destroyed board unit and any units it carried.
+///
+/// Cargo loss is a consequence of losing the carrier, not another combat
+/// strike, so it emits removal facts but earns no combat power charge.
+fn remove_combatant_and_cargo(
+    next: &mut State,
+    unit: UnitId,
+    reason: KnownReason,
+    events: &mut Vec<Event>,
+) {
+    let mut cargo: Vec<_> = next
+        .units
+        .iter()
+        .filter_map(|candidate| match candidate.location {
+            Location::Cargo { transport, slot } if transport == unit => Some((slot, candidate.id)),
+            _ => None,
+        })
+        .collect();
+    cargo.sort();
+    next.units.retain(|candidate| {
+        candidate.id != unit
+            && !matches!(
+                candidate.location,
+                Location::Cargo { transport, .. } if transport == unit
+            )
+    });
+    events.push(Event::UnitRemoved {
+        unit,
+        reason: reason.into(),
+    });
+    for (_, cargo) in cargo {
+        events.push(Event::UnitRemoved {
+            unit: cargo,
+            reason: KnownReason::CarrierLost.into(),
+        });
+    }
 }
 
 /// Mark the acting unit spent. Both exchange orders end here, and both reach it

--- a/crates/awvm/src/transition/movement.rs
+++ b/crates/awvm/src/transition/movement.rs
@@ -182,6 +182,9 @@ pub(crate) fn plan(
         if state.units.iter().any(|other| {
             other.id != unit_id
                 && board_position(other) == Some(position)
+                && state
+                    .find_player(&other.owner)
+                    .is_some_and(|owner| owner.team != actor_team)
                 && occupancy_is_disclosed(&view, other)
         }) {
             return Err(violation(Violation::PathOccupied { index, position }));
@@ -292,11 +295,15 @@ pub(crate) fn reset_capture_on_departure(
     if actual_path.len() < 2 || !state.units.contains(unit_id) {
         return;
     }
-    let tile = &mut state.board.tile_mut(origin);
+    reset_capture_on_removal(state, origin, events);
+}
+
+pub(crate) fn reset_capture_on_removal(state: &mut State, position: Pos, events: &mut Vec<Event>) {
+    let tile = &mut state.board.tile_mut(position);
     if let Some(before) = tile.capture_points.filter(|points| *points < 20) {
         tile.capture_points = Some(20);
         events.push(Event::CaptureChanged {
-            position: origin,
+            position,
             from: before,
             to: 20,
         });

--- a/crates/awvm/src/transition/powers.rs
+++ b/crates/awvm/src/transition/powers.rs
@@ -355,7 +355,7 @@ fn heal_exact_hp(cx: &mut Activation<'_>, amount: u8) -> Result<(), ExecuteError
         .next
         .units
         .iter()
-        .filter(|unit| unit.owner == cx.player)
+        .filter(|unit| unit.owner == cx.player && matches!(unit.location, Location::Board { .. }))
         .map(|unit| unit.id)
         .collect();
     targets.sort();
@@ -403,14 +403,16 @@ fn damage_exact_hp(
         .iter()
         .filter(|unit| {
             enemy_owners.contains(unit.owner.as_str())
-                && (!properties_only
-                    || match unit.location {
-                        Location::Board { position } => ruleset::terrain_has(
-                            cx.next.board.tile(position).terrain,
-                            TerrainTrait::Capturable,
-                        ),
-                        Location::Cargo { .. } => false,
-                    })
+                && match unit.location {
+                    Location::Board { position } => {
+                        !properties_only
+                            || ruleset::terrain_has(
+                                cx.next.board.tile(position).terrain,
+                                TerrainTrait::Capturable,
+                            )
+                    }
+                    Location::Cargo { .. } => false,
+                }
         })
         .map(|unit| unit.id)
         .collect();
@@ -478,7 +480,10 @@ fn drain_current_fuel_ratio(
         .next
         .units
         .iter()
-        .filter(|unit| enemy_owners.contains(unit.owner.as_str()))
+        .filter(|unit| {
+            enemy_owners.contains(unit.owner.as_str())
+                && matches!(unit.location, Location::Board { .. })
+        })
         .map(|unit| unit.id)
         .collect();
     targets.sort();
@@ -634,7 +639,11 @@ fn refresh_unit_action(
         .next
         .units
         .iter()
-        .filter(|unit| unit.owner == cx.player && !exclude_unit_kinds.contains(&unit.kind))
+        .filter(|unit| {
+            unit.owner == cx.player
+                && matches!(unit.location, Location::Board { .. })
+                && !exclude_unit_kinds.contains(&unit.kind)
+        })
         .map(|unit| unit.id)
         .collect();
     targets.sort();

--- a/crates/awvm/tests/goldens/observations.txt
+++ b/crates/awvm/tests/goldens/observations.txt
@@ -9,6 +9,8 @@ c5463462544e62e7  obs=4 ev=10  capture/capture-limit-precedes-hq.json
 4e0f6734e99fa404  obs=2 ev=0  capture/capture-noncapturer-rejected.json
 db403f863b43b1a7  obs=4 ev=8  capture/lab-ignored-with-hq.json
 45f947759da1556e  obs=6 ev=22  capture/lab-last-owned-lab.json
+66515e516d07717e  obs=4 ev=11  combat/carrier-loss-no-cargo-charge.json
+016b613e343bc08c  obs=4 ev=6  combat/lethal-capture-reset.json
 6215a59df49fbf34  obs=4 ev=10  combat/movement-direct-fog-capture.json
 e6c1d55dbd31ea57  obs=4 ev=3  combat/movement-hidden-blocker.json
 6ddfce451867b40f  obs=4 ev=8  combat/movement-tile-target.json
@@ -55,7 +57,7 @@ c0692d28c186322b  obs=4 ev=6  commander/drake-cop-combat.json
 7793c7e990b41333  obs=4 ev=16  commander/drake-day-to-day-combat.json
 af11b70e60f14885  obs=6 ev=4  commander/drake-day-to-day.json
 6fcf52e5370f5854  obs=4 ev=6  commander/drake-scop-combat.json
-e63b7f9d90fbd535  obs=6 ev=12  commander/drake-scop.json
+c0598516807940a7  obs=6 ev=12  commander/drake-scop.json
 772fd361e6fefc74  obs=4 ev=6  commander/eagle-cop-activation.json
 5a37bc5031b9b179  obs=4 ev=6  commander/eagle-cop.json
 c5bee54080e12499  obs=4 ev=8  commander/eagle-day-to-day-air-combat.json
@@ -91,7 +93,7 @@ ca27a2d48edd99e7  obs=4 ev=2  commander/hachi-scop-activation.json
 a0164822db8973f3  obs=2 ev=0  commander/hachi-scop-unit-limit.json
 517e66ab9efa2bb7  obs=2 ev=2  commander/hachi-scop.json
 dc92661fee749d6b  obs=4 ev=6  commander/hawke-cop-combat.json
-482441911fce6951  obs=6 ev=15  commander/hawke-cop.json
+3aa44023931bae61  obs=6 ev=15  commander/hawke-cop.json
 eec2214ccf006f1f  obs=4 ev=8  commander/hawke-day-to-day-combat.json
 a1dfb4d4b802cdec  obs=4 ev=6  commander/hawke-scop-combat.json
 bdc2e277a85c3a30  obs=4 ev=8  commander/hawke-scop.json
@@ -112,11 +114,11 @@ ba41d9f5a8bc0d8e  obs=4 ev=8  commander/javier-day-to-day-indirect-defense.json
 1270cac79ea97f86  obs=4 ev=2  commander/javier-scop.json
 49fbed91d2937617  obs=4 ev=10  commander/jess-cop-combat.json
 db40ea14aea3d463  obs=4 ev=2  commander/jess-cop-movement.json
-fe2a26bd26ddd194  obs=4 ev=6  commander/jess-cop.json
+f3200ee41c08031d  obs=4 ev=7  commander/jess-cop.json
 29d153a5e838dfd9  obs=4 ev=14  commander/jess-day-to-day-combat.json
 b56c25b7a8d945dd  obs=4 ev=10  commander/jess-scop-combat.json
 053a22d1900cb8a7  obs=4 ev=2  commander/jess-scop-movement.json
-8a51b669b74fe1a5  obs=4 ev=6  commander/jess-scop.json
+80042986c92a6a98  obs=4 ev=7  commander/jess-scop.json
 fd2aeaaf7d055379  obs=4 ev=6  commander/jugger-cop-combat.json
 46dd3e61cba8d8f7  obs=4 ev=2  commander/jugger-cop.json
 d1d952c1627f3967  obs=4 ev=8  commander/jugger-day-to-day-combat.json
@@ -262,6 +264,7 @@ c4b6f0ae7228f5ad  obs=2 ev=3  join/join-no-overflow.json
 5ef35b30b53b48cc  obs=4 ev=3  launch/move-launch-hidden-blocker.json
 8395ec1acf9091a4  obs=2 ev=4  launch/move-launch-radius-two.json
 796f07547a5f529e  obs=8 ev=0  launch/move-launch-validation.json
+9964111ae3cc7e7f  obs=2 ev=1  movement/allied-intermediate-traversal.json
 d81cc3d0c06517cf  obs=2 ev=1  movement/infantry-plain-move.json
 3f719ea7333bab91  obs=4 ev=0  movement/match-finished-rejected.json
 34bc012594f1cb5a  obs=2 ev=2  movement/move-wait-capture-reset.json

--- a/spec/fixtures/combat/carrier-loss-no-cargo-charge.json
+++ b/spec/fixtures/combat/carrier-loss-no-cargo-charge.json
@@ -1,11 +1,11 @@
 {
-  "id": "drake-typhoon",
+  "id": "combat-carrier-loss-no-cargo-charge",
   "spec_version": "0.1.0",
   "ruleset": { "id": "awbw", "revision": "2026-07-10" },
-  "feature": "commander-power-v1.drake.scop",
+  "feature": "combat-power-charge-v1.carrier-loss",
   "evidence": {
     "confidence": "confirmed-experiment",
-    "note": "Loaded cargo is off-map and is excluded from Typhoon fuel drain and damage."
+    "note": "AWBW cargo lost with a destroyed transport does not add CO power charge."
   },
   "initial_state": {
     "ruleset": { "id": "awbw", "revision": "2026-07-10" },
@@ -38,15 +38,14 @@
         "team": "red-team",
         "funds": 0,
         "status": "active",
-        "commanders": [{ "id": "drake", "active": true, "power_charge": 63000, "power_uses": 0 }],
-        "power_state": { "type": "none" }
-      },
-      {
-        "id": "ally",
-        "team": "red-team",
-        "funds": 0,
-        "status": "active",
-        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "commanders": [
+          {
+            "id": "nell",
+            "active": true,
+            "power_charge": 0,
+            "power_uses": 0
+          }
+        ],
         "power_state": { "type": "none" }
       },
       {
@@ -54,7 +53,14 @@
         "team": "blue-team",
         "funds": 0,
         "status": "active",
-        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "commanders": [
+          {
+            "id": "nell",
+            "active": true,
+            "power_charge": 0,
+            "power_uses": 0
+          }
+        ],
         "power_state": { "type": "none" }
       }
     ],
@@ -62,28 +68,28 @@
       "day": 1,
       "active_player": "red",
       "phase": "unit-action",
-      "order": ["red", "ally", "blue"],
+      "order": ["red", "blue"],
       "position": 0
     },
-    "weather": { "kind": "snow", "remaining_turns": 2 },
+    "weather": { "kind": "clear", "remaining_turns": 0 },
     "units": [
       {
         "id": 0,
-        "kind": "infantry",
+        "kind": "tank",
         "owner": "red",
         "hp": 100,
-        "fuel": 99,
-        "ammo": 0,
+        "fuel": 70,
+        "ammo": 9,
         "action": "ready",
         "concealment": "exposed",
         "location": { "type": "board", "position": [0, 0] }
       },
       {
         "id": 1,
-        "kind": "infantry",
-        "owner": "ally",
-        "hp": 50,
-        "fuel": 77,
+        "kind": "apc",
+        "owner": "blue",
+        "hp": 30,
+        "fuel": 70,
         "ammo": 0,
         "action": "ready",
         "concealment": "exposed",
@@ -91,34 +97,43 @@
       },
       {
         "id": 2,
-        "kind": "apc",
+        "kind": "infantry",
         "owner": "blue",
-        "hp": 15,
-        "fuel": 51,
+        "hp": 100,
+        "fuel": 99,
         "ammo": 0,
-        "action": "ready",
+        "action": "spent",
         "concealment": "exposed",
-        "location": { "type": "board", "position": [2, 0] }
+        "location": { "type": "cargo", "transport": 1, "slot": 0 }
       },
       {
         "id": 3,
         "kind": "infantry",
         "owner": "blue",
-        "hp": 50,
-        "fuel": 77,
+        "hp": 100,
+        "fuel": 99,
         "ammo": 0,
-        "action": "spent",
+        "action": "ready",
         "concealment": "exposed",
-        "location": { "type": "cargo", "transport": 2, "slot": 0 }
+        "location": { "type": "board", "position": [2, 0] }
       }
     ],
     "match": { "status": "active", "draw_offers": [] }
   },
   "steps": [
     {
-      "id": "activate-typhoon",
-      "command": { "type": "activate-power", "player": "red", "level": "scop" },
-      "random": [],
+      "id": "destroy-transport-with-cargo",
+      "command": {
+        "type": "move-attack",
+        "player": "red",
+        "unit": 0,
+        "path": [[0, 0]],
+        "target": { "type": "unit", "unit": 1 }
+      },
+      "random": [
+        { "type": "combat-good-luck", "value": 0 },
+        { "type": "combat-bad-luck", "value": 0 }
+      ],
       "expect": {
         "status": "accepted",
         "state": {
@@ -152,16 +167,13 @@
               "team": "red-team",
               "funds": 0,
               "status": "active",
-              "commanders": [{ "id": "drake", "active": true, "power_charge": 0, "power_uses": 1 }],
-              "power_state": { "type": "scop", "commander_slot": 0 }
-            },
-            {
-              "id": "ally",
-              "team": "red-team",
-              "funds": 0,
-              "status": "active",
               "commanders": [
-                { "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }
+                {
+                  "id": "nell",
+                  "active": true,
+                  "power_charge": 750,
+                  "power_uses": 0
+                }
               ],
               "power_state": { "type": "none" }
             },
@@ -171,7 +183,12 @@
               "funds": 0,
               "status": "active",
               "commanders": [
-                { "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }
+                {
+                  "id": "nell",
+                  "active": true,
+                  "power_charge": 1500,
+                  "power_uses": 0
+                }
               ],
               "power_state": { "type": "none" }
             }
@@ -180,85 +197,86 @@
             "day": 1,
             "active_player": "red",
             "phase": "unit-action",
-            "order": ["red", "ally", "blue"],
+            "order": ["red", "blue"],
             "position": 0
           },
-          "weather": { "kind": "rain", "remaining_turns": 3 },
+          "weather": { "kind": "clear", "remaining_turns": 0 },
           "units": [
             {
               "id": 0,
-              "kind": "infantry",
+              "kind": "tank",
               "owner": "red",
               "hp": 100,
-              "fuel": 99,
-              "ammo": 0,
-              "action": "ready",
+              "fuel": 70,
+              "ammo": 8,
+              "action": "spent",
               "concealment": "exposed",
               "location": { "type": "board", "position": [0, 0] }
-            },
-            {
-              "id": 1,
-              "kind": "infantry",
-              "owner": "ally",
-              "hp": 50,
-              "fuel": 77,
-              "ammo": 0,
-              "action": "ready",
-              "concealment": "exposed",
-              "location": { "type": "board", "position": [1, 0] }
-            },
-            {
-              "id": 2,
-              "kind": "apc",
-              "owner": "blue",
-              "hp": 1,
-              "fuel": 26,
-              "ammo": 0,
-              "action": "ready",
-              "concealment": "exposed",
-              "location": { "type": "board", "position": [2, 0] }
             },
             {
               "id": 3,
               "kind": "infantry",
               "owner": "blue",
-              "hp": 50,
-              "fuel": 77,
+              "hp": 100,
+              "fuel": 99,
               "ammo": 0,
-              "action": "spent",
+              "action": "ready",
               "concealment": "exposed",
-              "location": { "type": "cargo", "transport": 2, "slot": 0 }
+              "location": { "type": "board", "position": [2, 0] }
             }
           ],
           "match": { "status": "active", "draw_offers": [] }
         },
         "events": [
-          { "type": "power-activated", "player": "red", "commander": "drake", "power": "scop" },
           {
             "type": "unit-resourced",
-            "unit": 2,
-            "fuel_before": 51,
-            "fuel_after": 26,
-            "ammo_before": 0,
-            "ammo_after": 0,
-            "reason": "commander-power"
+            "unit": 0,
+            "fuel_before": 70,
+            "fuel_after": 70,
+            "ammo_before": 9,
+            "ammo_after": 8,
+            "reason": "combat"
+          },
+          {
+            "type": "attack-resolved",
+            "attacker": 0,
+            "weapon": "ammo",
+            "target": { "type": "unit", "unit": 1 }
           },
           {
             "type": "unit-damaged",
-            "unit": 2,
-            "from_hp": 15,
-            "to_hp": 1,
-            "reason": "commander-power"
+            "unit": 1,
+            "from_hp": 30,
+            "to_hp": 0,
+            "reason": "combat"
           },
           {
-            "type": "weather-changed",
-            "from": "snow",
-            "to": "rain",
-            "remaining_turns": 3,
-            "reason": "commander-power"
+            "type": "power-charge-changed",
+            "player": "red",
+            "commander_slot": 0,
+            "from": 0,
+            "to": 750,
+            "reason": "combat"
+          },
+          {
+            "type": "power-charge-changed",
+            "player": "blue",
+            "commander_slot": 0,
+            "from": 0,
+            "to": 1500,
+            "reason": "combat"
+          },
+          { "type": "unit-removed", "unit": 1, "reason": "combat" },
+          { "type": "unit-removed", "unit": 2, "reason": "carrier-lost" },
+          {
+            "type": "unit-action-changed",
+            "unit": 0,
+            "from": "ready",
+            "to": "spent",
+            "reason": "attack"
           }
         ],
-        "random_consumed": 0
+        "random_consumed": 2
       }
     }
   ]

--- a/spec/fixtures/combat/lethal-capture-reset.json
+++ b/spec/fixtures/combat/lethal-capture-reset.json
@@ -1,11 +1,11 @@
 {
-  "id": "drake-typhoon",
+  "id": "combat-lethal-capture-reset",
   "spec_version": "0.1.0",
   "ruleset": { "id": "awbw", "revision": "2026-07-10" },
-  "feature": "commander-power-v1.drake.scop",
+  "feature": "combat-neutral-v1",
   "evidence": {
-    "confidence": "confirmed-experiment",
-    "note": "Loaded cargo is off-map and is excluded from Typhoon fuel drain and damage."
+    "confidence": "confirmed-replay",
+    "note": "Archived AWBW replay 1362397 action 375 resets the defender's interrupted capture when the strike removes it."
   },
   "initial_state": {
     "ruleset": { "id": "awbw", "revision": "2026-07-10" },
@@ -13,7 +13,7 @@
       "fog": false,
       "income_per_property": 1000,
       "starting_funds": 0,
-      "powers": "enabled",
+      "powers": "disabled",
       "tags": false,
       "weather": "clear",
       "lab_units": [],
@@ -26,7 +26,13 @@
     "board": {
       "width": 3,
       "height": 1,
-      "tiles": [[{ "terrain": "plain" }, { "terrain": "plain" }, { "terrain": "plain" }]]
+      "tiles": [
+        [
+          { "terrain": "plain" },
+          { "terrain": "city", "owner": null, "capture_points": 10 },
+          { "terrain": "plain" }
+        ]
+      ]
     },
     "teams": [
       { "id": "red-team", "status": "active" },
@@ -35,14 +41,6 @@
     "players": [
       {
         "id": "red",
-        "team": "red-team",
-        "funds": 0,
-        "status": "active",
-        "commanders": [{ "id": "drake", "active": true, "power_charge": 63000, "power_uses": 0 }],
-        "power_state": { "type": "none" }
-      },
-      {
-        "id": "ally",
         "team": "red-team",
         "funds": 0,
         "status": "active",
@@ -62,10 +60,10 @@
       "day": 1,
       "active_player": "red",
       "phase": "unit-action",
-      "order": ["red", "ally", "blue"],
+      "order": ["red", "blue"],
       "position": 0
     },
-    "weather": { "kind": "snow", "remaining_turns": 2 },
+    "weather": { "kind": "clear", "remaining_turns": 0 },
     "units": [
       {
         "id": 0,
@@ -81,9 +79,9 @@
       {
         "id": 1,
         "kind": "infantry",
-        "owner": "ally",
-        "hp": 50,
-        "fuel": 77,
+        "owner": "blue",
+        "hp": 30,
+        "fuel": 99,
         "ammo": 0,
         "action": "ready",
         "concealment": "exposed",
@@ -91,34 +89,32 @@
       },
       {
         "id": 2,
-        "kind": "apc",
+        "kind": "infantry",
         "owner": "blue",
-        "hp": 15,
-        "fuel": 51,
+        "hp": 100,
+        "fuel": 99,
         "ammo": 0,
         "action": "ready",
         "concealment": "exposed",
         "location": { "type": "board", "position": [2, 0] }
-      },
-      {
-        "id": 3,
-        "kind": "infantry",
-        "owner": "blue",
-        "hp": 50,
-        "fuel": 77,
-        "ammo": 0,
-        "action": "spent",
-        "concealment": "exposed",
-        "location": { "type": "cargo", "transport": 2, "slot": 0 }
       }
     ],
     "match": { "status": "active", "draw_offers": [] }
   },
   "steps": [
     {
-      "id": "activate-typhoon",
-      "command": { "type": "activate-power", "player": "red", "level": "scop" },
-      "random": [],
+      "id": "lethal-strike-resets-capture-before-removal",
+      "command": {
+        "type": "move-attack",
+        "player": "red",
+        "unit": 0,
+        "path": [[0, 0]],
+        "target": { "type": "unit", "unit": 1 }
+      },
+      "random": [
+        { "type": "combat-good-luck", "value": 0 },
+        { "type": "combat-bad-luck", "value": 0 }
+      ],
       "expect": {
         "status": "accepted",
         "state": {
@@ -127,7 +123,7 @@
             "fog": false,
             "income_per_property": 1000,
             "starting_funds": 0,
-            "powers": "enabled",
+            "powers": "disabled",
             "tags": false,
             "weather": "clear",
             "lab_units": [],
@@ -140,7 +136,13 @@
           "board": {
             "width": 3,
             "height": 1,
-            "tiles": [[{ "terrain": "plain" }, { "terrain": "plain" }, { "terrain": "plain" }]]
+            "tiles": [
+              [
+                { "terrain": "plain" },
+                { "terrain": "city", "owner": null, "capture_points": 20 },
+                { "terrain": "plain" }
+              ]
+            ]
           },
           "teams": [
             { "id": "red-team", "status": "active" },
@@ -149,14 +151,6 @@
           "players": [
             {
               "id": "red",
-              "team": "red-team",
-              "funds": 0,
-              "status": "active",
-              "commanders": [{ "id": "drake", "active": true, "power_charge": 0, "power_uses": 1 }],
-              "power_state": { "type": "scop", "commander_slot": 0 }
-            },
-            {
-              "id": "ally",
               "team": "red-team",
               "funds": 0,
               "status": "active",
@@ -180,10 +174,10 @@
             "day": 1,
             "active_player": "red",
             "phase": "unit-action",
-            "order": ["red", "ally", "blue"],
+            "order": ["red", "blue"],
             "position": 0
           },
-          "weather": { "kind": "rain", "remaining_turns": 3 },
+          "weather": { "kind": "clear", "remaining_turns": 0 },
           "units": [
             {
               "id": 0,
@@ -192,73 +186,49 @@
               "hp": 100,
               "fuel": 99,
               "ammo": 0,
-              "action": "ready",
+              "action": "spent",
               "concealment": "exposed",
               "location": { "type": "board", "position": [0, 0] }
             },
             {
-              "id": 1,
-              "kind": "infantry",
-              "owner": "ally",
-              "hp": 50,
-              "fuel": 77,
-              "ammo": 0,
-              "action": "ready",
-              "concealment": "exposed",
-              "location": { "type": "board", "position": [1, 0] }
-            },
-            {
               "id": 2,
-              "kind": "apc",
+              "kind": "infantry",
               "owner": "blue",
-              "hp": 1,
-              "fuel": 26,
+              "hp": 100,
+              "fuel": 99,
               "ammo": 0,
               "action": "ready",
               "concealment": "exposed",
               "location": { "type": "board", "position": [2, 0] }
-            },
-            {
-              "id": 3,
-              "kind": "infantry",
-              "owner": "blue",
-              "hp": 50,
-              "fuel": 77,
-              "ammo": 0,
-              "action": "spent",
-              "concealment": "exposed",
-              "location": { "type": "cargo", "transport": 2, "slot": 0 }
             }
           ],
           "match": { "status": "active", "draw_offers": [] }
         },
         "events": [
-          { "type": "power-activated", "player": "red", "commander": "drake", "power": "scop" },
           {
-            "type": "unit-resourced",
-            "unit": 2,
-            "fuel_before": 51,
-            "fuel_after": 26,
-            "ammo_before": 0,
-            "ammo_after": 0,
-            "reason": "commander-power"
+            "type": "attack-resolved",
+            "attacker": 0,
+            "weapon": "unlimited",
+            "target": { "type": "unit", "unit": 1 }
           },
           {
             "type": "unit-damaged",
-            "unit": 2,
-            "from_hp": 15,
-            "to_hp": 1,
-            "reason": "commander-power"
+            "unit": 1,
+            "from_hp": 30,
+            "to_hp": 0,
+            "reason": "combat"
           },
+          { "type": "capture-changed", "position": [1, 0], "from": 10, "to": 20 },
+          { "type": "unit-removed", "unit": 1, "reason": "combat" },
           {
-            "type": "weather-changed",
-            "from": "snow",
-            "to": "rain",
-            "remaining_turns": 3,
-            "reason": "commander-power"
+            "type": "unit-action-changed",
+            "unit": 0,
+            "from": "ready",
+            "to": "spent",
+            "reason": "attack"
           }
         ],
-        "random_consumed": 0
+        "random_consumed": 2
       }
     }
   ]

--- a/spec/fixtures/commander/hawke-cop.json
+++ b/spec/fixtures/commander/hawke-cop.json
@@ -7,7 +7,8 @@
   },
   "feature": "commander-power-v1.hawke.cop",
   "evidence": {
-    "confidence": "corroborated-implementation"
+    "confidence": "confirmed-replay",
+    "note": "Archived AWBW replay 1468032 actions 1120/1179 and 1904/1912 show loaded cargo is excluded from Black Wave damage."
   },
   "initial_state": {
     "ruleset": {
@@ -193,10 +194,10 @@
       },
       {
         "id": 4,
-        "kind": "infantry",
+        "kind": "apc",
         "owner": "blue",
         "hp": 5,
-        "fuel": 99,
+        "fuel": 70,
         "ammo": 0,
         "action": "ready",
         "concealment": "exposed",
@@ -231,6 +232,21 @@
         "location": {
           "type": "board",
           "position": [6, 0]
+        }
+      },
+      {
+        "id": 7,
+        "kind": "infantry",
+        "owner": "blue",
+        "hp": 55,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "spent",
+        "concealment": "exposed",
+        "location": {
+          "type": "cargo",
+          "transport": 4,
+          "slot": 0
         }
       }
     ],
@@ -435,10 +451,10 @@
             },
             {
               "id": 4,
-              "kind": "infantry",
+              "kind": "apc",
               "owner": "blue",
               "hp": 1,
-              "fuel": 99,
+              "fuel": 70,
               "ammo": 0,
               "action": "ready",
               "concealment": "exposed",
@@ -473,6 +489,21 @@
               "location": {
                 "type": "board",
                 "position": [6, 0]
+              }
+            },
+            {
+              "id": 7,
+              "kind": "infantry",
+              "owner": "blue",
+              "hp": 55,
+              "fuel": 99,
+              "ammo": 0,
+              "action": "spent",
+              "concealment": "exposed",
+              "location": {
+                "type": "cargo",
+                "transport": 4,
+                "slot": 0
               }
             }
           ],

--- a/spec/fixtures/commander/jess-cop.json
+++ b/spec/fixtures/commander/jess-cop.json
@@ -7,7 +7,8 @@
   },
   "feature": "commander-power-v1.jess.cop",
   "evidence": {
-    "confidence": "corroborated-implementation"
+    "confidence": "confirmed-replay",
+    "note": "Landfall replay actions 1909/1912 and 4322/4346 show Turbo Charge resupplying loaded cargo even though the Power recipient rows omit it."
   },
   "initial_state": {
     "ruleset": {
@@ -139,7 +140,7 @@
       },
       {
         "id": 2,
-        "kind": "infantry",
+        "kind": "apc",
         "owner": "red",
         "hp": 100,
         "fuel": 50,
@@ -163,6 +164,21 @@
         "location": {
           "type": "board",
           "position": [2, 0]
+        }
+      },
+      {
+        "id": 4,
+        "kind": "infantry",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 50,
+        "ammo": 0,
+        "action": "spent",
+        "concealment": "exposed",
+        "location": {
+          "type": "cargo",
+          "transport": 2,
+          "slot": 0
         }
       }
     ],
@@ -315,10 +331,10 @@
               "action": "spent",
               "ammo": 0,
               "concealment": "exposed",
-              "fuel": 99,
+              "fuel": 70,
               "hp": 100,
               "id": 2,
-              "kind": "infantry",
+              "kind": "apc",
               "location": {
                 "position": [1, 0],
                 "type": "board"
@@ -336,6 +352,21 @@
               "location": {
                 "position": [2, 0],
                 "type": "board"
+              },
+              "owner": "red"
+            },
+            {
+              "action": "spent",
+              "ammo": 0,
+              "concealment": "exposed",
+              "fuel": 99,
+              "hp": 100,
+              "id": 4,
+              "kind": "infantry",
+              "location": {
+                "slot": 0,
+                "transport": 2,
+                "type": "cargo"
               },
               "owner": "red"
             }
@@ -364,11 +395,20 @@
           {
             "ammo_after": 0,
             "ammo_before": 0,
-            "fuel_after": 99,
+            "fuel_after": 70,
             "fuel_before": 50,
             "reason": "commander-power",
             "type": "unit-resourced",
             "unit": 2
+          },
+          {
+            "ammo_after": 0,
+            "ammo_before": 0,
+            "fuel_after": 99,
+            "fuel_before": 50,
+            "reason": "commander-power",
+            "type": "unit-resourced",
+            "unit": 4
           }
         ],
         "random_consumed": 0

--- a/spec/fixtures/commander/jess-scop.json
+++ b/spec/fixtures/commander/jess-scop.json
@@ -7,7 +7,8 @@
   },
   "feature": "commander-power-v1.jess.scop",
   "evidence": {
-    "confidence": "corroborated-implementation"
+    "confidence": "confirmed-experiment",
+    "note": "Loaded cargo receives Overdrive resupply."
   },
   "initial_state": {
     "ruleset": {
@@ -147,8 +148,9 @@
         "action": "spent",
         "concealment": "exposed",
         "location": {
-          "type": "board",
-          "position": [1, 0]
+          "type": "cargo",
+          "transport": 4,
+          "slot": 0
         }
       },
       {
@@ -163,6 +165,20 @@
         "location": {
           "type": "board",
           "position": [2, 0]
+        }
+      },
+      {
+        "id": 4,
+        "kind": "apc",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 50,
+        "ammo": 0,
+        "action": "spent",
+        "concealment": "exposed",
+        "location": {
+          "type": "board",
+          "position": [1, 0]
         }
       }
     ],
@@ -320,8 +336,9 @@
               "id": 2,
               "kind": "infantry",
               "location": {
-                "position": [1, 0],
-                "type": "board"
+                "slot": 0,
+                "transport": 4,
+                "type": "cargo"
               },
               "owner": "red"
             },
@@ -335,6 +352,20 @@
               "kind": "b-copter",
               "location": {
                 "position": [2, 0],
+                "type": "board"
+              },
+              "owner": "red"
+            },
+            {
+              "action": "spent",
+              "ammo": 0,
+              "concealment": "exposed",
+              "fuel": 70,
+              "hp": 100,
+              "id": 4,
+              "kind": "apc",
+              "location": {
+                "position": [1, 0],
                 "type": "board"
               },
               "owner": "red"
@@ -369,6 +400,15 @@
             "reason": "commander-power",
             "type": "unit-resourced",
             "unit": 2
+          },
+          {
+            "ammo_after": 0,
+            "ammo_before": 0,
+            "fuel_after": 70,
+            "fuel_before": 50,
+            "reason": "commander-power",
+            "type": "unit-resourced",
+            "unit": 4
           }
         ],
         "random_consumed": 0

--- a/spec/fixtures/movement/allied-intermediate-traversal.json
+++ b/spec/fixtures/movement/allied-intermediate-traversal.json
@@ -1,0 +1,176 @@
+{
+  "id": "allied-intermediate-traversal",
+  "spec_version": "0.1.0",
+  "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+  "feature": "movement-v1.move-wait.plain",
+  "evidence": {
+    "confidence": "confirmed-replay",
+    "note": "Archived AWBW replay 1362397 action 45 crosses an own unit at an intermediate path position."
+  },
+  "initial_state": {
+    "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+    "settings": {
+      "fog": false,
+      "income_per_property": 1000,
+      "starting_funds": 0,
+      "powers": "disabled",
+      "tags": false,
+      "weather": "clear",
+      "lab_units": [],
+      "unit_bans": [],
+      "commander_bans": { "lead": [], "backup": [] },
+      "capture_limit": null,
+      "day_limit": null,
+      "unit_limit": null
+    },
+    "board": {
+      "width": 3,
+      "height": 1,
+      "tiles": [[{ "terrain": "plain" }, { "terrain": "plain" }, { "terrain": "plain" }]]
+    },
+    "teams": [{ "id": "red-team", "status": "active" }],
+    "players": [
+      {
+        "id": "red",
+        "team": "red-team",
+        "funds": 0,
+        "status": "active",
+        "commanders": [{ "id": "nell", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "power_state": { "type": "none" }
+      }
+    ],
+    "turn": {
+      "day": 1,
+      "active_player": "red",
+      "phase": "unit-action",
+      "order": ["red"],
+      "position": 0
+    },
+    "weather": { "kind": "clear", "remaining_turns": 0 },
+    "units": [
+      {
+        "id": 0,
+        "kind": "infantry",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [0, 0] }
+      },
+      {
+        "id": 1,
+        "kind": "infantry",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [1, 0] }
+      }
+    ],
+    "match": { "status": "active", "draw_offers": [] }
+  },
+  "steps": [
+    {
+      "id": "move-through-allied-unit-and-wait",
+      "command": {
+        "type": "move-wait",
+        "player": "red",
+        "unit": 0,
+        "path": [
+          [0, 0],
+          [1, 0],
+          [2, 0]
+        ]
+      },
+      "random": [],
+      "expect": {
+        "status": "accepted",
+        "state": {
+          "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+          "settings": {
+            "fog": false,
+            "income_per_property": 1000,
+            "starting_funds": 0,
+            "powers": "disabled",
+            "tags": false,
+            "weather": "clear",
+            "lab_units": [],
+            "unit_bans": [],
+            "commander_bans": { "lead": [], "backup": [] },
+            "capture_limit": null,
+            "day_limit": null,
+            "unit_limit": null
+          },
+          "board": {
+            "width": 3,
+            "height": 1,
+            "tiles": [[{ "terrain": "plain" }, { "terrain": "plain" }, { "terrain": "plain" }]]
+          },
+          "teams": [{ "id": "red-team", "status": "active" }],
+          "players": [
+            {
+              "id": "red",
+              "team": "red-team",
+              "funds": 0,
+              "status": "active",
+              "commanders": [{ "id": "nell", "active": true, "power_charge": 0, "power_uses": 0 }],
+              "power_state": { "type": "none" }
+            }
+          ],
+          "turn": {
+            "day": 1,
+            "active_player": "red",
+            "phase": "unit-action",
+            "order": ["red"],
+            "position": 0
+          },
+          "weather": { "kind": "clear", "remaining_turns": 0 },
+          "units": [
+            {
+              "id": 0,
+              "kind": "infantry",
+              "owner": "red",
+              "hp": 100,
+              "fuel": 97,
+              "ammo": 0,
+              "action": "spent",
+              "concealment": "exposed",
+              "location": { "type": "board", "position": [2, 0] }
+            },
+            {
+              "id": 1,
+              "kind": "infantry",
+              "owner": "red",
+              "hp": 100,
+              "fuel": 99,
+              "ammo": 0,
+              "action": "ready",
+              "concealment": "exposed",
+              "location": { "type": "board", "position": [1, 0] }
+            }
+          ],
+          "match": { "status": "active", "draw_offers": [] }
+        },
+        "events": [
+          {
+            "type": "unit-moved",
+            "unit": 0,
+            "from": [0, 0],
+            "to": [2, 0],
+            "path": [
+              [0, 0],
+              [1, 0],
+              [2, 0]
+            ],
+            "fuel_spent": 2
+          }
+        ],
+        "random_consumed": 0
+      }
+    }
+  ]
+}

--- a/spec/semantics/combat.md
+++ b/spec/semantics/combat.md
@@ -42,6 +42,11 @@ Zero HP is an event value, not a state value. A lethal strike emits
 `unit-damaged` with `to_hp: 0`, performs any capture reset, and removes the unit
 before the complete post-state is exposed.
 
+If the removed unit is a transport carrying cargo, remove the transport first,
+then remove its cargo in ascending slot order with reason `carrier-lost`.
+Those cargo removals are consequences of losing the carrier, not additional
+strikes: they emit no `unit-damaged` event and add no combat power charge.
+
 For every executed strike consume one token of type `combat-good-luck`, then
 one token of type `combat-bad-luck`. A token value MUST lie in the applicable
 inclusive domain and is the resulting `G` or `L`; no scaling is performed.
@@ -56,7 +61,8 @@ when that strike begins.
 
 For this slice events are ordered: movement events (when the path changes
 position), attacker resource change if ammo was spent, `attack-resolved`,
-defender `unit-damaged`, then defender removal if lethal.
+defender `unit-damaged`, then defender removal and any `carrier-lost` cargo
+removals if lethal.
 For a counter, append its resource change, `attack-resolved`, attacker damage,
 and attacker removal in the same order. Finally emit the acting unit's
 `unit-action-changed`. Capture reset caused by damage follows

--- a/spec/semantics/movement.md
+++ b/spec/semantics/movement.md
@@ -71,13 +71,14 @@ transport's tile independently. The acting unit is ignored at `p_0`.
 
 For `move-wait`:
 
-- a visible enemy or allied unit on any `p_i`, `i > 0`, blocks the path;
-- an occupied intermediate position produces `PATH_OCCUPIED`;
+- an allied unit may be crossed at an intermediate position but may not be the
+  intended destination;
+- a disclosed enemy unit on any `p_i`, `i > 0`, blocks the path;
+- an enemy-occupied intermediate position produces `PATH_OCCUPIED`;
 - an occupied intended destination produces `DESTINATION_OCCUPIED`;
 - a hidden enemy obstruction under fog is not a validation failure and is
   handled by the trap execution below; and
-- a hidden allied unit is known through shared allied vision and is therefore
-  treated as a disclosed obstruction, not a trap.
+- an allied unit is known through shared allied vision and is never a trap.
 
 “Allied” means owned by any player on the actor's team. Join and load commands
 may license their declared destination occupant, but never an intermediate
@@ -116,9 +117,10 @@ completed over the path before the next category begins. Thus a later
 out-of-bounds position does not outrank an earlier non-adjacent step, and an
 impassable tile does not outrank any out-of-bounds position.
 
-`PATH_OCCUPIED` scans `p_1` through `p_(k-1)`. Destination occupancy is deferred
-until after family-specific checks because load/join may license it. For
-`move-wait`, the family-specific list is empty.
+`PATH_OCCUPIED` scans `p_1` through `p_(k-1)` for disclosed enemy occupancy;
+allied occupancy does not stop intermediate traversal. Destination occupancy
+is deferred until after family-specific checks because load/join may license
+it. For `move-wait`, the family-specific list is empty.
 
 Movement and fuel compare the intended full-path cost against the effective
 allowance and current fuel. Equality is legal. A one-position path is legal at
@@ -238,6 +240,8 @@ Documentation-only:
 - AWBW official terrain chart: the profile's weather/class/terrain costs.
 - AWBW Wiki “Units”: fuel spent equals movement points spent, including terrain
   and weather modifiers.
+- Archived AWBW replay `1362397`, action 45: a T-Copter's submitted path
+  crosses its own Infantry at intermediate position `[13,7]`.
 - AWBW Wiki “Fog of War”: a hidden enemy interrupts movement at first contact
   and the trapped unit loses all remaining actions.
 - AWBW Wiki “AWBW Guide”: manually selected paths must fit movement and may not

--- a/spec/semantics/powers.md
+++ b/spec/semantics/powers.md
@@ -126,9 +126,10 @@ use-counter changes; no separate public meter event is emitted.
 { "operator": "heal-visual-hp", "target": "owned-units", "amount": 2 }
 ```
 
-`owned-units` selects every living unit whose owner is the activating player,
-including cargo, and orders the selection by ascending unit ID. For each
-selected unit independently:
+`owned-units` selects every living **on-board** unit whose owner is the
+activating player and orders the selection by ascending unit ID. Cargo is
+excluded because a loaded unit is not present on the map. For each selected
+unit independently:
 
 ```text
 from = exact HP before this effect
@@ -149,7 +150,7 @@ fact. The operator never changes fuel, ammo, funds, action state, or location.
 { "operator": "heal-exact-hp", "target": "owned-units", "amount": 10 }
 ```
 
-`owned-units` has the same ownership, cargo inclusion, and ascending unit-ID
+`owned-units` has the same ownership, board-location requirement and ascending unit-ID
 ordering as `heal-visual-hp`. For each selected unit independently:
 
 ```text
@@ -174,8 +175,9 @@ Hawke's COP uses `amount: 10`, and his SCOP uses `amount: 20`.
 ```
 
 Let the activating player's team be `T`. `enemy-units` selects every living
-unit, including cargo, whose owner's team is not `T`; units owned by another
-player on `T` are not enemies. The selection is ordered by ascending unit ID.
+on-board unit whose owner's team is not `T`; units owned by another player on
+`T` are not enemies. Cargo is excluded. The selection is ordered by ascending
+unit ID.
 `enemy-units-on-properties` instead selects only such enemy units with a board
 location whose terrain has the ruleset `capturable` trait. Property ownership
 is irrelevant; cargo and units on other terrain are excluded. The filtered
@@ -211,7 +213,7 @@ or location.
 }
 ```
 
-`enemy-units` uses the same enemy-team selection, cargo inclusion, and
+`enemy-units` uses the same enemy-team selection, board-location requirement, and
 ascending unit-ID ordering as `damage-exact-hp`. For each selected unit:
 
 ```text
@@ -532,10 +534,11 @@ cost nor any power charge. Funds overflow is an invalid state.
 }
 ```
 
-`owned-units` starts with every living unit owned by the activating player.
-The revisioned `exclude_unit_kinds` predicate then removes matching kinds, and
-the remaining selection is ordered by ascending unit ID. For each selected
-unit whose action is `spent`, set its action to `ready` and emit
+`owned-units` starts with every living on-board unit owned by the activating
+player; cargo is excluded. The revisioned `exclude_unit_kinds` predicate then
+removes matching kinds, and the remaining selection is ordered by ascending
+unit ID. For each selected unit whose action is `spent`, set its action to
+`ready` and emit
 `unit-action-changed { unit, from: "spent", to: "ready", reason:
 "commander-power" }`.
 
@@ -552,10 +555,12 @@ same turn.
 { "operator": "resupply-units", "target": "owned-units" }
 ```
 
-`owned-units` selects every living unit owned by the activating player,
-including cargo, and orders the selection by ascending unit ID. Each selected
-unit's fuel and ammo are independently set to the revisioned maxima in
-`units.json`. When either value changes, emit:
+For this operator, `owned-units` selects every living unit owned by the
+activating player, including loaded cargo, and orders the selection by
+ascending unit ID. This is a resupply-specific exception to the board-only
+selection used by direct HP, fuel-drain, and action-refresh power effects.
+Each selected unit's fuel and ammo are independently set to the revisioned
+maxima in `units.json`. When either value changes, emit:
 
 ```text
 unit-resourced {
@@ -569,6 +574,9 @@ unit-resourced {
 A unit already at both maxima emits no event. A unit kind with maximum ammo
 zero may still emit when its fuel changes, with both ammo fields zero. The
 operator does not alter HP, action state, concealment, location, or funds.
+AWBW's archived Power payload omits loaded cargo from its recipient rows even
+though Jess's Turbo Charge and Overdrive update the cargo's internal fuel and
+ammo; a later Unload exposes the resupplied values.
 
 ## `spawn-units-on-owned-properties`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Allied units can now be crossed during movement but cannot be selected as destinations.
  - Destroyed transports now correctly remove carried units and reset capture progress when applicable.
  - Commander effects consistently exclude cargo from healing, damage, fuel drain, and action refresh.
  - Combat power charges no longer incorrectly include cargo lost with a destroyed transport.

- **Documentation**
  - Clarified movement, combat-removal, and commander-power rules, including cargo behavior.

- **Tests**
  - Added coverage for allied traversal, transport losses, lethal capture resets, and cargo-related commander effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->