### PR TITLE
Add power activation

### DIFF
--- a/crates/awbrn-client/Cargo.toml
+++ b/crates/awbrn-client/Cargo.toml
@@ -10,7 +10,7 @@ awbrn-map = { path = "../awbrn-map", features = ["bevy"] }
 awbrn-protocol = { path = "../awbrn-protocol" }
 awbrn-types = { path = "../awbrn-types", features = ["bevy"] }
 awbw-replay = { path = "../awbw-replay" }
-awvm = { path = "../awvm" }
+awvm = { path = "../awvm", features = ["typescript"] }
 awvm-awbw = { path = "../awvm-awbw" }
 bevy = { workspace = true, features = [
     "bevy_asset",

--- a/crates/awbrn-client/src/features/event_bus.rs
+++ b/crates/awbrn-client/src/features/event_bus.rs
@@ -254,6 +254,8 @@ pub struct PlayerRosterEntry {
     pub scop_cost: Option<u32>,
     /// Charge one power star is worth, so a meter can be drawn in segments.
     pub power_star_charge: Option<u32>,
+    /// The power that this player has active.
+    pub active_power: Option<awvm::commander::PowerLevel>,
     pub stats: PlayerRosterStats,
 }
 

--- a/crates/awbrn-client/src/features/player_roster.rs
+++ b/crates/awbrn-client/src/features/player_roster.rs
@@ -68,6 +68,8 @@ pub struct PlayerPowerMeter {
     pub scop_cost: Option<u32>,
     /// Charge that one star is worth at this player's current use count.
     pub star_charge: Option<u32>,
+    /// The power that this player has active.
+    pub active_power: Option<awvm::commander::PowerLevel>,
 }
 
 #[derive(Resource, Clone, Default)]
@@ -253,17 +255,39 @@ fn observed_player_commanders(player: &ObservedPlayer) -> Vec<awvm::semantic::Co
 
 /// Meter values for the commander currently leading, falling back to the first.
 pub fn active_power_meter(player: &ObservedPlayer) -> Option<PlayerPowerMeter> {
-    let (commander, charge, power_uses) = match player {
-        ObservedPlayer::Private { commanders, .. } => commanders
+    let (commander, charge, power_uses, power_state) = match player {
+        ObservedPlayer::Private {
+            commanders,
+            power_state,
+            ..
+        } => commanders
             .iter()
             .find(|commander| commander.active)
             .or_else(|| commanders.first())
-            .map(|commander| (commander.id, commander.power_charge, commander.power_uses)),
-        ObservedPlayer::Public { commanders, .. } => commanders
+            .map(|commander| {
+                (
+                    commander.id,
+                    commander.power_charge,
+                    commander.power_uses,
+                    power_state,
+                )
+            }),
+        ObservedPlayer::Public {
+            commanders,
+            power_state,
+            ..
+        } => commanders
             .iter()
             .find(|commander| commander.active)
             .or_else(|| commanders.first())
-            .map(|commander| (commander.id, commander.power_charge, commander.power_uses)),
+            .map(|commander| {
+                (
+                    commander.id,
+                    commander.power_charge,
+                    commander.power_uses,
+                    power_state,
+                )
+            }),
     }?;
     let cost = |level| {
         awvm::commander::power_activation_cost(commander, level, power_uses)
@@ -278,6 +302,11 @@ pub fn active_power_meter(player: &ObservedPlayer) -> Option<PlayerPowerMeter> {
         star_charge: awvm::commander::power_star_charge(power_uses)
             .ok()
             .and_then(|charge| u32::try_from(charge).ok()),
+        active_power: match power_state {
+            awvm::semantic::PowerState::None => None,
+            awvm::semantic::PowerState::Cop { .. } => Some(awvm::commander::PowerLevel::Cop),
+            awvm::semantic::PowerState::Scop { .. } => Some(awvm::commander::PowerLevel::Scop),
+        },
     })
 }
 
@@ -473,6 +502,7 @@ pub fn player_roster_snapshot(world: &mut World) -> Option<PlayerRosterSnapshot>
                     cop_cost: power_meter.and_then(|meter| meter.cop_cost),
                     scop_cost: power_meter.and_then(|meter| meter.scop_cost),
                     power_star_charge: power_meter.and_then(|meter| meter.star_charge),
+                    active_power: power_meter.and_then(|meter| meter.active_power),
                     stats,
                 }
             })
@@ -525,6 +555,30 @@ mod tests {
     use awbrn_types::{AwbwGamePlayerId, AwbwPlayerId};
     use bevy::app::App;
     use std::collections::HashMap;
+
+    #[test]
+    fn active_power_meter_reports_active_power() {
+        let player: ObservedPlayer = serde_json::from_value(serde_json::json!({
+            "id": "0",
+            "team": "red-team",
+            "relation": "self",
+            "funds": 0,
+            "status": "active",
+            "commanders": [{
+                "id": "andy",
+                "active": true,
+                "power_charge": 0,
+                "power_uses": 1
+            }],
+            "power_state": { "type": "cop", "commander_slot": 0 }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            active_power_meter(&player).unwrap().active_power,
+            Some(awvm::commander::PowerLevel::Cop)
+        );
+    }
 
     #[test]
     fn fog_hides_opponent_roster_stats() {

--- a/crates/awbrn-server/src/awvm_adapter.rs
+++ b/crates/awbrn-server/src/awvm_adapter.rs
@@ -261,6 +261,13 @@ fn command_error(command: &Command, violation: awvm::violation::Violation) -> Co
             cost: u32::try_from(required).unwrap_or(u32::MAX),
             available: u32::try_from(available).unwrap_or(u32::MAX),
         },
+        Violation::InsufficientPower {
+            required,
+            available,
+        } => CommandError::InsufficientPower {
+            cost: u32::try_from(required).unwrap_or(u32::MAX),
+            available: u32::try_from(available).unwrap_or(u32::MAX),
+        },
         Violation::InvalidTarget { .. } if matches!(command, Command::ProduceUnit { .. }) => {
             CommandError::InvalidBuildLocation
         }
@@ -306,6 +313,10 @@ fn commands(
             player,
             position: pos(*position),
             kind: *unit_type,
+        }),
+        GameCommand::ActivatePower { level } => one(Command::ActivatePower {
+            player,
+            level: *level,
         }),
         GameCommand::EndTurn => one(Command::EndTurn { player }),
         GameCommand::Unload {

--- a/crates/awbrn-server/src/command.rs
+++ b/crates/awbrn-server/src/command.rs
@@ -1,8 +1,45 @@
 use awbrn_map::Position;
 pub use awbrn_protocol::PostMoveAction;
+pub use awvm::commander::PowerLevel;
 use tsify::Tsify;
 
 use crate::unit_id::ServerUnitId;
+
+/// A command submitted by a player during their turn.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Tsify)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum GameCommand {
+    /// Move a unit along a path, optionally performing an action at the destination.
+    MoveUnit {
+        #[tsify(type = "number")]
+        unit_id: ServerUnitId,
+        /// Full path from current position to destination (inclusive of both endpoints).
+        /// Used for fuel consumption and client animation.
+        #[tsify(type = "{ x: number; y: number }[]")]
+        path: Vec<Position>,
+        /// Action to perform after arriving at the destination.
+        action: Option<PostMoveAction>,
+    },
+    /// Build a new unit at a production facility.
+    Build {
+        #[tsify(type = "{ x: number; y: number }")]
+        position: Position,
+        unit_type: awvm::ruleset::UnitKind,
+    },
+    /// Unload one carried unit without moving or spending its transport.
+    Unload {
+        #[tsify(type = "number")]
+        transport_id: ServerUnitId,
+        #[tsify(type = "number")]
+        cargo_id: ServerUnitId,
+        #[tsify(type = "{ x: number; y: number }")]
+        position: Position,
+    },
+    /// Activate the current commander's normal or super power.
+    ActivatePower { level: PowerLevel },
+    /// End the current player's turn.
+    EndTurn,
+}
 
 #[cfg(test)]
 mod tests {
@@ -62,6 +99,18 @@ mod tests {
                 transport_id: ServerUnitId(4),
                 cargo_id: ServerUnitId(7),
                 position: Position::new(2, 3),
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_activate_power() {
+        let json = r#"{"type":"activatePower","level":"scop"}"#;
+        let cmd: GameCommand = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            cmd,
+            GameCommand::ActivatePower {
+                level: PowerLevel::Scop
             }
         );
     }
@@ -130,38 +179,4 @@ mod tests {
         let json = r#"{"type":"MoveUnit","unitId":1,"path":[],"action":null}"#;
         assert!(serde_json::from_str::<GameCommand>(json).is_err());
     }
-}
-
-/// A command submitted by a player during their turn.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Tsify)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum GameCommand {
-    /// Move a unit along a path, optionally performing an action at the destination.
-    MoveUnit {
-        #[tsify(type = "number")]
-        unit_id: ServerUnitId,
-        /// Full path from current position to destination (inclusive of both endpoints).
-        /// Used for fuel consumption and client animation.
-        #[tsify(type = "{ x: number; y: number }[]")]
-        path: Vec<Position>,
-        /// Action to perform after arriving at the destination.
-        action: Option<PostMoveAction>,
-    },
-    /// Build a new unit at a production facility.
-    Build {
-        #[tsify(type = "{ x: number; y: number }")]
-        position: Position,
-        unit_type: awvm::ruleset::UnitKind,
-    },
-    /// Unload one carried unit without moving or spending its transport.
-    Unload {
-        #[tsify(type = "number")]
-        transport_id: ServerUnitId,
-        #[tsify(type = "number")]
-        cargo_id: ServerUnitId,
-        #[tsify(type = "{ x: number; y: number }")]
-        position: Position,
-    },
-    /// End the current player's turn.
-    EndTurn,
 }

--- a/crates/awbrn-server/src/error.rs
+++ b/crates/awbrn-server/src/error.rs
@@ -17,6 +17,8 @@ pub enum CommandError {
     InvalidAction { reason: String },
     /// Insufficient funds to build the requested unit.
     InsufficientFunds { cost: u32, available: u32 },
+    /// Insufficient charge to activate the requested power.
+    InsufficientPower { cost: u32, available: u32 },
     /// The position cannot produce the requested unit type.
     InvalidBuildLocation,
     /// The game is already over.
@@ -33,6 +35,9 @@ impl fmt::Display for CommandError {
             Self::InvalidAction { reason } => write!(f, "invalid action: {reason}"),
             Self::InsufficientFunds { cost, available } => {
                 write!(f, "insufficient funds: need {cost}, have {available}")
+            }
+            Self::InsufficientPower { cost, available } => {
+                write!(f, "insufficient power: need {cost}, have {available}")
             }
             Self::InvalidBuildLocation => write!(f, "invalid build location"),
             Self::GameOver => write!(f, "game is over"),

--- a/crates/awbrn-server/src/lib.rs
+++ b/crates/awbrn-server/src/lib.rs
@@ -11,7 +11,7 @@ mod view;
 mod wasm;
 
 pub use awbrn_types::Co;
-pub use command::{GameCommand, PostMoveAction};
+pub use command::{GameCommand, PostMoveAction, PowerLevel};
 pub use error::CommandError;
 pub use player::{PlayerId, PlayerRegistry};
 pub use replay::{ReplayError, ReplayEventError, StoredActionEvent, reconstruct_from_events};

--- a/crates/awbrn-server/src/wasm.rs
+++ b/crates/awbrn-server/src/wasm.rs
@@ -657,6 +657,7 @@ fn command_error(error: crate::error::CommandError) -> JsError {
         | crate::error::CommandError::InvalidPath { .. }
         | crate::error::CommandError::InvalidAction { .. }
         | crate::error::CommandError::InsufficientFunds { .. }
+        | crate::error::CommandError::InsufficientPower { .. }
         | crate::error::CommandError::InvalidBuildLocation => ("invalidCommand", 400),
     };
     js_error(code, error.to_string(), http_status, json!(null))

--- a/crates/awbrn-server/tests/server.rs
+++ b/crates/awbrn-server/tests/server.rs
@@ -8,8 +8,8 @@ use awbrn_types::{
 
 use awbrn_server::{
     CaptureEvent, Co, CommandError, GameCommand, GameServer, GameSetup, PlayerId, PlayerSetup,
-    PostMoveAction, ReplayError, ReplayEventError, ServerUnitId, SetupError, StoredActionEvent,
-    reconstruct_from_events,
+    PostMoveAction, PowerLevel, ReplayError, ReplayEventError, ServerUnitId, SetupError,
+    StoredActionEvent, reconstruct_from_events,
 };
 use awvm::semantic::{ObservedEvent, ObservedUnitRef};
 
@@ -427,6 +427,28 @@ fn build_rejects_insufficient_funds() {
             available: 1000
         }
     ));
+}
+
+#[test]
+fn activate_power_rejects_insufficient_charge() {
+    let mut server = GameServer::new(two_player_setup(3, 3)).unwrap();
+
+    let err = server
+        .submit_command(
+            p1(),
+            GameCommand::ActivatePower {
+                level: PowerLevel::Cop,
+            },
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        CommandError::InsufficientPower {
+            cost: 27_000,
+            available: 0
+        }
+    );
 }
 
 #[test]

--- a/crates/awvm/src/commander.rs
+++ b/crates/awvm/src/commander.rs
@@ -422,6 +422,7 @@ pub(crate) enum PlayerTarget {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "typescript", derive(tsify::Tsify))]
 #[serde(rename_all = "kebab-case")]
 pub enum PowerLevel {
     Cop,

--- a/web/src/matches/match_protocol.test.ts
+++ b/web/src/matches/match_protocol.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type { MatchSetup } from "./schemas.ts";
 import {
   initialMatchConnectionMessages,
+  type ActivatePowerCommand,
   type EndTurnCommand,
   type LiveTransition,
   type MatchGameState,
@@ -9,6 +10,13 @@ import {
 } from "./match_protocol.ts";
 
 describe("live match commands", () => {
+  it("uses the server's tagged power command", () => {
+    expectTypeOf<ActivatePowerCommand>().toEqualTypeOf<{
+      type: "activatePower";
+      level: "cop" | "scop";
+    }>();
+  });
+
   it("uses the server's tagged end-turn command", () => {
     expectTypeOf<EndTurnCommand>().toEqualTypeOf<{ type: "endTurn" }>();
   });

--- a/web/src/matches/match_protocol.ts
+++ b/web/src/matches/match_protocol.ts
@@ -63,6 +63,7 @@ export interface ErrorMessage {
 
 /** A player command sent over the live-match websocket. */
 export type MatchCommand = WasmGameCommand;
+export type ActivatePowerCommand = Extract<MatchCommand, { type: "activatePower" }>;
 export type EndTurnCommand = Extract<MatchCommand, { type: "endTurn" }>;
 
 export type UnitMoved = UnitMovedMessage;

--- a/web/src/matches/screens/MatchActivePage.tsx
+++ b/web/src/matches/screens/MatchActivePage.tsx
@@ -27,6 +27,7 @@ import type { MatchParticipantSnapshot } from "#/matches/schemas.ts";
 import { BuildMenu } from "#/matches/components/BuildMenu.tsx";
 import { UnitActionMenu } from "#/matches/components/UnitActionMenu.tsx";
 import { RosterList, RosterRow } from "#/replay/RosterRow.tsx";
+import type { ActivatablePowerLevel } from "#/replay/power_meter.ts";
 import type {
   PlayerRosterEntry,
   PlayerRosterSnapshot,
@@ -107,10 +108,16 @@ export function MatchActivePage({
   const [spectatorFogActive, setSpectatorFogActive] = useState<boolean | null>(null);
   const [activePlayerSlot, setActivePlayerSlot] = useState<number | null>(null);
   const [isEndingTurn, setIsEndingTurn] = useState(false);
+  const [activatingPower, setActivatingPower] = useState<ActivatablePowerLevel>();
   const isEndingTurnRef = useRef(false);
+  const isActivatingPowerRef = useRef(false);
   const finishEndingTurn = useCallback(() => {
     isEndingTurnRef.current = false;
     setIsEndingTurn(false);
+  }, []);
+  const finishActivatingPower = useCallback(() => {
+    isActivatingPowerRef.current = false;
+    setActivatingPower(undefined);
   }, []);
   // A command the server refuses, or one that never leaves, puts the board back
   // the way it was: the unit selected at its origin with its route intact, so a
@@ -137,6 +144,7 @@ export function MatchActivePage({
           // turn with this frame and not with a player update, so the end turn
           // command must stop here too.
           finishEndingTurn();
+          finishActivatingPower();
           setViewerSlotIndex(message.slotIndex);
           // The notice arrives before this frame and only ever for a spectator,
           // so holding a seat here means an earlier notice has gone stale.
@@ -147,6 +155,7 @@ export function MatchActivePage({
         }
         case "error": {
           finishEndingTurn();
+          finishActivatingPower();
           setMatchError(message.message);
           restoreAfterRefusal();
           return;
@@ -175,7 +184,7 @@ export function MatchActivePage({
         }
       }
     },
-    [finishEndingTurn, restoreAfterRefusal, runner],
+    [finishActivatingPower, finishEndingTurn, restoreAfterRefusal, runner],
   );
   const { reconnect, sendMessage, status } = useMatchWebSocket(matchId, handleMatchMessage);
 
@@ -195,10 +204,49 @@ export function MatchActivePage({
   const viewerArmy = armies.find((army) => army.entry.playerId === viewerSlotIndex);
 
   useEffect(() => {
+    if (activatingPower !== undefined && viewerArmy?.entry.activePower !== undefined) {
+      finishActivatingPower();
+    }
+  }, [activatingPower, finishActivatingPower, viewerArmy?.entry.activePower]);
+
+  useEffect(() => {
     if (status !== "connected") {
       finishEndingTurn();
+      finishActivatingPower();
     }
-  }, [finishEndingTurn, status]);
+  }, [finishActivatingPower, finishEndingTurn, status]);
+
+  const handleActivatePower = useCallback(
+    (level: ActivatablePowerLevel) => {
+      if (
+        isActivatingPowerRef.current ||
+        status !== "connected" ||
+        viewerSlotIndex === null ||
+        viewerSlotIndex === undefined ||
+        viewerSlotIndex !== activePlayerSlot
+      ) {
+        return;
+      }
+
+      isActivatingPowerRef.current = true;
+      setActivatingPower(level);
+      setMatchError(null);
+      if (!sendMessage({ type: "activatePower", level })) {
+        finishActivatingPower();
+        setMatchError("The CO power could not be activated because the connection is not open.");
+        return;
+      }
+      setProductionOptions(null);
+    },
+    [
+      activePlayerSlot,
+      finishActivatingPower,
+      sendMessage,
+      setProductionOptions,
+      status,
+      viewerSlotIndex,
+    ],
+  );
 
   const handleEndTurn = useCallback(() => {
     if (
@@ -318,9 +366,17 @@ export function MatchActivePage({
                   {armies.map((army) => (
                     <RosterRow
                       isActive={army.isActive}
+                      activatingPower={activatingPower}
                       isViewer={viewerSlotIndex === army.entry.playerId}
                       key={army.entry.playerId}
                       name={army.name}
+                      onActivatePower={
+                        status === "connected" &&
+                        army.isActive &&
+                        viewerSlotIndex === army.entry.playerId
+                          ? handleActivatePower
+                          : undefined
+                      }
                       onFactionChange={
                         army.hasLiveStats
                           ? (factionId) =>
@@ -669,6 +725,7 @@ function seatEntry(participant: MatchParticipantSnapshot, index: number): Player
     copCost: undefined,
     scopCost: undefined,
     powerStarCharge: undefined,
+    activePower: undefined,
     stats: {
       funds: undefined,
       income: undefined,

--- a/web/src/replay/PowerMeter.tsx
+++ b/web/src/replay/PowerMeter.tsx
@@ -1,15 +1,23 @@
+import { Button } from "@astryxdesign/core/Button";
 import { Icon } from "@astryxdesign/core/Icon";
 import { HStack, VStack } from "@astryxdesign/core/Stack";
 import { Text } from "@astryxdesign/core/Text";
 import { Tooltip } from "@astryxdesign/core/Tooltip";
 import { VisuallyHidden } from "@astryxdesign/core/VisuallyHidden";
 import * as stylex from "@stylexjs/stylex";
-import type { SVGProps } from "react";
+import type { ComponentType, SVGProps } from "react";
 import type { PlayerRosterEntry } from "#/wasm/awbrn_wasm.js";
-import { readPowerMeter, type PowerMeterReading } from "./power_meter.ts";
+import {
+  canActivatePower,
+  readPowerMeter,
+  type ActivatablePowerLevel,
+  type PowerMeterReading,
+} from "./power_meter.ts";
 import { uiAtlasSpriteStyle } from "#/components/game_sprites.ts";
 
 const STAR = uiAtlasSpriteStyle("TerrainStar.png");
+const NORMAL_POWER = uiAtlasSpriteStyle("NormalPower.png");
+const SUPER_POWER = uiAtlasSpriteStyle("SuperPower.png");
 
 /**
  * A CO power meter drawn in stars, at the length that CO's powers actually run.
@@ -21,7 +29,15 @@ const STAR = uiAtlasSpriteStyle("TerrainStar.png");
  * ones, parted by an ink rule. The step in height is the boundary — a player
  * sees where the normal power ends without reading anything.
  */
-export function PowerMeter({ player }: { player: PlayerRosterEntry }) {
+export function PowerMeter({
+  activatingPower,
+  onActivatePower,
+  player,
+}: {
+  activatingPower?: ActivatablePowerLevel;
+  onActivatePower?: (level: ActivatablePowerLevel) => void;
+  player: PlayerRosterEntry;
+}) {
   const meter = readPowerMeter(player);
   // A seat taken from the match record knows its CO but not yet its charge. The
   // row keeps the meter's height so it does not jump when the engine reports.
@@ -31,56 +47,78 @@ export function PowerMeter({ player }: { player: PlayerRosterEntry }) {
   const superStars = scop === null ? 0 : scop.stars - (cop?.stars ?? 0);
 
   return (
-    <Tooltip content={<PowerBreakdown meter={meter} />} focusTrigger="always" placement="above">
-      <HStack align="end" gap={2} tabIndex={0} xstyle={styles.meter}>
-        <HStack
-          align="end"
-          aria-label="CO power"
-          aria-valuemax={totalStars}
-          aria-valuemin={0}
-          aria-valuenow={charged}
-          aria-valuetext={describe(meter)}
-          gap={0}
-          role="meter"
-        >
-          {cop === null ? null : (
-            <Zone
-              charged={charged}
-              isJoined={superStars > 0}
-              isReady={level !== "charging"}
-              offset={0}
-              size="cop"
-              stars={cop.stars}
-            />
-          )}
-          {superStars === 0 ? null : (
-            <Zone
-              charged={charged}
-              isJoined={cop !== null}
-              isReady={level === "scop"}
-              offset={cop?.stars ?? 0}
-              size="scop"
-              stars={superStars}
-            />
-          )}
-        </HStack>
+    <HStack align="end" gap={2} justify="between">
+      <Tooltip content={<PowerBreakdown meter={meter} />} focusTrigger="always" placement="above">
+        <HStack align="end" gap={2} tabIndex={0} xstyle={styles.meter}>
+          <HStack
+            align="end"
+            aria-label="CO power"
+            aria-valuemax={totalStars}
+            aria-valuemin={0}
+            aria-valuenow={charged}
+            aria-valuetext={describe(meter)}
+            gap={0}
+            role="meter"
+          >
+            {cop === null ? null : (
+              <Zone
+                charged={charged}
+                isJoined={superStars > 0}
+                isReady={level !== "charging"}
+                offset={0}
+                size="cop"
+                stars={cop.stars}
+              />
+            )}
+            {superStars === 0 ? null : (
+              <Zone
+                charged={charged}
+                isJoined={cop !== null}
+                isReady={level === "scop"}
+                offset={cop?.stars ?? 0}
+                size="scop"
+                stars={superStars}
+              />
+            )}
+          </HStack>
 
-        <Text
-          color={level === "charging" ? "secondary" : "accent"}
-          hasTabularNumbers
-          type="label"
-          xstyle={styles.readout}
-        >
-          <Icon
-            aria-hidden="true"
-            icon={SpriteImage}
-            style={STAR ?? undefined}
-            xstyle={styles.sprite}
-          />
-          {formatStars(charged)}/{totalStars}
-        </Text>
-      </HStack>
-    </Tooltip>
+          <Text
+            color={level === "charging" ? "secondary" : "accent"}
+            hasTabularNumbers
+            type="label"
+            xstyle={styles.readout}
+          >
+            <Icon
+              aria-hidden="true"
+              icon={SpriteImage}
+              style={STAR ?? undefined}
+              xstyle={styles.sprite}
+            />
+            {formatStars(charged)}/{totalStars}
+          </Text>
+        </HStack>
+      </Tooltip>
+      {onActivatePower ? (
+        <HStack align="end" gap={1}>
+          {canActivatePower(player, "cop") ? (
+            <PowerButton
+              art={NormalPowerSprite}
+              isLoading={activatingPower === "cop"}
+              label="Activate CO power"
+              onActivate={() => onActivatePower("cop")}
+            />
+          ) : null}
+          {canActivatePower(player, "scop") ? (
+            <PowerButton
+              art={SuperPowerSprite}
+              isLoading={activatingPower === "scop"}
+              label="Activate super CO power"
+              onActivate={() => onActivatePower("scop")}
+            />
+          ) : null}
+        </HStack>
+      ) : null}
+    </HStack>
   );
 }
 
@@ -171,6 +209,41 @@ function BreakdownRow({ label, value }: { label: string; value: number }) {
 /** Lets Astryx Icon host a CSS-atlas sprite while retaining its image semantics. */
 function SpriteImage(props: SVGProps<SVGSVGElement>) {
   return <svg {...props} />;
+}
+
+/** Lets the action button show the source game's dedicated normal-power art. */
+function NormalPowerSprite(props: SVGProps<SVGSVGElement>) {
+  return <svg {...props} style={{ ...props.style, ...NORMAL_POWER }} />;
+}
+
+/** Lets the action button show the source game's dedicated super-power art. */
+function SuperPowerSprite(props: SVGProps<SVGSVGElement>) {
+  return <svg {...props} style={{ ...props.style, ...SUPER_POWER }} />;
+}
+
+function PowerButton({
+  art,
+  isLoading,
+  label,
+  onActivate,
+}: {
+  art: ComponentType<SVGProps<SVGSVGElement>>;
+  isLoading: boolean;
+  label: string;
+  onActivate: () => void;
+}) {
+  return (
+    <Button
+      clickAction={onActivate}
+      isLoading={isLoading}
+      label={label}
+      size="sm"
+      tooltip={label}
+      variant="ghost"
+    >
+      <Icon icon={art} />
+    </Button>
+  );
 }
 
 /** A partial star is worth reporting; a whole one should not read as "3.0". */

--- a/web/src/replay/RosterRow.tsx
+++ b/web/src/replay/RosterRow.tsx
@@ -13,6 +13,7 @@ import { ROSTER_MEDIA_SIZE, ROSTER_STAT_COLUMN_MIN_WIDTH } from "#/ui/layout.ts"
 import { rosterLayout } from "#/ui/rosterLayout.stylex.ts";
 import type { PlayerRosterEntry } from "#/wasm/awbrn_wasm.js";
 import { PowerMeter } from "./PowerMeter.tsx";
+import type { ActivatablePowerLevel } from "./power_meter.ts";
 import { infantrySpriteStyle, uiAtlasSpriteStyle } from "#/components/game_sprites.ts";
 
 const formatMoney = (value: number | null | undefined) =>
@@ -98,17 +99,21 @@ function Readout({ icon, label, value }: { icon: ReactNode; label: string; value
  * what they can do next, and what they hold.
  */
 export function RosterRow({
+  activatingPower,
   isActive,
   isViewer = false,
   name,
+  onActivatePower,
   onFactionChange,
   player,
   portraitCatalog,
 }: {
+  activatingPower?: ActivatablePowerLevel;
   isActive: boolean;
   /** Marks the army the viewer is playing. A reviewer plays none of them. */
   isViewer?: boolean;
   name: string;
+  onActivatePower?: (level: ActivatablePowerLevel) => void;
   onFactionChange?: (factionId: number) => void | Promise<void>;
   player: PlayerRosterEntry;
   portraitCatalog: CoPortraitCatalog;
@@ -172,7 +177,11 @@ export function RosterRow({
         ) : null}
       </HStack>
 
-      <PowerMeter player={player} />
+      <PowerMeter
+        activatingPower={activatingPower}
+        onActivatePower={onActivatePower}
+        player={player}
+      />
 
       {/* A grid rather than a row: the four numbers land on the same columns in
           every army, which is what makes two armies comparable at a glance. */}

--- a/web/src/replay/power_meter.test.ts
+++ b/web/src/replay/power_meter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readPowerMeter } from "./power_meter.ts";
+import { canActivatePower, readPowerMeter } from "./power_meter.ts";
 import type { PlayerRosterEntry } from "#/wasm/awbrn_wasm.js";
 
 /** A roster entry with only the fields the meter reads. */
@@ -24,6 +24,7 @@ function entry(power: Partial<PlayerRosterEntry>): PlayerRosterEntry {
     copCost: undefined,
     scopCost: undefined,
     powerStarCharge: undefined,
+    activePower: undefined,
     stats: { funds: undefined, income: undefined, unitCount: undefined, unitValue: undefined },
     ...power,
   };
@@ -88,5 +89,25 @@ describe("readPowerMeter", () => {
   it("draws nothing when the CO has no power to charge toward", () => {
     expect(readPowerMeter(entry({ powerCharge: 0, powerStarCharge: 9_000 }))).toBeNull();
     expect(readPowerMeter(entry({ powerCharge: 0, copCost: 27_000 }))).toBeNull();
+  });
+});
+
+describe("canActivatePower", () => {
+  const costs = { copCost: 27_000, scopCost: 54_000, powerStarCharge: 9_000 };
+
+  it("becomes available at the normal-power threshold", () => {
+    expect(canActivatePower(entry({ powerCharge: 26_999, ...costs }), "cop")).toBe(false);
+    expect(canActivatePower(entry({ powerCharge: 27_000, ...costs }), "cop")).toBe(true);
+  });
+
+  it("becomes available at the super-power threshold", () => {
+    expect(canActivatePower(entry({ powerCharge: 53_999, ...costs }), "scop")).toBe(false);
+    expect(canActivatePower(entry({ powerCharge: 54_000, ...costs }), "scop")).toBe(true);
+  });
+
+  it("is unavailable while a power is active", () => {
+    const player = entry({ powerCharge: 54_000, activePower: "scop", ...costs });
+    expect(canActivatePower(player, "cop")).toBe(false);
+    expect(canActivatePower(player, "scop")).toBe(false);
   });
 });

--- a/web/src/replay/power_meter.ts
+++ b/web/src/replay/power_meter.ts
@@ -32,6 +32,9 @@ export interface PowerLevelCost {
 /** Which power the current charge pays for. */
 export type PowerLevel = "charging" | "cop" | "scop";
 
+/** A power level that a player can activate. */
+export type ActivatablePowerLevel = Exclude<PowerLevel, "charging">;
+
 /**
  * A meter is worth drawing only when the CO has a power and the star value is
  * known; a CO without either has nothing to charge toward.
@@ -57,6 +60,12 @@ export function readPowerMeter(player: PlayerRosterEntry): PowerMeterReading | n
     totalStars,
     level: powerLevel(charge, player.copCost, player.scopCost),
   };
+}
+
+/** Whether the player can activate one power shown by this meter. */
+export function canActivatePower(player: PlayerRosterEntry, level: ActivatablePowerLevel): boolean {
+  const meter = readPowerMeter(player);
+  return player.activePower === undefined && meter?.[level]?.remaining === 0;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added normal and super power activation from the match roster.
  - Power controls now show availability, loading state, tooltips, and accessible meter information.
  - Added support for sending power activation commands and reporting insufficient charge.
  - Roster entries now display currently active powers.

- **Bug Fixes**
  - Invalid power activation attempts now return clear client errors.

- **Tests**
  - Added coverage for activation eligibility, command handling, power thresholds, and insufficient charge scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->