### PR TITLE
Fixup some assets with backgrounds

### DIFF
--- a/crates/awbrn-client/src/projection/mod.rs
+++ b/crates/awbrn-client/src/projection/mod.rs
@@ -52,6 +52,8 @@ pub(crate) struct UnitProjectionResources<'w> {
     visibility: Res<'w, ViewerVisibility>,
     player_roster: Option<Res<'w, PlayerRosterConfig>>,
     display_faction_overrides: Option<Res<'w, PlayerDisplayFactionOverrides>>,
+    registry: Option<Res<'w, ReplayPlayerRegistry>>,
+    replay_state: Option<Res<'w, ReplayState>>,
 }
 
 #[derive(SystemParam)]
@@ -107,6 +109,32 @@ fn current_knowledge_key(
             .active_player_id
             .and_then(|id| registry.knowledge_key_for_player(id)),
         ReplayViewpoint::Player(id) => registry.knowledge_key_for_player(*id),
+    }
+}
+
+/// The faction whose turn it is, if the presentation knows one.
+fn active_faction(
+    replay_state: Option<&ReplayState>,
+    registry: Option<&ReplayPlayerRegistry>,
+) -> Option<awbrn_types::PlayerFaction> {
+    let player = replay_state?.active_player_id?;
+    registry?.faction_for_player(player)
+}
+
+/// Whether a unit is drawn ready rather than greyed out.
+///
+/// Only the player whose turn it is can spend units, so a waiting unit of any
+/// other player says nothing to the viewer. AWBW greys out the current
+/// player's spent units alone, and the presentation follows it. Without a
+/// known active faction every unit falls back to its own `UnitActive`.
+fn unit_is_active(
+    is_active: bool,
+    faction: Faction,
+    active_faction: Option<awbrn_types::PlayerFaction>,
+) -> bool {
+    match active_faction {
+        Some(active) => is_active || faction.0 != active,
+        None => is_active,
     }
 }
 
@@ -202,6 +230,11 @@ pub(crate) fn project_unit_render_state(
     resources: UnitProjectionResources,
     units: Query<UnitProjectionItem<'_>, With<Unit>>,
 ) {
+    let active_faction = active_faction(
+        resources.replay_state.as_deref(),
+        resources.registry.as_deref(),
+    );
+
     for (
         entity,
         unit,
@@ -229,7 +262,7 @@ pub(crate) fn project_unit_render_state(
             unit: *unit,
             faction: Faction(display_faction),
             visible: unit_visible_to_viewer(&resources, unit_id, is_carried),
-            active: is_active,
+            active: unit_is_active(is_active, *faction, active_faction),
             overlays: ProjectedUnitOverlayFlags {
                 health: projected_health(hp),
                 capturing: is_capturing,
@@ -414,5 +447,63 @@ mod tests {
             .collect::<Vec<_>>();
         drawn.sort_unstable();
         assert_eq!(drawn, vec![seen]);
+    }
+
+    /// Only the current player has spent units to grey out.
+    #[test]
+    fn a_waiting_unit_of_another_player_is_still_drawn_ready() {
+        let current = AwbwGamePlayerId::new(1);
+        let other = AwbwGamePlayerId::new(2);
+
+        let mut app = App::new();
+        app.add_plugins(GameWorldPlugin);
+        app.add_systems(Update, project_unit_render_state);
+
+        let mut registry = ReplayPlayerRegistry::default();
+        registry.add_player(current, PlayerFaction::OrangeStar, 0);
+        registry.add_player(other, PlayerFaction::BlueMoon, 0);
+        app.world_mut().insert_resource(registry);
+        app.world_mut().insert_resource(ReplayState {
+            active_player_id: Some(current),
+            ..ReplayState::default()
+        });
+
+        // Neither unit can act: one has spent its turn, the other is waiting
+        // for a turn it does not have yet.
+        let spent = app
+            .world_mut()
+            .spawn((
+                Unit(awbrn_types::Unit::Infantry),
+                Faction(PlayerFaction::OrangeStar),
+                MapPosition::new(0, 0),
+            ))
+            .id();
+        let waiting = app
+            .world_mut()
+            .spawn((
+                Unit(awbrn_types::Unit::Infantry),
+                Faction(PlayerFaction::BlueMoon),
+                MapPosition::new(1, 0),
+            ))
+            .id();
+
+        app.update();
+
+        assert!(
+            !app.world()
+                .entity(spent)
+                .get::<ProjectedUnitRenderState>()
+                .unwrap()
+                .active,
+            "the current player's spent unit is greyed out"
+        );
+        assert!(
+            app.world()
+                .entity(waiting)
+                .get::<ProjectedUnitRenderState>()
+                .unwrap()
+                .active,
+            "another player's unit is drawn ready"
+        );
     }
 }

--- a/crates/awbrn-client/src/render/units.rs
+++ b/crates/awbrn-client/src/render/units.rs
@@ -334,11 +334,10 @@ pub(crate) fn handle_unit_spawn(
     trigger: On<Insert, Unit>,
     mut commands: Commands,
     unit_atlas: Res<UnitAtlasResource>,
-    mut query: Query<(&Unit, &Faction, Has<UnitActive>)>,
+    query: Query<(&Unit, &Faction, Has<UnitActive>), Without<Sprite>>,
 ) {
     let entity = trigger.entity;
-    let Ok((unit, faction, has_active)) = query.get_mut(entity) else {
-        warn!("Unit entity {:?} not found in query", entity);
+    let Ok((unit, faction, has_active)) = query.get(entity) else {
         return;
     };
 
@@ -537,6 +536,45 @@ mod tests {
         assert_eq!(animation.start_index, expected.start_index());
         assert_eq!(animation.frame_durations, expected.raw());
         assert_eq!(animation.current_frame, 0);
+    }
+
+    /// Transition sync rewrites `Unit` on every action.
+    ///
+    /// The spawn observer must not treat that as a new unit: it would restart
+    /// the idle animation and hide a unit whose projected state has not
+    /// changed, which leaves every unit but the ones that acted invisible.
+    #[test]
+    fn rewriting_unit_keeps_the_sprite_and_the_visibility() {
+        let mut app = unit_render_test_app();
+        let entity = spawn_test_unit(&mut app, PlayerFaction::GreenEarth, true);
+
+        app.update();
+        let frame = 3;
+        app.world_mut()
+            .entity_mut(entity)
+            .get_mut::<Animation>()
+            .unwrap()
+            .current_frame = frame;
+
+        app.world_mut()
+            .entity_mut(entity)
+            .insert(Unit(awbrn_types::Unit::Infantry));
+        app.update();
+
+        assert_eq!(
+            app.world().entity(entity).get::<Visibility>(),
+            Some(&Visibility::Inherited),
+            "a rewritten unit stays visible"
+        );
+        assert_eq!(
+            app.world()
+                .entity(entity)
+                .get::<Animation>()
+                .unwrap()
+                .current_frame,
+            frame,
+            "a rewritten unit keeps its idle animation"
+        );
     }
 
     #[test]

--- a/crates/xtask-assets/src/main.rs
+++ b/crates/xtask-assets/src/main.rs
@@ -715,7 +715,14 @@ fn run_tiles() -> Result<()> {
     all_frames.extend(snow_frames);
     all_frames.extend(rain_frames);
 
-    let _tilesheet = build_spritesheet(&all_frames, &tilesheet_path, TILESHEET_COLUMNS, 0)?;
+    // Terrain fills its own frame, so an opaque border is correct here.
+    let _tilesheet = build_spritesheet(
+        &all_frames,
+        &tilesheet_path,
+        TILESHEET_COLUMNS,
+        0,
+        SpriteRepair::None,
+    )?;
     optimize_png(&tilesheet_path)?;
 
     let tilesheet_rows = (all_frames.len() as u32).div_ceil(TILESHEET_COLUMNS);
@@ -759,6 +766,7 @@ fn run_units() -> Result<()> {
         &unitsheet_path,
         UNITSHEET_COLUMNS,
         UNIT_SPRITESHEET_BLEED,
+        SpriteRepair::FlattenedBackground,
     )?;
     optimize_png(&unitsheet_path)?;
 
@@ -811,7 +819,7 @@ fn run_logos() -> Result<()> {
     // Checked-in source logos were downloaded from:
     // https://awbw.amarriner.com/terrain/aw2/{code}logo.gif
     let paths = collect_logo_paths(&countries, &logos_root)?;
-    let spritesheet = build_spritesheet(&paths, &sheet_path, LOGO_COLUMNS, 0)?;
+    let spritesheet = build_spritesheet(&paths, &sheet_path, LOGO_COLUMNS, 0, SpriteRepair::None)?;
     validate_logo_dimensions(spritesheet)?;
     optimize_png(&sheet_path)?;
 
@@ -849,7 +857,13 @@ fn run_co_portraits() -> Result<()> {
         .iter()
         .map(|portrait| portrait.image_path.clone())
         .collect::<Vec<_>>();
-    let spritesheet = build_spritesheet(&paths, &sheet_path, CO_PORTRAIT_COLUMNS, 0)?;
+    let spritesheet = build_spritesheet(
+        &paths,
+        &sheet_path,
+        CO_PORTRAIT_COLUMNS,
+        0,
+        SpriteRepair::None,
+    )?;
     optimize_png(&sheet_path)?;
 
     let co_portrait_data = build_co_portrait_data(&portraits, spritesheet)?;
@@ -1881,13 +1895,17 @@ fn build_spritesheet(
     output_path: &Path,
     columns: u32,
     bleed: u32,
+    repair: SpriteRepair,
 ) -> Result<SpritesheetBuild> {
     let mut images = Vec::new();
     let mut max_width = 0;
     let mut max_height = 0;
 
     for path in paths {
-        let rgba = load_rgba_image(path)?;
+        let mut rgba = load_rgba_image(path)?;
+        if repair == SpriteRepair::FlattenedBackground {
+            repair_flattened_background(&mut rgba);
+        }
         let (width, height) = rgba.dimensions();
         max_width = max_width.max(width);
         max_height = max_height.max(height);
@@ -2009,6 +2027,74 @@ fn validate_logo_dimensions(spritesheet: SpritesheetBuild) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Whether a source frame is packed as authored or repaired first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpriteRepair {
+    /// Pack the frame exactly as it is.
+    None,
+    /// Give back the transparency a flattened frame lost.
+    FlattenedBackground,
+}
+
+/// Remove the background a unit frame was flattened onto.
+///
+/// Some upstream unit frames arrive with no transparency: the art sits in a
+/// solid block of background colour, which draws as a box around the unit. A
+/// unit frame never fills its own frame, so a fully opaque border identifies
+/// these frames and nothing else — as of AWBW-Replay-Player v0.13.1 it selects
+/// the 47 damaged Silver Claw frames and the three damaged Bomber frames,
+/// leaving the other 5698 frames untouched.
+///
+/// Only background colour that touches the border is removed. An enclosed
+/// pixel of the same colour is part of the art — a cockpit window, a hull
+/// highlight — and stays. Terrain does fill its frame, which is why this is a
+/// unit-frame repair.
+fn repair_flattened_background(image: &mut RgbaImage) -> bool {
+    let (width, height) = image.dimensions();
+    if width == 0 || height == 0 || !border_is_opaque(image) {
+        return false;
+    }
+
+    let background = *image.get_pixel(0, 0);
+    let mut pending = border_positions(width, height)
+        .filter(|(x, y)| *image.get_pixel(*x, *y) == background)
+        .collect::<Vec<_>>();
+
+    // Clearing a pixel also marks it as visited: the cleared alpha can no
+    // longer equal the opaque background colour.
+    while let Some((x, y)) = pending.pop() {
+        if *image.get_pixel(x, y) != background {
+            continue;
+        }
+        image.put_pixel(x, y, image::Rgba([0, 0, 0, 0]));
+
+        pending.extend(
+            [
+                (x.checked_sub(1), Some(y)),
+                (Some(x + 1), Some(y)),
+                (Some(x), y.checked_sub(1)),
+                (Some(x), Some(y + 1)),
+            ]
+            .into_iter()
+            .filter_map(|(x, y)| Some((x?, y?)))
+            .filter(|(x, y)| *x < width && *y < height),
+        );
+    }
+
+    true
+}
+
+fn border_is_opaque(image: &RgbaImage) -> bool {
+    let (width, height) = image.dimensions();
+    border_positions(width, height).all(|(x, y)| image.get_pixel(x, y).0[3] == u8::MAX)
+}
+
+fn border_positions(width: u32, height: u32) -> impl Iterator<Item = (u32, u32)> {
+    let rows = (0..width).flat_map(move |x| [(x, 0), (x, height - 1)]);
+    let columns = (0..height).flat_map(move |y| [(0, y), (width - 1, y)]);
+    rows.chain(columns)
 }
 
 fn extrude_rect(sheet: &mut RgbaImage, x: u32, y: u32, width: u32, height: u32, bleed: u32) {
@@ -2378,4 +2464,76 @@ fn render_terrain_animation_data(tiles: &[TileMetadata]) -> String {
     output.push_str("        _ => None,\n");
     output.push_str("    }\n}\n");
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::Rgba;
+
+    const CLEAR: Rgba<u8> = Rgba([0, 0, 0, 0]);
+    const WHITE: Rgba<u8> = Rgba([255, 255, 255, 255]);
+    const BODY: Rgba<u8> = Rgba([40, 60, 90, 255]);
+
+    /// A flattened frame keeps its art and loses only its background.
+    #[test]
+    fn repairing_a_flattened_frame_spares_an_enclosed_pixel() {
+        // A ring of body colour around one white pixel, in a white block. The
+        // enclosed white is a highlight; the rest is background.
+        let mut image = RgbaImage::from_pixel(5, 5, WHITE);
+        for x in 1..4 {
+            for y in 1..4 {
+                image.put_pixel(x, y, BODY);
+            }
+        }
+        image.put_pixel(2, 2, WHITE);
+
+        assert!(repair_flattened_background(&mut image));
+
+        assert_eq!(*image.get_pixel(0, 0), CLEAR, "the border is background");
+        assert_eq!(*image.get_pixel(4, 4), CLEAR, "the border is background");
+        assert_eq!(*image.get_pixel(1, 1), BODY, "the art is kept");
+        assert_eq!(
+            *image.get_pixel(2, 2),
+            WHITE,
+            "an enclosed background colour is art, not background"
+        );
+    }
+
+    /// Background colour reaches the border through a gap in the art.
+    #[test]
+    fn repairing_a_flattened_frame_follows_a_gap_inward() {
+        let mut image = RgbaImage::from_pixel(3, 3, WHITE);
+        image.put_pixel(0, 1, BODY);
+        image.put_pixel(2, 1, BODY);
+
+        assert!(repair_flattened_background(&mut image));
+
+        assert_eq!(*image.get_pixel(1, 1), CLEAR);
+        assert_eq!(*image.get_pixel(0, 1), BODY);
+    }
+
+    /// A correctly authored frame is identified by its transparent border and
+    /// is never touched.
+    #[test]
+    fn a_frame_with_a_transparent_border_is_left_alone() {
+        let mut image = RgbaImage::from_pixel(3, 3, CLEAR);
+        image.put_pixel(1, 1, WHITE);
+
+        assert!(!repair_flattened_background(&mut image));
+        assert_eq!(*image.get_pixel(1, 1), WHITE, "white art survives");
+    }
+
+    /// The background is whatever colour was flattened in, not white.
+    #[test]
+    fn repairing_a_flattened_frame_reads_the_background_colour_from_the_frame() {
+        let grey = Rgba([176, 184, 200, 255]);
+        let mut image = RgbaImage::from_pixel(3, 3, grey);
+        image.put_pixel(1, 1, WHITE);
+
+        assert!(repair_flattened_background(&mut image));
+
+        assert_eq!(*image.get_pixel(0, 0), CLEAR);
+        assert_eq!(*image.get_pixel(1, 1), WHITE);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unit readiness indicators now correctly reflect the active faction during replays.
  * Rewriting unit data no longer resets visibility or idle animations.
  * Improved unit sprite rendering by removing unwanted border backgrounds while preserving enclosed details.
* **Tests**
  * Added coverage for faction-based readiness, animation preservation, and sprite background repair scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->