### PR TITLE
Support remaining post move actions

### DIFF
--- a/crates/awbrn-client/src/modes/play/mod.rs
+++ b/crates/awbrn-client/src/modes/play/mod.rs
@@ -1354,9 +1354,20 @@ fn build_options(
             action: PostMoveAction::Supply,
         });
     }
+    for target in &available.repair {
+        let target = position_from_pos(*target);
+        if let Some(target_id) = unit_id_at_position(target, unit_selection) {
+            options.push(UnitActionOption {
+                name: "Repair".to_string(),
+                action: PostMoveAction::Repair {
+                    target_id: u64::from(target_id),
+                },
+            });
+        }
+    }
     // Join and Load name the unit already standing there, which is friendly by
     // definition and therefore has a real id in the projection.
-    if let Some(occupant) = occupant_unit_id(pending.destination, unit_selection) {
+    if let Some(occupant) = unit_id_at_position(pending.destination, unit_selection) {
         if available.join {
             options.push(UnitActionOption {
                 name: "Join".to_string(),
@@ -1386,6 +1397,20 @@ fn build_options(
             action: PostMoveAction::Unhide,
         });
     }
+    for target in &available.launch {
+        options.push(UnitActionOption {
+            name: "Launch".to_string(),
+            action: PostMoveAction::Launch {
+                target: position_from_pos(*target),
+            },
+        });
+    }
+    if available.explode {
+        options.push(UnitActionOption {
+            name: "Explode".to_string(),
+            action: PostMoveAction::Explode,
+        });
+    }
     if available.wait {
         options.push(UnitActionOption {
             name: "Wait".to_string(),
@@ -1396,7 +1421,7 @@ fn build_options(
     options
 }
 
-fn occupant_unit_id(
+fn unit_id_at_position(
     position: Position,
     unit_selection: &PlayUnitSelectionParams<'_, '_>,
 ) -> Option<u32> {

--- a/crates/awbrn-protocol/src/lib.rs
+++ b/crates/awbrn-protocol/src/lib.rs
@@ -29,12 +29,21 @@ pub enum PostMoveAction {
     },
     /// Supply adjacent friendly units.
     Supply,
+    /// Repair and resupply one adjacent friendly unit.
+    Repair { target_id: u64 },
     /// Dive or activate stealth.
     Hide,
     /// Surface or deactivate stealth.
     Unhide,
     /// Join with a friendly unit of the same type at the destination.
     Join { target_id: u64 },
+    /// Launch the missile silo at the destination at a target tile.
+    Launch {
+        #[cfg_attr(target_family = "wasm", tsify(type = "{ x: number; y: number }"))]
+        target: Position,
+    },
+    /// Self-destruct after moving.
+    Explode,
     /// End the unit's turn without a further action.
     Wait,
 }

--- a/crates/awbrn-server/src/awvm_adapter.rs
+++ b/crates/awbrn-server/src/awvm_adapter.rs
@@ -361,6 +361,12 @@ fn commands(
                     },
                 ]),
                 Some(PostMoveAction::Supply) => one(Command::MoveSupply { player, unit, path }),
+                Some(PostMoveAction::Repair { target_id }) => one(Command::MoveRepair {
+                    player,
+                    unit,
+                    path,
+                    target: command_unit_id(*target_id)?,
+                }),
                 Some(PostMoveAction::Hide) => one(Command::MoveHide { player, unit, path }),
                 Some(PostMoveAction::Unhide) => one(Command::MoveReveal { player, unit, path }),
                 Some(PostMoveAction::Join { target_id }) => one(Command::MoveJoin {
@@ -369,6 +375,13 @@ fn commands(
                     path,
                     target: command_unit_id(*target_id)?,
                 }),
+                Some(PostMoveAction::Launch { target }) => one(Command::MoveLaunch {
+                    player,
+                    unit,
+                    path,
+                    target: pos(*target),
+                }),
+                Some(PostMoveAction::Explode) => one(Command::MoveExplode { player, unit, path }),
                 Some(PostMoveAction::Wait) | None => one(Command::MoveWait { player, unit, path }),
             }
         }

--- a/crates/awbrn-server/src/command.rs
+++ b/crates/awbrn-server/src/command.rs
@@ -76,6 +76,25 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_special_post_move_actions() {
+        let repair: PostMoveAction =
+            serde_json::from_str(r#"{"type":"repair","target_id":17}"#).unwrap();
+        assert_eq!(repair, PostMoveAction::Repair { target_id: 17 });
+
+        let launch: PostMoveAction =
+            serde_json::from_str(r#"{"type":"launch","target":{"x":3,"y":4}}"#).unwrap();
+        assert_eq!(
+            launch,
+            PostMoveAction::Launch {
+                target: Position::new(3, 4)
+            }
+        );
+
+        let explode: PostMoveAction = serde_json::from_str(r#"{"type":"explode"}"#).unwrap();
+        assert_eq!(explode, PostMoveAction::Explode);
+    }
+
+    #[test]
     fn wrong_tag_is_rejected() {
         let json = r#"{"type":"MoveUnit","unitId":1,"path":[],"action":null}"#;
         assert!(serde_json::from_str::<GameCommand>(json).is_err());

--- a/crates/awbrn-server/src/view.rs
+++ b/crates/awbrn-server/src/view.rs
@@ -611,12 +611,21 @@ fn graphical_terrain(
     let mut graphical = template
         .filter(|candidate| semantic_terrain(candidate.as_terrain()) == terrain)
         .unwrap_or_else(|| fallback_terrain(terrain, silo));
-    if let GraphicalTerrain::Property(property) = graphical {
-        let faction = owner
-            .player()
-            .and_then(|owner| authority.player_faction(owner))
-            .map_or(Faction::Neutral, Faction::Player);
-        graphical = GraphicalTerrain::Property(property.with_owner(faction));
+    match graphical {
+        GraphicalTerrain::Property(property) => {
+            let faction = owner
+                .player()
+                .and_then(|owner| authority.player_faction(owner))
+                .map_or(Faction::Neutral, Faction::Player);
+            graphical = GraphicalTerrain::Property(property.with_owner(faction));
+        }
+        GraphicalTerrain::MissileSilo(_) => {
+            graphical = GraphicalTerrain::MissileSilo(match silo {
+                Some(awvm::semantic::Silo::Spent) => MissileSiloStatus::Unloaded,
+                _ => MissileSiloStatus::Loaded,
+            });
+        }
+        _ => {}
     }
     graphical
 }

--- a/crates/awbrn-server/tests/server.rs
+++ b/crates/awbrn-server/tests/server.rs
@@ -2,8 +2,8 @@ use std::num::NonZeroU8;
 
 use awbrn_map::{AwbrnMap, Position};
 use awbrn_types::{
-    Faction as TerrainFaction, GraphicalTerrain, PlayerFaction, Property, SeaDirection, Unit,
-    UnitExt,
+    Faction as TerrainFaction, GraphicalTerrain, MissileSiloStatus, PlayerFaction, Property,
+    SeaDirection, Unit, UnitExt,
 };
 
 use awbrn_server::{
@@ -1335,6 +1335,116 @@ fn primary_weapon_attack_consumes_ammo() {
 }
 
 // ── Non-combat post-move action integration tests ────────────────────────────
+
+#[test]
+fn special_post_move_actions_reach_awvm() {
+    // Manual repair is accepted and routed to move-repair.
+    let mut repair_setup = two_player_setup(3, 2);
+    repair_setup.map.set_terrain(
+        Position::new(0, 0),
+        GraphicalTerrain::Sea(SeaDirection::Sea),
+    );
+    let mut repair_server = GameServer::new(repair_setup).unwrap();
+    let boat = repair_server.spawn_unit(
+        Position::new(0, 0),
+        Unit::BlackBoat,
+        PlayerFaction::OrangeStar,
+    );
+    let repair_target = repair_server.spawn_unit(
+        Position::new(1, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    repair_server
+        .submit_command(
+            p1(),
+            action_command(
+                boat,
+                vec![Position::new(0, 0)],
+                PostMoveAction::Repair {
+                    target_id: repair_target.0,
+                },
+            ),
+        )
+        .unwrap();
+
+    // Launch consumes the silo and applies its area strike.
+    let mut launch_setup = two_player_setup(5, 5);
+    launch_setup.map.set_terrain(
+        Position::new(0, 0),
+        GraphicalTerrain::MissileSilo(MissileSiloStatus::Loaded),
+    );
+    let mut launch_server = GameServer::new(launch_setup).unwrap();
+    let infantry = launch_server.spawn_unit(
+        Position::new(0, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let victim = launch_server.spawn_unit(Position::new(3, 3), Unit::Tank, PlayerFaction::BlueMoon);
+    launch_server
+        .submit_command(
+            p1(),
+            action_command(
+                infantry,
+                vec![Position::new(0, 0)],
+                PostMoveAction::Launch {
+                    target: Position::new(3, 3),
+                },
+            ),
+        )
+        .unwrap();
+    let launch_view = launch_server.player_view(p1()).unwrap();
+    assert_eq!(
+        launch_view
+            .units
+            .iter()
+            .find(|unit| unit.id == victim)
+            .unwrap()
+            .hp,
+        7
+    );
+    assert_eq!(
+        launch_view
+            .terrain
+            .iter()
+            .find(|tile| tile.position == Position::new(0, 0))
+            .unwrap()
+            .terrain,
+        GraphicalTerrain::MissileSilo(MissileSiloStatus::Unloaded)
+    );
+
+    // Explode removes the bomb after applying damage.
+    let mut explode_server = GameServer::new(two_player_setup(5, 5)).unwrap();
+    let bomb = explode_server.spawn_unit(
+        Position::new(2, 2),
+        Unit::BlackBomb,
+        PlayerFaction::OrangeStar,
+    );
+    explode_server.spawn_unit(
+        Position::new(0, 0),
+        Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    let blast_victim =
+        explode_server.spawn_unit(Position::new(3, 2), Unit::Tank, PlayerFaction::BlueMoon);
+    explode_server
+        .submit_command(
+            p1(),
+            action_command(bomb, vec![Position::new(2, 2)], PostMoveAction::Explode),
+        )
+        .unwrap();
+    let explode_view = explode_server.player_view(p1()).unwrap();
+    assert!(!explode_view.units.iter().any(|unit| unit.id == bomb));
+    assert_eq!(
+        explode_view
+            .units
+            .iter()
+            .find(|unit| unit.id == blast_victim)
+            .unwrap()
+            .hp,
+        5
+    );
+}
 
 #[test]
 fn supply_restores_self_owned_adjacent_fuel_and_ammo() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added post-move actions for repairing units, launching missiles, and exploding bombs.
  - Available actions now appear with valid targets and destinations.
  - Missile launches and bomb explosions apply their effects correctly.

- **Bug Fixes**
  - Missile-silo status and ownership are now displayed consistently.
  - Spent missile silos are shown as unloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->