### PR TITLE
Implement undo

### DIFF
--- a/crates/awbrn-client/src/modes/replay/bootstrap.rs
+++ b/crates/awbrn-client/src/modes/replay/bootstrap.rs
@@ -8,7 +8,8 @@ use crate::features::player_roster::{
 use crate::loading::LoadedReplay;
 use crate::modes::replay::presentation::{ReplayAdvanceLock, ReplayTransitionSource};
 use awbrn_game::replay::{
-    RecipientObservations, initialize_replay_semantic_world, refresh_viewer_visibility,
+    RecipientObservations, ReplayTerrainKnowledge, initialize_replay_semantic_world,
+    refresh_viewer_visibility,
 };
 
 /// Hand the presentation the projections of the archive's opening state.
@@ -38,6 +39,10 @@ pub fn initialize_replay_semantic_world_for_client(world: &mut World) {
         });
 
     initialize_replay_semantic_world(&replay, world);
+    let initial_terrain_knowledge = world.resource::<ReplayTerrainKnowledge>().clone();
+    if let Some(mut source) = world.get_resource_mut::<ReplayTransitionSource>() {
+        source.set_initial_terrain_knowledge(initial_terrain_knowledge);
+    }
     seed_initial_observations(world);
 
     if let Some((config, funds, unit_costs)) = player_roster_seed_from_replay(&replay) {

--- a/crates/awbrn-client/src/modes/replay/controls.rs
+++ b/crates/awbrn-client/src/modes/replay/controls.rs
@@ -1,6 +1,8 @@
 use crate::loading::LoadedReplay;
 use crate::modes::replay::navigation::action_requires_path_animation;
-use crate::modes::replay::presentation::{ReplayAdvanceLock, ReplayTurnCommand};
+use crate::modes::replay::presentation::{
+    ReplayAdvanceLock, ReplayRewindCommand, ReplayTurnCommand,
+};
 use crate::modes::replay::state::ReplayControlState;
 use awbrn_game::replay::ReplayState;
 use bevy::input::{ButtonState, keyboard::KeyboardInput};
@@ -67,6 +69,16 @@ pub(crate) fn handle_replay_controls(
         }
 
         match event.key_code {
+            KeyCode::ArrowLeft => {
+                if replay_blocked || replay_state.next_action_index == 0 {
+                    continue;
+                }
+
+                commands.queue(ReplayRewindCommand {
+                    target_index: replay_state.next_action_index - 1,
+                });
+                replay_control.suppress_exhausted_repeat = false;
+            }
             KeyCode::ArrowRight => {
                 if replay_blocked {
                     continue;
@@ -135,12 +147,19 @@ pub(crate) fn handle_replay_controls(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::loading::apply_replay_building_overrides;
+    use crate::modes::replay::bootstrap::initialize_replay_semantic_world_for_client;
+    use awbrn_game::GameWorldPlugin;
     use awbrn_game::replay::AwbwUnitId;
-    use awbrn_game::world::StrongIdMap;
+    use awbrn_game::world::{GameMap, StrongIdMap};
+    use awbrn_map::{AwbrnMap, AwbwMap, AwbwMapData};
     use awbrn_types::AwbwGamePlayerId;
     use awbw_replay::AwbwReplay;
+    use awbw_replay::ReplayParser;
     use awbw_replay::turn_models::{Action, PowerAction};
+    use awvm_awbw::RecordedAdapter;
     use bevy::input::keyboard::{Key, NativeKey};
+    use std::path::Path;
 
     #[test]
     fn replay_press_advances_immediately() {
@@ -230,6 +249,75 @@ mod tests {
         assert_eq!(app.world().resource::<ReplayState>().next_action_index, 1);
     }
 
+    #[test]
+    fn replay_left_rewinds_one_action_boundary() {
+        let (mut app, _) = replay_rewind_controls_test_app();
+        app.world_mut()
+            .resource_mut::<ReplayState>()
+            .next_action_index = 2;
+
+        send_key_event(&mut app, KeyCode::ArrowLeft, ButtonState::Pressed, false);
+        app.update();
+
+        assert_eq!(app.world().resource::<ReplayState>().next_action_index, 1);
+    }
+
+    #[test]
+    fn replay_left_stops_at_the_initial_boundary() {
+        let (mut app, _) = replay_rewind_controls_test_app();
+
+        send_key_event(&mut app, KeyCode::ArrowLeft, ButtonState::Pressed, false);
+        app.update();
+
+        assert_eq!(app.world().resource::<ReplayState>().next_action_index, 0);
+    }
+
+    #[test]
+    fn replay_left_repeat_rewinds_one_action_boundary() {
+        let (mut app, _) = replay_rewind_controls_test_app();
+        app.world_mut()
+            .resource_mut::<ReplayState>()
+            .next_action_index = 2;
+
+        send_key_event(&mut app, KeyCode::ArrowLeft, ButtonState::Pressed, true);
+        app.update();
+
+        assert_eq!(app.world().resource::<ReplayState>().next_action_index, 1);
+    }
+
+    #[test]
+    fn replay_left_repeat_is_ignored_while_advance_is_locked() {
+        let (mut app, replay) = replay_rewind_controls_test_app();
+        for action in replay.turns.iter().cloned() {
+            ReplayTurnCommand { action }.apply(app.world_mut());
+            if app.world().resource::<ReplayAdvanceLock>().is_active() {
+                break;
+            }
+        }
+        assert!(app.world().resource::<ReplayAdvanceLock>().is_active());
+        app.world_mut()
+            .resource_mut::<ReplayState>()
+            .next_action_index = 2;
+
+        send_key_event(&mut app, KeyCode::ArrowLeft, ButtonState::Pressed, true);
+        app.update();
+
+        assert_eq!(app.world().resource::<ReplayState>().next_action_index, 2);
+    }
+
+    #[test]
+    fn replay_left_keeps_index_when_rewind_source_is_missing() {
+        let mut app = replay_controls_test_app(3);
+        app.world_mut()
+            .resource_mut::<ReplayState>()
+            .next_action_index = 2;
+
+        send_key_event(&mut app, KeyCode::ArrowLeft, ButtonState::Pressed, false);
+        app.update();
+
+        assert_eq!(app.world().resource::<ReplayState>().next_action_index, 2);
+    }
+
     fn replay_controls_test_app(action_count: usize) -> App {
         replay_controls_test_app_with_actions(vec![test_replay_action(); action_count])
     }
@@ -252,6 +340,46 @@ mod tests {
         app.init_resource::<awbrn_game::replay::ReplayViewpoint>();
         app.init_resource::<awbrn_game::replay::ReplayPlayerRegistry>();
         app
+    }
+
+    fn replay_rewind_controls_test_app() -> (App, AwbwReplay) {
+        let replay_bytes = std::fs::read(replay_fixture_path("1362397.zip")).unwrap();
+        let replay = ReplayParser::new().parse(&replay_bytes).unwrap();
+        let map_data: AwbwMapData =
+            serde_json::from_slice(&std::fs::read(map_fixture_path("162795.json")).unwrap())
+                .unwrap();
+        let adapter = RecordedAdapter::new(&replay, &map_data).unwrap();
+        let mut graphical_map = AwbwMap::try_from(&map_data).unwrap();
+        apply_replay_building_overrides(
+            &mut graphical_map,
+            &replay.games.first().unwrap().buildings,
+        );
+
+        let mut app = App::new();
+        app.add_plugins(GameWorldPlugin);
+        app.add_message::<KeyboardInput>();
+        app.add_systems(Update, handle_replay_controls);
+        app.world_mut()
+            .resource_mut::<GameMap>()
+            .set(AwbrnMap::from_map(&graphical_map));
+        app.insert_resource(LoadedReplay(replay.clone()));
+        app.insert_resource(
+            crate::modes::replay::presentation::ReplayTransitionSource::new(adapter),
+        );
+        initialize_replay_semantic_world_for_client(app.world_mut());
+        (app, replay)
+    }
+
+    fn replay_fixture_path(file_name: &str) -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../assets/replays")
+            .join(file_name)
+    }
+
+    fn map_fixture_path(file_name: &str) -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../assets/maps")
+            .join(file_name)
     }
 
     fn send_key_event(app: &mut App, key_code: KeyCode, state: ButtonState, repeat: bool) {

--- a/crates/awbrn-client/src/modes/replay/presentation.rs
+++ b/crates/awbrn-client/src/modes/replay/presentation.rs
@@ -7,17 +7,18 @@
 use awbw_replay::turn_models::Action;
 use awvm::semantic::{ObservedEvent, ObservedTransition, ObservedUnitRef, PlayerId, Pos};
 use bevy::{log, prelude::*};
+use std::collections::BTreeMap;
 
 use crate::features::event_bus::{EventSink, NewDay as ExternalNewDay};
 use crate::features::player_roster::{
     PlayerFunds, PlayerPowerCharges, PlayerRosterConfig, PlayerUnitCosts, active_power_charge,
-    emit_player_roster_updated,
+    emit_player_roster_updated, player_roster_seed_from_replay,
 };
 use crate::modes::replay::navigation::PendingCourseArrows;
 use crate::render::animation::UnitPathAnimation;
 use awbrn_game::replay::{
-    AwbwUnitId, NewDay, ReplayState, ReplayViewpoint, apply_observed_transition,
-    apply_observed_transitions,
+    AwbwUnitId, NewDay, ReplayState, ReplayTerrainKnowledge, ReplayViewpoint, TransitionApplyError,
+    apply_observed_transition, apply_observed_transitions,
 };
 use awbrn_game::world::{BoardIndex, CarriedBy, StrongIdMap};
 use awbrn_types::UnitExt;
@@ -28,12 +29,25 @@ use awbrn_types::UnitExt;
 /// AWVM command or reconstructs random tokens.
 #[derive(Resource)]
 pub struct ReplayTransitionSource {
+    initial_adapter: awvm_awbw::RecordedAdapter,
     adapter: awvm_awbw::RecordedAdapter,
+    checkpoints: BTreeMap<usize, awvm_awbw::RecordedAdapter>,
+    initial_terrain_knowledge: Option<ReplayTerrainKnowledge>,
 }
 
 impl ReplayTransitionSource {
     pub fn new(adapter: awvm_awbw::RecordedAdapter) -> Self {
-        Self { adapter }
+        let checkpoints = BTreeMap::from([(0, adapter.clone())]);
+        Self {
+            initial_adapter: adapter.clone(),
+            adapter,
+            checkpoints,
+            initial_terrain_knowledge: None,
+        }
+    }
+
+    pub(crate) fn set_initial_terrain_knowledge(&mut self, knowledge: ReplayTerrainKnowledge) {
+        self.initial_terrain_knowledge = Some(knowledge);
     }
 
     /// Each player's view of the archive before any action is applied.
@@ -42,17 +56,65 @@ impl ReplayTransitionSource {
     /// already populated; these projections are what a viewpoint switch made
     /// before the first action selects between.
     pub fn initial_observations(&self) -> Result<Vec<awvm::semantic::Observation>, String> {
-        let state = self.adapter.state();
-        state
-            .players
-            .iter()
-            .map(|player| {
-                awvm::semantic::observe(&awvm::semantic::AwbwVisibility, state, &player.id).map_err(
-                    |error| format!("Could not project the initial archive state: {error}"),
-                )
-            })
-            .collect()
+        observations_for_state(self.initial_adapter.state())
     }
+
+    fn rebuild_to(
+        &mut self,
+        replay: &awbw_replay::AwbwReplay,
+        target_index: usize,
+    ) -> Result<(awvm_awbw::RecordedAdapter, Vec<ObservedTransition>), String> {
+        const CHECKPOINT_INTERVAL: usize = 64;
+
+        let (checkpoint_index, mut adapter) = self
+            .checkpoints
+            .range(..=target_index)
+            .next_back()
+            .map(|(index, adapter)| (*index, adapter.clone()))
+            .unwrap_or_else(|| (0, self.initial_adapter.clone()));
+        for (index, action) in replay
+            .turns
+            .iter()
+            .enumerate()
+            .take(target_index)
+            .skip(checkpoint_index)
+        {
+            adapter.advance(action).map_err(|error| {
+                format!(
+                    "Could not rebuild recorded replay through action {index} ({}): {error}",
+                    action.kind_name()
+                )
+            })?;
+            let completed = index + 1;
+            if completed % CHECKPOINT_INTERVAL == 0 {
+                self.checkpoints
+                    .entry(completed)
+                    .or_insert_with(|| adapter.clone());
+            }
+        }
+
+        let transitions = observations_for_state(adapter.state())?
+            .into_iter()
+            .map(|post| ObservedTransition {
+                post,
+                events: Vec::new(),
+            })
+            .collect();
+        Ok((adapter, transitions))
+    }
+}
+
+fn observations_for_state(
+    state: &awvm::semantic::State,
+) -> Result<Vec<awvm::semantic::Observation>, String> {
+    state
+        .players
+        .iter()
+        .map(|player| {
+            awvm::semantic::observe(&awvm::semantic::AwbwVisibility, state, &player.id)
+                .map_err(|error| format!("Could not project the archive state: {error}"))
+        })
+        .collect()
 }
 
 /// Terminal marker for a replay whose typed source can no longer be trusted.
@@ -166,6 +228,69 @@ impl Command for ReplayTurnCommand {
     }
 }
 
+/// Restore one stable replay action boundary without presenting the actions
+/// used to calculate it. The adapter is rebuilt in local memory first; only
+/// the final projections are committed to the ECS.
+pub struct ReplayRewindCommand {
+    pub target_index: u32,
+}
+
+impl Command for ReplayRewindCommand {
+    type Out = ();
+
+    fn apply(self, world: &mut World) {
+        if world
+            .get_resource::<ReplayAdvanceLock>()
+            .is_some_and(ReplayAdvanceLock::is_active)
+        {
+            return;
+        }
+
+        let Some(replay) = world.get_resource::<crate::loading::LoadedReplay>() else {
+            log::error!("Cannot rewind replay without a loaded replay");
+            return;
+        };
+        let target_index = usize::try_from(self.target_index)
+            .unwrap_or(usize::MAX)
+            .min(replay.0.turns.len());
+
+        if !world.contains_resource::<ReplayTransitionSource>() {
+            log::error!("Cannot rewind replay without a typed transition source");
+            return;
+        }
+        let rebuilt = world.resource_scope(|world, mut source: Mut<ReplayTransitionSource>| {
+            let replay = &world.resource::<crate::loading::LoadedReplay>().0;
+            source.rebuild_to(replay, target_index)
+        });
+        let (adapter, transitions) = match rebuilt {
+            Ok(rebuilt) => rebuilt,
+            Err(error) => {
+                log::error!("{error}");
+                return;
+            }
+        };
+
+        // Reset action-derived roster caches before applying the final AWVM
+        // projections. All of this happens in one deferred command, between
+        // rendered frames, so no intermediate replay state is observable.
+        reset_player_roster_for_rewind(target_index, world);
+        if let Some(knowledge) = world
+            .resource::<ReplayTransitionSource>()
+            .initial_terrain_knowledge
+            .clone()
+        {
+            world.insert_resource(knowledge);
+        }
+        if let Err(error) = apply_typed_transitions(&transitions, world, true) {
+            log::error!("Could not apply typed replay presentation transition: {error}");
+            return;
+        }
+        world.resource_mut::<ReplayState>().next_action_index = target_index as u32;
+        world.resource_mut::<ReplayTransitionSource>().adapter = adapter;
+        world.remove_resource::<ReplayTransitionFailed>();
+    }
+}
+
 impl ReplayTurnCommand {
     fn apply_typed(self, world: &mut World) {
         if world.contains_resource::<ReplayTransitionFailed>() {
@@ -208,35 +333,65 @@ impl ReplayTurnCommand {
             return;
         }
 
-        apply_typed_transitions(&observed, world);
+        if let Err(error) = apply_typed_transitions(&observed, world, true) {
+            log::error!("Could not apply typed replay presentation transition: {error}");
+            world.insert_resource(ReplayTransitionFailed);
+        }
     }
 }
 
 fn apply_deferred_transitions(transitions: &DeferredTransitions, world: &mut World) {
     match transitions {
-        DeferredTransitions::Complete(transitions) => apply_typed_transitions(transitions, world),
+        DeferredTransitions::Complete(transitions) => {
+            if let Err(error) = apply_typed_transitions(transitions, world, true) {
+                log::error!("Could not apply typed replay presentation transition: {error}");
+                world.insert_resource(ReplayTransitionFailed);
+            }
+        }
         DeferredTransitions::Recipient(transition) => {
             apply_recipient_transition(transition, world);
         }
     }
 }
 
-fn apply_typed_transitions(transitions: &[ObservedTransition], world: &mut World) {
+fn apply_typed_transitions(
+    transitions: &[ObservedTransition],
+    world: &mut World,
+    emit_new_day: bool,
+) -> Result<(), TransitionApplyError> {
     let previous_day = world
         .get_resource::<ReplayState>()
         .map_or(1, |state| state.day);
-    if let Err(error) = apply_observed_transitions(world, transitions) {
-        log::error!("Could not apply typed replay presentation transition: {error}");
-        return;
-    }
+    apply_observed_transitions(world, transitions)?;
     sync_player_roster_from_transition(transitions, world);
     let current_day = world
         .get_resource::<ReplayState>()
         .map_or(previous_day, |state| state.day);
-    if current_day != previous_day {
+    if emit_new_day && current_day != previous_day {
         world.trigger(NewDay { day: current_day });
     }
     emit_player_roster_updated(world);
+    Ok(())
+}
+
+fn reset_player_roster_for_rewind(target_index: usize, world: &mut World) {
+    let rebuilt = {
+        let replay = &world.resource::<crate::loading::LoadedReplay>().0;
+        let Some((config, funds, mut unit_costs)) = player_roster_seed_from_replay(replay) else {
+            return;
+        };
+        for action in replay.turns.iter().take(target_index) {
+            for (unit_id, cost) in collect_player_roster_unit_cost_updates(action) {
+                unit_costs.set(unit_id, cost);
+            }
+        }
+        (config, funds, unit_costs)
+    };
+    let (config, funds, unit_costs) = rebuilt;
+    world.insert_resource(config);
+    world.insert_resource(funds);
+    world.insert_resource(unit_costs);
+    world.insert_resource(PlayerPowerCharges::default());
 }
 
 fn apply_recipient_transition(transition: &ObservedTransition, world: &mut World) {

--- a/crates/awbrn-client/tests/replay_typed_presentation.rs
+++ b/crates/awbrn-client/tests/replay_typed_presentation.rs
@@ -1,13 +1,18 @@
 use std::path::Path;
 
+use awbrn_client::features::player_roster::PlayerPowerCharges;
+use awbrn_client::loading::LoadedReplay;
 use awbrn_client::loading::apply_replay_building_overrides;
+use awbrn_client::modes::replay::bootstrap::initialize_replay_semantic_world_for_client;
 use awbrn_client::modes::replay::navigation::PendingCourseArrows;
 use awbrn_client::modes::replay::presentation::{
-    ReplayAdvanceLock, ReplayFollowupCommand, ReplayTransitionSource, ReplayTurnCommand,
+    ReplayAdvanceLock, ReplayFollowupCommand, ReplayRewindCommand, ReplayTransitionFailed,
+    ReplayTransitionSource, ReplayTurnCommand,
 };
 use awbrn_client::render::animation::UnitPathAnimation;
 use awbrn_game::GameWorldPlugin;
-use awbrn_game::replay::{ReplayViewpoint, initialize_replay_semantic_world};
+use awbrn_game::replay::{NewDay, ReplayPlayerRegistry, ReplayState};
+use awbrn_game::snapshot::{canonicalize_replay_semantic_snapshot, capture_game_snapshot};
 use awbrn_game::world::GameMap;
 use awbrn_map::{AwbrnMap, AwbwMap, AwbwMapData};
 use awbw_replay::ReplayParser;
@@ -20,20 +25,7 @@ fn archived_movement_animates_and_applies_only_typed_transitions() {
     let replay = ReplayParser::new().parse(&replay_bytes).unwrap();
     let map_data: AwbwMapData =
         serde_json::from_slice(&std::fs::read(map_fixture_path("162795.json")).unwrap()).unwrap();
-    let adapter = RecordedAdapter::new(&replay, &map_data).unwrap();
-
-    let mut graphical_map = AwbwMap::try_from(&map_data).unwrap();
-    apply_replay_building_overrides(&mut graphical_map, &replay.games.first().unwrap().buildings);
-
-    let mut app = App::new();
-    app.add_plugins(GameWorldPlugin);
-    app.world_mut()
-        .resource_mut::<GameMap>()
-        .set(AwbrnMap::from_map(&graphical_map));
-    initialize_replay_semantic_world(&replay, app.world_mut());
-    app.insert_resource(ReplayTransitionSource::new(adapter));
-    app.insert_resource(ReplayAdvanceLock::default());
-    app.insert_resource(ReplayViewpoint::Spectator);
+    let mut app = replay_test_app(&replay, &map_data);
 
     for action in replay.turns.iter().cloned() {
         ReplayTurnCommand { action }.apply(app.world_mut());
@@ -102,27 +94,11 @@ fn archived_movement_animates_and_applies_only_typed_transitions() {
 /// presentation cache must track it rather than derive it from unit costs.
 #[test]
 fn typed_transitions_record_public_power_charge() {
-    use awbrn_client::features::player_roster::PlayerPowerCharges;
-
     let replay_bytes = std::fs::read(replay_fixture_path("1362397.zip")).unwrap();
     let replay = ReplayParser::new().parse(&replay_bytes).unwrap();
     let map_data: AwbwMapData =
         serde_json::from_slice(&std::fs::read(map_fixture_path("162795.json")).unwrap()).unwrap();
-    let adapter = RecordedAdapter::new(&replay, &map_data).unwrap();
-
-    let mut graphical_map = AwbwMap::try_from(&map_data).unwrap();
-    apply_replay_building_overrides(&mut graphical_map, &replay.games.first().unwrap().buildings);
-
-    let mut app = App::new();
-    app.add_plugins(GameWorldPlugin);
-    app.world_mut()
-        .resource_mut::<GameMap>()
-        .set(AwbrnMap::from_map(&graphical_map));
-    initialize_replay_semantic_world(&replay, app.world_mut());
-    app.insert_resource(ReplayTransitionSource::new(adapter));
-    app.insert_resource(ReplayAdvanceLock::default());
-    app.insert_resource(ReplayViewpoint::Spectator);
-    app.insert_resource(PlayerPowerCharges::default());
+    let mut app = replay_test_app(&replay, &map_data);
 
     let mut charged = false;
     for action in replay.turns.iter().cloned() {
@@ -155,6 +131,203 @@ fn typed_transitions_record_public_power_charge() {
         charged,
         "combat in the fixture should raise at least one player's power charge"
     );
+}
+
+#[test]
+fn initial_observations_stay_at_the_opening_state_after_advancing() {
+    let replay_bytes = std::fs::read(replay_fixture_path("1362397.zip")).unwrap();
+    let replay = ReplayParser::new().parse(&replay_bytes).unwrap();
+    let map_data: AwbwMapData =
+        serde_json::from_slice(&std::fs::read(map_fixture_path("162795.json")).unwrap()).unwrap();
+    let mut app = replay_test_app(&replay, &map_data);
+    let initial = app
+        .world()
+        .resource::<ReplayTransitionSource>()
+        .initial_observations()
+        .unwrap();
+
+    apply_settled_action(&mut app, &replay, 0);
+
+    assert_eq!(
+        app.world()
+            .resource::<ReplayTransitionSource>()
+            .initial_observations()
+            .unwrap(),
+        initial
+    );
+}
+
+#[derive(Resource, Default)]
+struct ObservedDays(Vec<u32>);
+
+fn record_new_day(trigger: On<NewDay>, mut observed: ResMut<ObservedDays>) {
+    observed.0.push(trigger.day);
+}
+
+#[test]
+fn rewind_emits_one_new_day_only_when_the_day_changes() {
+    let replay_bytes = std::fs::read(replay_fixture_path("1362397.zip")).unwrap();
+    let replay = ReplayParser::new().parse(&replay_bytes).unwrap();
+    let map_data: AwbwMapData =
+        serde_json::from_slice(&std::fs::read(map_fixture_path("162795.json")).unwrap()).unwrap();
+    let mut app = replay_test_app(&replay, &map_data);
+    app.init_resource::<ObservedDays>();
+    app.add_observer(record_new_day);
+
+    for index in 0..replay.turns.len() {
+        apply_settled_action(&mut app, &replay, index);
+        if app.world().resource::<ReplayState>().day > 1 {
+            break;
+        }
+    }
+    assert!(app.world().resource::<ReplayState>().day > 1);
+    app.world_mut().resource_mut::<ObservedDays>().0.clear();
+
+    ReplayRewindCommand { target_index: 0 }.apply(app.world_mut());
+
+    assert_eq!(app.world().resource::<ObservedDays>().0, vec![1]);
+    app.world_mut().resource_mut::<ObservedDays>().0.clear();
+    ReplayRewindCommand { target_index: 0 }.apply(app.world_mut());
+    assert!(app.world().resource::<ObservedDays>().0.is_empty());
+}
+
+#[test]
+fn rewind_apply_failure_does_not_commit_the_cursor_or_clear_failure() {
+    let replay_bytes = std::fs::read(replay_fixture_path("1362397.zip")).unwrap();
+    let replay = ReplayParser::new().parse(&replay_bytes).unwrap();
+    let map_data: AwbwMapData =
+        serde_json::from_slice(&std::fs::read(map_fixture_path("162795.json")).unwrap()).unwrap();
+    let mut app = replay_test_app(&replay, &map_data);
+    for index in 0..5 {
+        apply_settled_action(&mut app, &replay, index);
+    }
+    let cursor = app.world().resource::<ReplayState>().next_action_index;
+    app.insert_resource(ReplayPlayerRegistry::default());
+    app.insert_resource(ReplayTransitionFailed);
+
+    ReplayRewindCommand { target_index: 1 }.apply(app.world_mut());
+
+    assert_eq!(
+        app.world().resource::<ReplayState>().next_action_index,
+        cursor
+    );
+    assert!(app.world().contains_resource::<ReplayTransitionFailed>());
+}
+
+#[test]
+fn rewind_atomically_matches_direct_playback_and_keeps_the_adapter_aligned() {
+    const TARGET: usize = 5;
+    const FURTHEST: usize = 9;
+
+    let replay_bytes = std::fs::read(replay_fixture_path("1362397.zip")).unwrap();
+    let replay = ReplayParser::new().parse(&replay_bytes).unwrap();
+    let map_data: AwbwMapData =
+        serde_json::from_slice(&std::fs::read(map_fixture_path("162795.json")).unwrap()).unwrap();
+
+    let mut direct = replay_test_app(&replay, &map_data);
+    for index in 0..TARGET {
+        apply_settled_action(&mut direct, &replay, index);
+    }
+
+    let mut rewound = replay_test_app(&replay, &map_data);
+    for index in 0..FURTHEST {
+        apply_settled_action(&mut rewound, &replay, index);
+    }
+    ReplayRewindCommand {
+        target_index: TARGET as u32,
+    }
+    .apply(rewound.world_mut());
+
+    assert_eq!(
+        rewound.world().resource::<ReplayState>().next_action_index,
+        TARGET as u32
+    );
+    assert!(!rewound.world().resource::<ReplayAdvanceLock>().is_active());
+    assert_eq!(
+        rewound
+            .world_mut()
+            .query::<&UnitPathAnimation>()
+            .iter(rewound.world())
+            .count(),
+        0,
+        "rebuild actions must never enter the animation pipeline"
+    );
+    assert_eq!(
+        semantic_snapshot(&mut rewound),
+        semantic_snapshot(&mut direct)
+    );
+
+    // Matching now is not enough: advancing both worlds once more proves the
+    // rewind also restored the hidden adapter cursor, not only the visible ECS.
+    apply_settled_action(&mut rewound, &replay, TARGET);
+    apply_settled_action(&mut direct, &replay, TARGET);
+    assert_eq!(
+        semantic_snapshot(&mut rewound),
+        semantic_snapshot(&mut direct)
+    );
+
+    // Boundary zero takes a projection of the initial adapter rather than the
+    // post-state of an action, so exercise that separate path too.
+    let mut initial = replay_test_app(&replay, &map_data);
+    ReplayRewindCommand { target_index: 0 }.apply(rewound.world_mut());
+    assert_eq!(
+        semantic_snapshot(&mut rewound),
+        semantic_snapshot(&mut initial)
+    );
+    apply_settled_action(&mut rewound, &replay, 0);
+    apply_settled_action(&mut initial, &replay, 0);
+    assert_eq!(
+        semantic_snapshot(&mut rewound),
+        semantic_snapshot(&mut initial)
+    );
+}
+
+fn replay_test_app(replay: &awbw_replay::AwbwReplay, map_data: &AwbwMapData) -> App {
+    let adapter = RecordedAdapter::new(replay, map_data).unwrap();
+    let mut graphical_map = AwbwMap::try_from(map_data).unwrap();
+    apply_replay_building_overrides(&mut graphical_map, &replay.games.first().unwrap().buildings);
+
+    let mut app = App::new();
+    app.add_plugins(GameWorldPlugin);
+    app.world_mut()
+        .resource_mut::<GameMap>()
+        .set(AwbrnMap::from_map(&graphical_map));
+    app.insert_resource(LoadedReplay(replay.clone()));
+    app.insert_resource(ReplayTransitionSource::new(adapter));
+    initialize_replay_semantic_world_for_client(app.world_mut());
+    app
+}
+
+fn apply_settled_action(app: &mut App, replay: &awbw_replay::AwbwReplay, index: usize) {
+    ReplayTurnCommand {
+        action: replay.turns[index].clone(),
+    }
+    .apply(app.world_mut());
+    if let Some(entity) = app.world().resource::<ReplayAdvanceLock>().active_entity() {
+        let followup = app
+            .world_mut()
+            .resource_mut::<ReplayAdvanceLock>()
+            .release_for(entity)
+            .unwrap();
+        app.world_mut()
+            .entity_mut(entity)
+            .remove::<UnitPathAnimation>();
+        ReplayFollowupCommand {
+            transitions: followup.transitions,
+        }
+        .apply(app.world_mut());
+    }
+    app.world_mut()
+        .resource_mut::<ReplayState>()
+        .next_action_index = (index + 1) as u32;
+}
+
+fn semantic_snapshot(app: &mut App) -> awbrn_game::snapshot::CanonicalReplaySnapshot {
+    let snapshot = capture_game_snapshot(app.world_mut()).unwrap();
+    let registry = app
+        .world()
+        .resource::<bevy::ecs::reflect::AppTypeRegistry>();
+    canonicalize_replay_semantic_snapshot(&snapshot, &registry.read()).unwrap()
 }
 
 fn replay_fixture_path(file_name: &str) -> std::path::PathBuf {

--- a/crates/awbrn-game/src/replay/visibility.rs
+++ b/crates/awbrn-game/src/replay/visibility.rs
@@ -72,7 +72,7 @@ pub enum ReplayKnowledgeKey {
 /// A projection reports a fogged tile's terrain but not its owner
 /// (`spec/semantics/fog.md`), so the property sprite a viewer remembers is
 /// presentation memory the observation cannot supply.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Clone)]
 pub struct ReplayTerrainKnowledge {
     pub by_view: HashMap<ReplayKnowledgeKey, HashMap<Position, awbrn_types::GraphicalTerrain>>,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to rewind replay playback one action at a time using the Left Arrow key.
  - Rewinding can return playback to the beginning and rebuild the game state consistently.
  - Replay animations, unit details, and displayed state now remain synchronized after rewinding.

- **Bug Fixes**
  - Corrected replay state and failure handling when moving backward through actions.

- **Tests**
  - Added coverage for single-action rewinds, rewinding to the beginning, and replay consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->