### PR TITLE
Implement delete unit action

### DIFF
--- a/crates/awbrn-client/src/features/event_bus.rs
+++ b/crates/awbrn-client/src/features/event_bus.rs
@@ -227,6 +227,7 @@ pub enum UnitOrder {
         #[cfg_attr(target_family = "wasm", tsify(type = "{ x: number; y: number }"))]
         position: Position,
     },
+    Delete,
 }
 
 /// The destination menu implied by the current proposal.
@@ -271,6 +272,15 @@ pub struct UnloadCommandRequested {
     pub cargo_id: u32,
     #[cfg_attr(target_family = "wasm", tsify(type = "{ x: number; y: number }"))]
     pub position: Position,
+}
+
+/// A voluntary unit-removal intent chosen on the live board.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(target_family = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteUnitCommandRequested {
+    pub unit_id: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/awbrn-client/src/features/mod.rs
+++ b/crates/awbrn-client/src/features/mod.rs
@@ -9,11 +9,11 @@ pub mod weather;
 pub use awbrn_game::world::{CurrentWeather, FriendlyFactions, ViewerVisibility};
 pub use camera::CameraScale;
 pub use event_bus::{
-    EventSink, HoveredCargoUnit, HoveredTile, HoveredUnit, MapDimensions, MoveCommandRequested,
-    NewDay, PlayerRosterEntry, PlayerRosterSnapshot, PlayerRosterStats, PostMoveAction,
-    ProductionOption, ProductionOptionsChanged, ProductionSite, ReplayLoaded, ReplayLoadedPlayer,
-    TileHoverChanged, TileSelected, UnitActionOption, UnitActionsChanged, UnitBuilt, UnitMoved,
-    UnitOrder, UnloadCommandRequested,
+    DeleteUnitCommandRequested, EventSink, HoveredCargoUnit, HoveredTile, HoveredUnit,
+    MapDimensions, MoveCommandRequested, NewDay, PlayerRosterEntry, PlayerRosterSnapshot,
+    PlayerRosterStats, PostMoveAction, ProductionOption, ProductionOptionsChanged, ProductionSite,
+    ReplayLoaded, ReplayLoadedPlayer, TileHoverChanged, TileSelected, UnitActionOption,
+    UnitActionsChanged, UnitBuilt, UnitMoved, UnitOrder, UnloadCommandRequested,
 };
 pub use input::{SelectedTile, TileCursor};
 

--- a/crates/awbrn-client/src/lib.rs
+++ b/crates/awbrn-client/src/lib.rs
@@ -10,11 +10,11 @@ mod ui_atlas;
 
 pub use awbrn_plugin::AwbrnPlugin;
 pub use features::event_bus::{
-    EventSink, HoveredCargoUnit, HoveredTile, HoveredUnit, MapDimensions, MoveCommandRequested,
-    NewDay, PlayerRosterEntry, PlayerRosterSnapshot, PlayerRosterStats, PostMoveAction,
-    ProductionOption, ProductionOptionsChanged, ProductionSite, ReplayLoaded, ReplayLoadedPlayer,
-    TileHoverChanged, TileSelected, UnitActionOption, UnitActionsChanged, UnitBuilt, UnitMoved,
-    UnitOrder, UnloadCommandRequested,
+    DeleteUnitCommandRequested, EventSink, HoveredCargoUnit, HoveredTile, HoveredUnit,
+    MapDimensions, MoveCommandRequested, NewDay, PlayerRosterEntry, PlayerRosterSnapshot,
+    PlayerRosterStats, PostMoveAction, ProductionOption, ProductionOptionsChanged, ProductionSite,
+    ReplayLoaded, ReplayLoadedPlayer, TileHoverChanged, TileSelected, UnitActionOption,
+    UnitActionsChanged, UnitBuilt, UnitMoved, UnitOrder, UnloadCommandRequested,
 };
 pub use json_plugin::*;
 pub use loading::{

--- a/crates/awbrn-client/src/modes/play/mod.rs
+++ b/crates/awbrn-client/src/modes/play/mod.rs
@@ -4,8 +4,9 @@ use crate::core::coords::{TILE_SIZE, position_to_world_translation};
 use crate::core::{AppState, GameMode, RenderLayer, SpriteSize};
 use crate::features::camera::{CameraScale, FocusBoardOn};
 use crate::features::event_bus::{
-    EventSink, MoveCommandRequested, PostMoveAction, ProductionOption, ProductionOptionsChanged,
-    ProductionSite, UnitActionOption, UnitActionsChanged, UnitOrder, UnloadCommandRequested,
+    DeleteUnitCommandRequested, EventSink, MoveCommandRequested, PostMoveAction, ProductionOption,
+    ProductionOptionsChanged, ProductionSite, UnitActionOption, UnitActionsChanged, UnitOrder,
+    UnloadCommandRequested,
 };
 use crate::features::input::{
     BoardProjection, DragOwner, PointerGesture, PointerGestureKind, PointerSet, ReturnToTouchFloor,
@@ -209,6 +210,7 @@ pub(crate) struct UnitActionParams<'w> {
 
 #[derive(SystemParam)]
 pub(crate) struct UnitCommandSinks<'w> {
+    delete_unit_command: Option<Res<'w, EventSink<DeleteUnitCommandRequested>>>,
     move_command: Option<Res<'w, EventSink<MoveCommandRequested>>>,
     unload_command: Option<Res<'w, EventSink<UnloadCommandRequested>>>,
 }
@@ -333,7 +335,7 @@ fn observed_unloads_for(
 ///
 /// Most units can stay where they stand, but a teleporter moves whatever enters
 /// it, so a unit that starts on one has no order that keeps it there. Such a
-/// unit can still unload, because the transport does not move to do it.
+/// unit can still unload or delete, because these actions do not move the unit.
 fn can_act_in_place(
     entity: Entity,
     origin: Position,
@@ -343,7 +345,27 @@ fn can_act_in_place(
     let can_stop = field.is_some_and(|field| {
         semantic_position(origin).is_some_and(|position| field.can_stop_at(position))
     });
-    can_stop || !observed_unloads_for(entity, unit_selection).is_empty()
+    can_stop
+        || !observed_unloads_for(entity, unit_selection).is_empty()
+        || observed_can_delete(entity, unit_selection)
+}
+
+fn observed_can_delete(entity: Entity, unit_selection: &PlayUnitSelectionParams<'_, '_>) -> bool {
+    let (Some(observations), Some(viewpoint), Ok(id)) = (
+        unit_selection.observations.as_deref(),
+        unit_selection.viewpoint.as_deref(),
+        unit_selection.unit_ids.get(entity),
+    ) else {
+        return false;
+    };
+    let awbrn_game::replay::ReplayViewpoint::Player(player) = viewpoint else {
+        return false;
+    };
+    let Some(observation) = observations.for_player(*player) else {
+        return false;
+    };
+    awvm::query::observed_can_delete(observation, awvm::semantic::UnitId::new(id.0.as_u32()))
+        .unwrap_or(false)
 }
 
 fn clear_selection_state(selection: &mut PlaySelectionState<'_>) {
@@ -589,7 +611,8 @@ fn selectable_unit_at(
         .then(|| observed_move_field(entity, unit_selection))
         .flatten();
     let can_unload = !observed_unloads_for(entity, unit_selection).is_empty();
-    (field.is_some() || can_unload).then_some((entity, origin, field))
+    let can_delete = observed_can_delete(entity, unit_selection);
+    (field.is_some() || can_unload || can_delete).then_some((entity, origin, field))
 }
 
 pub(crate) fn handle_play_pointer_gestures(
@@ -1126,13 +1149,21 @@ pub(crate) fn clear_invalid_selection(
         return;
     };
 
-    if !unit_is_selectable(
-        *faction,
-        is_active,
-        is_carried,
-        has_cargo,
-        &friendly_factions,
-    ) || map_position.position() != selected_unit.origin
+    let accepted_move_finished = *selection.phase == PlayUiPhase::AwaitingServer
+        && !is_active
+        && committed
+            .0
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.kind == CommittedKind::Move);
+    if accepted_move_finished
+        || !unit_is_selectable(
+            *faction,
+            is_active,
+            is_carried,
+            has_cargo,
+            &friendly_factions,
+        )
+        || map_position.position() != selected_unit.origin
     {
         if *selection.phase == PlayUiPhase::AwaitingServer {
             committed.0 = None;
@@ -1387,6 +1418,7 @@ pub struct CommittedSnapshot {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommittedKind {
+    Delete,
     Move,
     Unload,
 }
@@ -1452,12 +1484,21 @@ pub(crate) fn emit_unit_actions(
 
     // The AWBW unit id and the AWVM unit id are the same number by
     // construction; see `awvm_awbw::command::unit_id`.
+    let semantic_unit_id = awvm::semantic::UnitId::new(unit_id.0.as_u32());
+    let is_in_place = pending.destination == pending.origin;
+    let unloads = if is_in_place {
+        awvm::query::observed_unloads(observation, semantic_unit_id).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let can_delete = is_in_place && observed_can_delete(pending.unit, &unit_selection);
     let available = match awvm::query::observed_actions_at(
         observation,
-        awvm::semantic::UnitId::new(unit_id.0.as_u32()),
+        semantic_unit_id,
         awvm::semantic::Pos::new(x, y),
     ) {
         Ok(available) => available,
+        Err(_) if !unloads.is_empty() || can_delete => awvm::query::ObservedActionSet::default(),
         Err(error) => {
             warn!(
                 "Could not read the orders for unit {}: {error}",
@@ -1467,14 +1508,7 @@ pub(crate) fn emit_unit_actions(
             return;
         }
     };
-
-    let unloads = if pending.destination == pending.origin {
-        awvm::query::observed_unloads(observation, awvm::semantic::UnitId::new(unit_id.0.as_u32()))
-            .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-    let options = build_options(&available, &unloads, pending, &unit_selection);
+    let options = build_options(&available, &unloads, can_delete, pending, &unit_selection);
     if options.is_empty() {
         offered.0.clear();
         close_unit_actions(Some(sink));
@@ -1504,6 +1538,7 @@ pub(crate) fn emit_unit_actions(
 fn build_options(
     available: &awvm::query::ObservedActionSet,
     unloads: &[awvm::query::ObservedUnload],
+    can_delete: bool,
     pending: &PendingMoveDestinationSelection,
     unit_selection: &PlayUnitSelectionParams<'_, '_>,
 ) -> Vec<UnitActionOption> {
@@ -1623,6 +1658,12 @@ fn build_options(
             },
         });
     }
+    if can_delete {
+        options.push(UnitActionOption {
+            name: "Delete".to_string(),
+            action: UnitOrder::Delete,
+        });
+    }
 
     options
 }
@@ -1672,12 +1713,22 @@ pub(crate) fn handle_unit_action_chosen(
         destination: pending.destination,
         attack_intent: pending.attack_intent,
         kind: match &option.action {
+            UnitOrder::Delete => CommittedKind::Delete,
             UnitOrder::Move { .. } => CommittedKind::Move,
             UnitOrder::Unload { .. } => CommittedKind::Unload,
         },
     });
 
     match &option.action {
+        UnitOrder::Delete => {
+            let Some(sink) = command_sinks.delete_unit_command.as_deref() else {
+                committed.0 = None;
+                return;
+            };
+            sink.emit(DeleteUnitCommandRequested {
+                unit_id: unit_id.0.as_u32(),
+            });
+        }
         UnitOrder::Move { action } => {
             let Some(sink) = command_sinks.move_command.as_deref() else {
                 committed.0 = None;
@@ -2309,7 +2360,7 @@ mod tests {
     }
 
     #[test]
-    fn inactive_and_enemy_units_are_not_selectable() {
+    fn spent_and_enemy_units_are_not_selectable() {
         let mut app = play_test_app();
         set_plain_map(&mut app, 5, 5);
         app.world_mut()
@@ -2511,7 +2562,7 @@ mod tests {
     }
 
     #[test]
-    fn clicking_the_tile_of_a_unit_that_cannot_stay_keeps_it_selected() {
+    fn clicking_a_teleporter_unit_offers_delete_when_it_cannot_stay() {
         let mut app = play_test_app();
         set_plain_map(&mut app, 5, 5);
         app.world_mut()
@@ -2534,7 +2585,7 @@ mod tests {
             .resource_mut::<GameMap>()
             .set_terrain(origin, GraphicalTerrain::Teleporter);
 
-        spawn_unit(
+        let unit = spawn_unit(
             &mut app,
             origin,
             awbrn_types::Unit::Infantry,
@@ -2542,14 +2593,32 @@ mod tests {
             true,
             Some(99),
         );
+        app.world_mut()
+            .insert_resource(EventSink::<UnitActionsChanged>::new(|_| {}));
 
         click_tile(&mut app, origin);
         click_tile(&mut app, origin);
 
-        assert_eq!(app.world().resource::<PendingMoveDestination>().0, None);
+        assert_eq!(
+            app.world().resource::<PendingMoveDestination>().0,
+            Some(PendingMoveDestinationSelection {
+                unit,
+                origin,
+                destination: origin,
+                path: vec![origin],
+                attack_intent: None,
+            })
+        );
         assert_eq!(
             *app.world().resource::<PlayUiPhase>(),
-            PlayUiPhase::UnitSelected
+            PlayUiPhase::DestinationSelected
+        );
+        assert!(
+            app.world()
+                .resource::<OfferedActions>()
+                .0
+                .iter()
+                .any(|option| option.action == UnitOrder::Delete)
         );
     }
 
@@ -2736,6 +2805,72 @@ mod tests {
                 cargo_id: 7,
                 position: Position::new(1, 0),
             }]
+        );
+    }
+
+    #[test]
+    fn ready_unit_offers_delete_and_sends_a_standalone_command() {
+        let mut app = play_test_app();
+        set_plain_map(&mut app, 3, 3);
+        app.world_mut()
+            .resource_mut::<FriendlyFactions>()
+            .0
+            .insert(PlayerFaction::OrangeStar);
+        let unit = spawn_unit(
+            &mut app,
+            Position::new(1, 1),
+            awbrn_types::Unit::Infantry,
+            PlayerFaction::OrangeStar,
+            true,
+            Some(99),
+        );
+        app.world_mut()
+            .entity_mut(unit)
+            .insert(AwbwUnitId(awbrn_types::AwbwUnitId::new(42)));
+
+        let menus = Arc::new(Mutex::new(Vec::new()));
+        let menus_by_sink = menus.clone();
+        app.world_mut()
+            .insert_resource(EventSink::<UnitActionsChanged>::new(move |event| {
+                menus_by_sink.lock().unwrap().push(event);
+            }));
+        let commands = Arc::new(Mutex::new(Vec::new()));
+        let commands_by_sink = commands.clone();
+        app.world_mut()
+            .insert_resource(EventSink::<DeleteUnitCommandRequested>::new(move |event| {
+                commands_by_sink.lock().unwrap().push(event);
+            }));
+
+        click_tile(&mut app, Position::new(1, 1));
+        click_tile(&mut app, Position::new(1, 1));
+
+        let delete_index = app
+            .world()
+            .resource::<OfferedActions>()
+            .0
+            .iter()
+            .position(|option| option.action == UnitOrder::Delete)
+            .expect("the current-tile menu must offer deletion");
+        assert!(menus.lock().unwrap().iter().any(|menu| {
+            menu.options
+                .iter()
+                .any(|option| option.action == UnitOrder::Delete)
+        }));
+
+        app.world_mut()
+            .resource_mut::<Messages<UnitActionChosen>>()
+            .write(UnitActionChosen {
+                index: delete_index,
+            });
+        app.update();
+
+        assert_eq!(
+            commands.lock().unwrap().as_slice(),
+            &[DeleteUnitCommandRequested { unit_id: 42 }]
+        );
+        assert_eq!(
+            *app.world().resource::<PlayUiPhase>(),
+            PlayUiPhase::AwaitingServer
         );
     }
 

--- a/crates/awbrn-server/src/awvm_adapter.rs
+++ b/crates/awbrn-server/src/awvm_adapter.rs
@@ -319,6 +319,10 @@ fn commands(
             level: *level,
         }),
         GameCommand::EndTurn => one(Command::EndTurn { player }),
+        GameCommand::DeleteUnit { unit_id } => one(Command::DeleteUnit {
+            player,
+            unit: command_unit_id(unit_id.0)?,
+        }),
         GameCommand::Unload {
             transport_id,
             cargo_id,

--- a/crates/awbrn-server/src/command.rs
+++ b/crates/awbrn-server/src/command.rs
@@ -35,6 +35,11 @@ pub enum GameCommand {
         #[tsify(type = "{ x: number; y: number }")]
         position: Position,
     },
+    /// Remove one owned unit from the board without compensation.
+    DeleteUnit {
+        #[tsify(type = "number")]
+        unit_id: ServerUnitId,
+    },
     /// Activate the current commander's normal or super power.
     ActivatePower { level: PowerLevel },
     /// End the current player's turn.
@@ -111,6 +116,18 @@ mod tests {
             cmd,
             GameCommand::ActivatePower {
                 level: PowerLevel::Scop
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_delete_unit() {
+        let json = r#"{"type":"deleteUnit","unit_id":9}"#;
+        let command: GameCommand = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            command,
+            GameCommand::DeleteUnit {
+                unit_id: ServerUnitId(9)
             }
         );
     }

--- a/crates/awbrn-server/tests/server.rs
+++ b/crates/awbrn-server/tests/server.rs
@@ -293,6 +293,59 @@ fn create_server_and_spawn_unit() {
 }
 
 #[test]
+fn delete_unit_rejects_an_owned_unit_after_it_acts() {
+    let mut server = GameServer::new(two_player_setup(5, 5)).unwrap();
+    let deleted = server.spawn_unit(
+        Position::new(1, 1),
+        awbrn_types::Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    server.spawn_unit(
+        Position::new(2, 1),
+        awbrn_types::Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+
+    server
+        .submit_command(
+            p1(),
+            action_command(deleted, vec![Position::new(1, 1)], PostMoveAction::Wait),
+        )
+        .unwrap();
+    let error = server
+        .submit_command(p1(), GameCommand::DeleteUnit { unit_id: deleted })
+        .unwrap_err();
+
+    let view = server.player_view(p1()).unwrap();
+    assert_eq!(error, CommandError::UnitAlreadyActed(deleted));
+    assert!(view.units.iter().any(|unit| unit.id == deleted));
+}
+
+#[test]
+fn delete_unit_removes_a_ready_owned_unit() {
+    let mut server = GameServer::new(two_player_setup(5, 5)).unwrap();
+    let deleted = server.spawn_unit(
+        Position::new(1, 1),
+        awbrn_types::Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+    server.spawn_unit(
+        Position::new(2, 1),
+        awbrn_types::Unit::Infantry,
+        PlayerFaction::OrangeStar,
+    );
+
+    let result = server
+        .submit_command(p1(), GameCommand::DeleteUnit { unit_id: deleted })
+        .unwrap();
+
+    let view = server.player_view(p1()).unwrap();
+    assert!(!view.units.iter().any(|unit| unit.id == deleted));
+    let (_, update) = result.updates.iter().find(|(id, _)| *id == p1()).unwrap();
+    assert!(update.units_removed.contains(&deleted));
+}
+
+#[test]
 fn player_view_returns_none_for_unknown_player() {
     let server = GameServer::new(two_player_setup(2, 2)).unwrap();
 

--- a/crates/awbrn-wasm/src/lib.rs
+++ b/crates/awbrn-wasm/src/lib.rs
@@ -1,9 +1,9 @@
 use awbrn_client::{
-    AwbrnPlugin, EventSink, LiveMatchPlayer, MapAssetPathResolver, MapDimensions,
-    MoveCommandRequested, NewDay, PendingGameStart, PendingLiveMatch, PendingLiveTransitions,
-    PendingMatchMap, PlayerRosterSnapshot, ProductionOptionsChanged, ReplayLoaded, ReplayToLoad,
-    StaticAssetPathResolver, TileHoverChanged, TileSelected, UnitActionsChanged, UnitBuilt,
-    UnitMoved, UnloadCommandRequested, core::coords::LogicalPx,
+    AwbrnPlugin, DeleteUnitCommandRequested, EventSink, LiveMatchPlayer, MapAssetPathResolver,
+    MapDimensions, MoveCommandRequested, NewDay, PendingGameStart, PendingLiveMatch,
+    PendingLiveTransitions, PendingMatchMap, PlayerRosterSnapshot, ProductionOptionsChanged,
+    ReplayLoaded, ReplayToLoad, StaticAssetPathResolver, TileHoverChanged, TileSelected,
+    UnitActionsChanged, UnitBuilt, UnitMoved, UnloadCommandRequested, core::coords::LogicalPx,
 };
 use awbrn_map::AwbwMapData;
 use awbrn_types::{AwbwGamePlayerId, PlayerFaction};
@@ -48,6 +48,7 @@ pub enum GameEvent {
     ProductionOptionsChanged(ProductionOptionsChanged),
     MoveCommandRequested(MoveCommandRequested),
     UnloadCommandRequested(UnloadCommandRequested),
+    DeleteUnitCommandRequested(DeleteUnitCommandRequested),
     UnitActionsChanged(UnitActionsChanged),
     MapDimensions(MapDimensions),
     ReplayLoaded(ReplayLoaded),
@@ -220,6 +221,7 @@ impl BevyApp {
             wasm_sink!(ProductionOptionsChanged, ProductionOptionsChanged);
             wasm_sink!(MoveCommandRequested, MoveCommandRequested);
             wasm_sink!(UnloadCommandRequested, UnloadCommandRequested);
+            wasm_sink!(DeleteUnitCommandRequested, DeleteUnitCommandRequested);
             wasm_sink!(UnitActionsChanged, UnitActionsChanged);
             wasm_sink!(MapDimensions, MapDimensions);
             wasm_sink!(ReplayLoaded, ReplayLoaded);

--- a/crates/awvm/src/query.rs
+++ b/crates/awvm/src/query.rs
@@ -578,6 +578,20 @@ pub fn observed_unloads(
     Ok(orders)
 }
 
+/// Whether the recipient may remove `unit` from the board now.
+///
+/// The reducer remains the authority for readiness, ownership, phase, and
+/// board-position checks.
+pub fn observed_can_delete(observation: &Observation, unit: UnitId) -> Result<bool, QueryError> {
+    if !recipient_may_command(observation) {
+        return Ok(false);
+    }
+
+    let state = reify(observation)?;
+    let player = lookup(&state, unit)?.owner.clone();
+    Ok(is_accepted(&state, Command::DeleteUnit { player, unit }))
+}
+
 /// Restate an [`ActionSet`]'s targets as the positions its units occupy.
 ///
 /// A unit named by an action is on the board by construction — the reducer

--- a/crates/awvm/src/transition.rs
+++ b/crates/awvm/src/transition.rs
@@ -7,8 +7,8 @@ use crate::event::{AttackTarget, Event};
 use crate::random::{Entropy, Luck, RandomError, RandomTape, RandomToken, RandomTokenKind};
 use crate::ruleset::{self, Domain, UnitKind};
 use crate::semantic::{
-    Location, Match, Outcome, Phase, PlayerId, Pos, State, TerrainId, Unit, UnitId, UnitKindId,
-    Viewpoint, WeatherKind,
+    KnownReason, Location, Match, Outcome, Phase, PlayerId, Pos, State, TerrainId, Unit, UnitId,
+    UnitKindId, Viewpoint, WeatherKind,
 };
 use crate::violation::Violation;
 
@@ -340,6 +340,46 @@ pub(crate) fn board_position(unit: &Unit) -> Option<Pos> {
     match unit.location {
         Location::Board { position } => Some(position),
         Location::Cargo { .. } => None,
+    }
+}
+
+/// Remove a board unit and any units it carried.
+///
+/// Cargo has no board position of its own, so it cannot outlive its carrier.
+/// The loss is a consequence of losing the carrier, not a separate strike, so
+/// the cargo removals carry `carrier-lost` whatever took the carrier out.
+/// Cargo is reported in slot order to keep the event sequence deterministic.
+pub(crate) fn remove_unit_and_cargo(
+    state: &mut State,
+    unit: UnitId,
+    reason: KnownReason,
+    events: &mut Vec<Event>,
+) {
+    let mut cargo: Vec<_> = state
+        .units
+        .iter()
+        .filter_map(|candidate| match candidate.location {
+            Location::Cargo { transport, slot } if transport == unit => Some((slot, candidate.id)),
+            _ => None,
+        })
+        .collect();
+    cargo.sort();
+    state.units.retain(|candidate| {
+        candidate.id != unit
+            && !matches!(
+                candidate.location,
+                Location::Cargo { transport, .. } if transport == unit
+            )
+    });
+    events.push(Event::UnitRemoved {
+        unit,
+        reason: reason.into(),
+    });
+    for (_, cargo) in cargo {
+        events.push(Event::UnitRemoved {
+            unit: cargo,
+            reason: KnownReason::CarrierLost.into(),
+        });
     }
 }
 

--- a/crates/awvm/src/transition/attack.rs
+++ b/crates/awvm/src/transition/attack.rs
@@ -860,7 +860,7 @@ fn resolve_exchange(
                 unreachable!("an attacking unit is on the board");
             };
             movement::reset_capture_on_removal(&mut next, position, &mut events);
-            remove_combatant_and_cargo(
+            remove_unit_and_cargo(
                 &mut next,
                 attacker.id,
                 KnownReason::CombatCounter,
@@ -876,7 +876,7 @@ fn resolve_exchange(
             unreachable!("a defending unit is on the board");
         };
         movement::reset_capture_on_removal(&mut next, position, &mut events);
-        remove_combatant_and_cargo(&mut next, defender.id, KnownReason::Combat, &mut events);
+        remove_unit_and_cargo(&mut next, defender.id, KnownReason::Combat, &mut events);
     }
     if !attacker_removed {
         spend_attacker(&mut next, &mut events, attacker.id);
@@ -946,7 +946,7 @@ fn resolve_counter_first(
             unreachable!("an attacking unit is on the board");
         };
         movement::reset_capture_on_removal(&mut next, position, &mut events);
-        remove_combatant_and_cargo(
+        remove_unit_and_cargo(
             &mut next,
             attacker.id,
             KnownReason::CombatCounter,
@@ -978,7 +978,7 @@ fn resolve_counter_first(
             unreachable!("a defending unit is on the board");
         };
         movement::reset_capture_on_removal(&mut next, position, &mut events);
-        remove_combatant_and_cargo(&mut next, defender.id, KnownReason::Combat, &mut events);
+        remove_unit_and_cargo(&mut next, defender.id, KnownReason::Combat, &mut events);
     } else {
         let defender_index = next
             .units
@@ -995,44 +995,6 @@ fn resolve_counter_first(
         events,
         random_consumed: draws.drawn(),
     })
-}
-
-/// Remove a destroyed board unit and any units it carried.
-///
-/// Cargo loss is a consequence of losing the carrier, not another combat
-/// strike, so it emits removal facts but earns no combat power charge.
-fn remove_combatant_and_cargo(
-    next: &mut State,
-    unit: UnitId,
-    reason: KnownReason,
-    events: &mut Vec<Event>,
-) {
-    let mut cargo: Vec<_> = next
-        .units
-        .iter()
-        .filter_map(|candidate| match candidate.location {
-            Location::Cargo { transport, slot } if transport == unit => Some((slot, candidate.id)),
-            _ => None,
-        })
-        .collect();
-    cargo.sort();
-    next.units.retain(|candidate| {
-        candidate.id != unit
-            && !matches!(
-                candidate.location,
-                Location::Cargo { transport, .. } if transport == unit
-            )
-    });
-    events.push(Event::UnitRemoved {
-        unit,
-        reason: reason.into(),
-    });
-    for (_, cargo) in cargo {
-        events.push(Event::UnitRemoved {
-            unit: cargo,
-            reason: KnownReason::CarrierLost.into(),
-        });
-    }
 }
 
 /// Mark the acting unit spent. Both exchange orders end here, and both reach it

--- a/crates/awvm/src/transition/special.rs
+++ b/crates/awvm/src/transition/special.rs
@@ -10,7 +10,9 @@ use super::*;
 use crate::commander::AreaStrikePolicy;
 use crate::event::Event;
 use crate::ruleset::{MISSILE_SILO_STRIKE, UNIT_EXPLOSION, UnitKind};
-use crate::semantic::{AwbwVisibility, KnownReason, Pos, Silo, UnitId, VictoryReason, Visibility};
+use crate::semantic::{
+    AwbwVisibility, KnownReason, Pos, Silo, UnitAction, UnitId, VictoryReason, Visibility,
+};
 use crate::violation::{Action, Violation};
 
 pub(crate) fn execute_move_launch(
@@ -230,6 +232,9 @@ pub(crate) fn execute_delete_unit(
     }
     let position = board_position(unit)
         .ok_or_else(|| violation(Violation::UnitNotOnBoard { unit: unit_id }))?;
+    if unit.action != UnitAction::Ready {
+        return Err(violation(Violation::UnitAlreadyActed { unit: unit_id }));
+    }
 
     let mut next = state.clone();
     let mut events = Vec::new();
@@ -246,11 +251,7 @@ pub(crate) fn execute_delete_unit(
             to: 20,
         });
     }
-    next.units.remove(unit_index);
-    events.push(Event::UnitRemoved {
-        unit: unit_id,
-        reason: KnownReason::Delete.into(),
-    });
+    remove_unit_and_cargo(&mut next, unit_id, KnownReason::Delete, &mut events);
     if !next.units.iter().any(|unit| unit.owner == player) {
         eliminate_player(
             &mut next,

--- a/crates/awvm/src/transition/turn.rs
+++ b/crates/awvm/src/transition/turn.rs
@@ -731,34 +731,7 @@ fn crash_out_of_fuel(next: &mut State, incoming: &Incoming, events: &mut Vec<Eve
         if !next.units.contains(unit_id) {
             continue;
         }
-        let mut cargo: Vec<_> = next
-            .units
-            .iter()
-            .filter_map(|unit| match &unit.location {
-                Location::Cargo { transport, slot } if transport == &unit_id => {
-                    Some((*slot, unit.id))
-                }
-                _ => None,
-            })
-            .collect();
-        cargo.sort();
-        next.units.retain(|unit| {
-            unit.id != unit_id
-                && !matches!(
-                    &unit.location,
-                    Location::Cargo { transport, .. } if transport == &unit_id
-                )
-        });
-        events.push(Event::UnitRemoved {
-            unit: unit_id,
-            reason: KnownReason::FuelDepleted.into(),
-        });
-        for (_, cargo_id) in cargo {
-            events.push(Event::UnitRemoved {
-                unit: cargo_id,
-                reason: KnownReason::CarrierLost.into(),
-            });
-        }
+        remove_unit_and_cargo(next, unit_id, KnownReason::FuelDepleted, events);
     }
     removed_units
 }

--- a/crates/awvm/tests/goldens/observations.txt
+++ b/crates/awvm/tests/goldens/observations.txt
@@ -231,8 +231,9 @@ a3e8364c34a96b44  obs=2 ev=0  concealment/reveal-already-exposed-rejected.json
 858a61c9c7165815  obs=2 ev=2  concealment/stealth-hides-in-place.json
 daf97ae6453d44a0  obs=2 ev=2  concealment/sub-dives.json
 98a74d44f546ce2e  obs=2 ev=2  concealment/sub-surfaces.json
+675a219075bd0d08  obs=4 ev=3  delete/delete-loaded-transport.json
 02d79c6f03bb1b08  obs=4 ev=4  delete/delete-unit-capture-reset.json
-0277d369e97a4fbc  obs=6 ev=0  delete/delete-unit-validation.json
+92938d9c47a6932a  obs=8 ev=0  delete/delete-unit-validation.json
 b91180873b3079aa  obs=6 ev=27  elimination/hq-capture-cascade-transfers.json
 d0d9210a97b96394  obs=6 ev=44  elimination/resign-cascade-continues.json
 13da93802601e072  obs=4 ev=8  elimination/resign-ends-match.json
@@ -285,7 +286,7 @@ a667b0972784b891  obs=2 ev=2  production/lab-unit-owned-lab.json
 744463c9bfc742fc  obs=2 ev=0  production/produce-occupied-facility.json
 cfcb3acc62abb3d9  obs=2 ev=0  production/produce-wrong-domain.json
 d5db25691c977b55  obs=2 ev=0  production/unit-limit-counts-cargo.json
-d7b58f025f91fe6f  obs=15 ev=13  production/unit-limit-owner-scope.json
+ab592403b54dd65b  obs=15 ev=13  production/unit-limit-owner-scope.json
 1338c4f1a4fb6914  obs=2 ev=4  repair/black-boat-repairs-black-boat.json
 b126dd2b2592acd3  obs=2 ev=2  repair/repair-full-hp-resupply-only.json
 f7e64ddcbee4466b  obs=2 ev=0  repair/repair-non-black-boat-rejected.json

--- a/spec/fixtures/delete/delete-loaded-transport.json
+++ b/spec/fixtures/delete/delete-loaded-transport.json
@@ -1,0 +1,202 @@
+{
+  "id": "delete-loaded-transport",
+  "spec_version": "0.1.0",
+  "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+  "feature": "delete-unit-v1",
+  "evidence": { "confidence": "documentation-only" },
+  "initial_state": {
+    "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+    "settings": {
+      "fog": false,
+      "income_per_property": 1000,
+      "starting_funds": 0,
+      "powers": "disabled",
+      "tags": false,
+      "weather": "clear",
+      "lab_units": [],
+      "unit_bans": [],
+      "commander_bans": { "lead": [], "backup": [] },
+      "capture_limit": null,
+      "day_limit": null,
+      "unit_limit": null
+    },
+    "board": {
+      "width": 3,
+      "height": 1,
+      "tiles": [[{ "terrain": "plain" }, { "terrain": "plain" }, { "terrain": "plain" }]]
+    },
+    "teams": [
+      { "id": "red-team", "status": "active" },
+      { "id": "blue-team", "status": "active" }
+    ],
+    "players": [
+      {
+        "id": "red",
+        "team": "red-team",
+        "funds": 0,
+        "status": "active",
+        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "power_state": { "type": "none" }
+      },
+      {
+        "id": "blue",
+        "team": "blue-team",
+        "funds": 0,
+        "status": "active",
+        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "power_state": { "type": "none" }
+      }
+    ],
+    "turn": {
+      "day": 1,
+      "active_player": "red",
+      "phase": "unit-action",
+      "order": ["red", "blue"],
+      "position": 0
+    },
+    "weather": { "kind": "clear", "remaining_turns": 0 },
+    "units": [
+      {
+        "id": 0,
+        "kind": "apc",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 70,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [0, 0] }
+      },
+      {
+        "id": 1,
+        "kind": "infantry",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "spent",
+        "concealment": "exposed",
+        "location": { "type": "cargo", "transport": 0, "slot": 0 }
+      },
+      {
+        "id": 2,
+        "kind": "infantry",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [1, 0] }
+      },
+      {
+        "id": 3,
+        "kind": "infantry",
+        "owner": "blue",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [2, 0] }
+      }
+    ],
+    "match": { "status": "active", "draw_offers": [] }
+  },
+  "steps": [
+    {
+      "id": "cargo-dies-with-its-transport",
+      "command": { "type": "delete-unit", "player": "red", "unit": 0 },
+      "random": [],
+      "expect": {
+        "status": "accepted",
+        "state": {
+          "board": {
+            "height": 1,
+            "tiles": [[{ "terrain": "plain" }, { "terrain": "plain" }, { "terrain": "plain" }]],
+            "width": 3
+          },
+          "match": { "draw_offers": [], "status": "active" },
+          "players": [
+            {
+              "commanders": [
+                { "active": true, "id": "neutral", "power_charge": 0, "power_uses": 0 }
+              ],
+              "funds": 0,
+              "id": "red",
+              "power_state": { "type": "none" },
+              "status": "active",
+              "team": "red-team"
+            },
+            {
+              "commanders": [
+                { "active": true, "id": "neutral", "power_charge": 0, "power_uses": 0 }
+              ],
+              "funds": 0,
+              "id": "blue",
+              "power_state": { "type": "none" },
+              "status": "active",
+              "team": "blue-team"
+            }
+          ],
+          "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+          "settings": {
+            "capture_limit": null,
+            "commander_bans": { "backup": [], "lead": [] },
+            "day_limit": null,
+            "fog": false,
+            "income_per_property": 1000,
+            "lab_units": [],
+            "powers": "disabled",
+            "starting_funds": 0,
+            "tags": false,
+            "unit_bans": [],
+            "unit_limit": null,
+            "weather": "clear"
+          },
+          "teams": [
+            { "id": "red-team", "status": "active" },
+            { "id": "blue-team", "status": "active" }
+          ],
+          "turn": {
+            "active_player": "red",
+            "day": 1,
+            "order": ["red", "blue"],
+            "phase": "unit-action",
+            "position": 0
+          },
+          "units": [
+            {
+              "action": "ready",
+              "ammo": 0,
+              "concealment": "exposed",
+              "fuel": 99,
+              "hp": 100,
+              "id": 2,
+              "kind": "infantry",
+              "location": { "position": [1, 0], "type": "board" },
+              "owner": "red"
+            },
+            {
+              "action": "ready",
+              "ammo": 0,
+              "concealment": "exposed",
+              "fuel": 99,
+              "hp": 100,
+              "id": 3,
+              "kind": "infantry",
+              "location": { "position": [2, 0], "type": "board" },
+              "owner": "blue"
+            }
+          ],
+          "weather": { "kind": "clear", "remaining_turns": 0 }
+        },
+        "events": [
+          { "reason": "delete", "type": "unit-removed", "unit": 0 },
+          { "reason": "carrier-lost", "type": "unit-removed", "unit": 1 }
+        ],
+        "random_consumed": 0
+      }
+    }
+  ]
+}

--- a/spec/fixtures/delete/delete-unit-validation.json
+++ b/spec/fixtures/delete/delete-unit-validation.json
@@ -63,7 +63,7 @@
         "hp": 100,
         "fuel": 70,
         "ammo": 0,
-        "action": "ready",
+        "action": "spent",
         "concealment": "exposed",
         "location": { "type": "board", "position": [0, 0] }
       },
@@ -110,6 +110,16 @@
       "expect": {
         "status": "rejected",
         "violation": { "code": "UNIT_NOT_ON_BOARD", "unit": 1 },
+        "random_consumed": 0
+      }
+    },
+    {
+      "id": "reject-spent-unit",
+      "command": { "type": "delete-unit", "player": "red", "unit": 0 },
+      "random": [],
+      "expect": {
+        "status": "rejected",
+        "violation": { "code": "UNIT_ALREADY_ACTED", "unit": 0 },
         "random_consumed": 0
       }
     }

--- a/spec/fixtures/production/unit-limit-owner-scope.json
+++ b/spec/fixtures/production/unit-limit-owner-scope.json
@@ -275,8 +275,8 @@
       }
     },
     {
-      "id": "delete-created-unit",
-      "command": { "type": "delete-unit", "player": "red", "unit": 10 },
+      "id": "delete-ready-unit",
+      "command": { "type": "delete-unit", "player": "red", "unit": 0 },
       "random": [],
       "expect": {
         "status": "accepted",
@@ -349,17 +349,6 @@
           "weather": { "kind": "clear", "remaining_turns": 0 },
           "units": [
             {
-              "id": 0,
-              "kind": "tank",
-              "owner": "red",
-              "hp": 100,
-              "fuel": 70,
-              "ammo": 9,
-              "action": "ready",
-              "concealment": "exposed",
-              "location": { "type": "board", "position": [1, 0] }
-            },
-            {
               "id": 1,
               "kind": "tank",
               "owner": "ally",
@@ -380,12 +369,23 @@
               "action": "ready",
               "concealment": "exposed",
               "location": { "type": "board", "position": [4, 0] }
+            },
+            {
+              "id": 10,
+              "kind": "infantry",
+              "owner": "red",
+              "hp": 100,
+              "fuel": 99,
+              "ammo": 0,
+              "action": "spent",
+              "concealment": "exposed",
+              "location": { "type": "board", "position": [0, 0] }
             }
           ],
           "next_unit_id": 11,
           "match": { "status": "active", "draw_offers": [] }
         },
-        "events": [{ "type": "unit-removed", "unit": 10, "reason": "delete" }],
+        "events": [{ "type": "unit-removed", "unit": 0, "reason": "delete" }],
         "random_consumed": 0
       }
     },
@@ -469,17 +469,6 @@
           "weather": { "kind": "clear", "remaining_turns": 0 },
           "units": [
             {
-              "id": 0,
-              "kind": "tank",
-              "owner": "red",
-              "hp": 100,
-              "fuel": 70,
-              "ammo": 9,
-              "action": "ready",
-              "concealment": "exposed",
-              "location": { "type": "board", "position": [1, 0] }
-            },
-            {
               "id": 1,
               "kind": "tank",
               "owner": "ally",
@@ -500,6 +489,17 @@
               "action": "ready",
               "concealment": "exposed",
               "location": { "type": "board", "position": [4, 0] }
+            },
+            {
+              "id": 10,
+              "kind": "infantry",
+              "owner": "red",
+              "hp": 100,
+              "fuel": 99,
+              "ammo": 0,
+              "action": "spent",
+              "concealment": "exposed",
+              "location": { "type": "board", "position": [0, 0] }
             },
             {
               "id": 11,

--- a/spec/model/events.md
+++ b/spec/model/events.md
@@ -108,11 +108,11 @@ match-completion events follow.
 
 ## `delete-unit`
 
-`delete-unit` removes an owned on-board unit without compensation. If it is
-standing on an incomplete capture, `capture-changed` restores that property to
-20 before `unit-removed`. If the owner has no units remaining, the normal rout
-and match-completion events follow. Deletion grants no power charge and its
-removal is projected through the ordinary fog visibility rules.
+`delete-unit` removes a ready, owned, on-board unit without compensation. If it
+is standing on an incomplete capture, `capture-changed` restores that property
+to 20 before `unit-removed`. If the owner has no units remaining, the normal
+rout and match-completion events follow. Deletion grants no power charge and
+its removal is projected through the ordinary fog visibility rules.
 
 ## Phase boundaries
 

--- a/spec/semantics/delete.md
+++ b/spec/semantics/delete.md
@@ -2,16 +2,20 @@
 
 This revision implements `delete-unit-v1` for AWBW `2026-07-10`.
 
-The command is legal during the active player's unit-action phase for an owned
-unit on the board. It does not require the unit to be ready and provides no
-funds, resources, or other compensation. Cargo units are not eligible because
-they have no board position.
+The command is legal during the active player's unit-action phase for a ready,
+owned unit on the board. It provides no funds, resources, or other
+compensation. Cargo units are not eligible because they have no board position.
 
 If the unit occupies a property with incomplete capture progress, deletion
 restores that progress to 20. The event order is `capture-changed` first when
 needed, then `unit-removed` with reason `delete`. If this removes the owner's
 last unit, normal rout, property, team, and match-completion consequences
 follow the removal.
+
+Deleting a loaded transport also removes its cargo, because cargo has no board
+position to fall back to. Each carried unit gets its own `unit-removed` with
+reason `carrier-lost`, in slot order, after the transport's own removal. This
+matches the loss of a transport in combat.
 
 Deletion is not a unit strike and generates no power charge. Removal event
 projection uses the recipient's before/after visibility; a hidden enemy unit

--- a/web/src/engine/game_runner.ts
+++ b/web/src/engine/game_runner.ts
@@ -7,7 +7,12 @@ import {
 } from "#/canvas_courier/index.ts";
 import type { AwbwMapData } from "#/awbw/schemas.ts";
 import type { ObservedTransition } from "#/wasm/awbrn_server.js";
-import type { GameEvent, MoveCommandRequested, UnloadCommandRequested } from "#/wasm/awbrn_wasm.js";
+import type {
+  DeleteUnitCommandRequested,
+  GameEvent,
+  MoveCommandRequested,
+  UnloadCommandRequested,
+} from "#/wasm/awbrn_wasm.js";
 import type { MatchCommand } from "#/matches/match_protocol.ts";
 import type { LiveMatchPlayer } from "./worker_module";
 import { gameAssetConfig } from "./asset_manifest";
@@ -178,6 +183,10 @@ export class GameRunner implements CanvasCourierController {
         this.handleUnloadCommandRequest(event);
         break;
       }
+      case "DeleteUnitCommandRequested": {
+        this.handleDeleteUnitCommandRequest(event);
+        break;
+      }
       case "UnitActionsChanged": {
         useGameStore
           .getState()
@@ -217,6 +226,17 @@ export class GameRunner implements CanvasCourierController {
       transport_id: request.transportId,
       cargo_id: request.cargoId,
       position: request.position,
+    });
+  }
+
+  private handleDeleteUnitCommandRequest(request: DeleteUnitCommandRequested): void {
+    if (!this.liveCommandHandler) {
+      console.error("GameRunner received a delete-unit command without a live command handler");
+      return;
+    }
+    this.liveCommandHandler({
+      type: "deleteUnit",
+      unit_id: request.unitId,
     });
   }
 

--- a/web/src/matches/components/BoardMenu.tsx
+++ b/web/src/matches/components/BoardMenu.tsx
@@ -1,7 +1,7 @@
 import { spacingDefaults } from "@astryxdesign/core";
 import { Button } from "#/ui/Button.tsx";
 import { Dialog } from "@astryxdesign/core/Dialog";
-import { HStack, VStack } from "@astryxdesign/core/Stack";
+import { VStack } from "@astryxdesign/core/Stack";
 import * as stylex from "@stylexjs/stylex";
 import {
   useCallback,
@@ -37,6 +37,14 @@ export interface BoardMenuShellProps {
   /** Hands the keyboard back to the board once the menu has closed. */
   onRestoreFocus: () => void;
   presentation: BoardMenuPresentation;
+  /**
+   * What the sheet offers at the bottom edge, when the default way out is not
+   * the only command that belongs in thumb reach. A menu that asks a question
+   * answers it here, because a second Cancel below the answers is the sheet
+   * disagreeing with itself. The node carries its own padding and rules: a
+   * footer that follows an empty body needs no divider of its own.
+   */
+  footer?: ReactNode;
   /**
    * How wide the board-anchored menu is drawn. It sits over the tile the player
    * is deciding about, so each menu asks for the width its own content needs
@@ -166,7 +174,7 @@ function BoardAnchoredMenu({
  * than leaving two live surfaces, and the sheet keeps the phone's own dismissal
  * habits: press outside, press Cancel, or send Escape from a keyboard.
  */
-function MenuSheet({ children, label, onDismiss, onRestoreFocus }: BoardMenuShellProps) {
+function MenuSheet({ children, footer, label, onDismiss, onRestoreFocus }: BoardMenuShellProps) {
   const handleOpenChange = useCallback(
     (isOpen: boolean) => {
       if (!isOpen) onDismiss();
@@ -190,15 +198,17 @@ function MenuSheet({ children, label, onDismiss, onRestoreFocus }: BoardMenuShel
           focus ring nobody asked for the moment the sheet opens. */}
       <MenuKeyboardScope
         footer={
-          <HStack gap={0} paddingBlock={3} paddingInline={3} xstyle={styles.sheetFooter}>
-            <Button
-              clickAction={onDismiss}
-              label="Cancel"
-              size="lg"
-              variant="secondary"
-              width="100%"
-            />
-          </HStack>
+          footer ?? (
+            <VStack gap={0} paddingBlock={3} paddingInline={3} xstyle={styles.sheetFooter}>
+              <Button
+                clickAction={onDismiss}
+                label="Cancel"
+                size="lg"
+                variant="secondary"
+                width="100%"
+              />
+            </VStack>
+          )
         }
         onDismiss={onDismiss}
         onRestoreFocus={onRestoreFocus}

--- a/web/src/matches/components/UnitActionMenu.tsx
+++ b/web/src/matches/components/UnitActionMenu.tsx
@@ -1,11 +1,13 @@
 import { HStack, VStack } from "@astryxdesign/core/Stack";
 import { Text } from "@astryxdesign/core/Text";
 import * as stylex from "@stylexjs/stylex";
+import { useCallback, useState } from "react";
 import {
   BoardMenuShell,
   boardMenuStyles,
   type BoardMenuPresentation,
 } from "#/matches/components/BoardMenu.tsx";
+import { Button } from "#/ui/Button.tsx";
 import type { UnitActionOption } from "#/wasm/awbrn_wasm.js";
 
 interface UnitActionMenuProps {
@@ -48,9 +50,64 @@ export function UnitActionMenu({
   preselected,
   presentation,
 }: UnitActionMenuProps) {
+  // Which order is waiting on a second press, if any. It is held by identity
+  // rather than by index: the engine may re-offer the orders while the question
+  // is on screen, and a remembered index would then commit whatever moved into
+  // that row.
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+  const handleChoose = useCallback(
+    (index: number) => {
+      const option = options[index];
+      if (option && needsConfirmation(option)) {
+        setPendingKey(rowKey(option));
+        return;
+      }
+      onChoose(index);
+    },
+    [onChoose, options],
+  );
+
+  const pendingIndex =
+    pendingKey === null ? -1 : options.findIndex((o) => rowKey(o) === pendingKey);
+  const pending = pendingIndex === -1 ? undefined : options[pendingIndex];
+
+  const cancelConfirmation = useCallback(() => setPendingKey(null), []);
+  const confirmPending = useCallback(() => {
+    if (isEnabled && pendingIndex !== -1) onChoose(pendingIndex);
+  }, [isEnabled, onChoose, pendingIndex]);
+
   return (
     <BoardMenuShell
       anchor={anchor}
+      // The sheet answers its own question at the bottom edge: the commit, then
+      // the way back to the orders. The stock Cancel would dismiss the whole
+      // menu and lose the move the player already planned. The header rule
+      // already divides these from what is above them, so the footer carries no
+      // rule of its own here.
+      footer={
+        pending ? (
+          <VStack gap={2} paddingBlock={3} paddingInline={3}>
+            <Button
+              clickAction={confirmPending}
+              isDisabled={!isEnabled}
+              label={pending.name}
+              size="lg"
+              variant="destructive"
+              width="100%"
+              xstyle={styles.key}
+            />
+            <Button
+              clickAction={cancelConfirmation}
+              label="Cancel"
+              size="lg"
+              variant="secondary"
+              width="100%"
+              xstyle={styles.key}
+            />
+          </VStack>
+        ) : undefined
+      }
       label={`Orders at ${destination.x}, ${destination.y}`}
       onDismiss={onDismiss}
       inlineSize="var(--size-action-menu)"
@@ -68,27 +125,37 @@ export function UnitActionMenu({
             xstyle={boardMenuStyles.header}
           >
             <Text type="label" xstyle={styles.heading}>
-              Orders
+              {pending ? pending.name : "Orders"}
             </Text>
             <Text type="label" xstyle={styles.coordinate}>
               {destination.x}, {destination.y}
             </Text>
           </HStack>
 
-          <VStack gap={0} xstyle={boardMenuStyles.list}>
-            {options.map((option, index) => (
-              <OrderRow
-                index={index}
-                isEnabled={isEnabled}
-                isPreselected={index === preselected}
-                key={`${option.name}-${orderKey(option)}`}
-                onChoose={onChoose}
-                option={option}
-                spriteScale={spriteScale}
-                title={disabledReason}
-              />
-            ))}
-          </VStack>
+          {pending ? (
+            <ConfirmOrder
+              isEnabled={isEnabled}
+              onCancel={cancelConfirmation}
+              onConfirm={confirmPending}
+              option={pending}
+              presentation={presentation}
+            />
+          ) : (
+            <VStack gap={0} xstyle={boardMenuStyles.list}>
+              {options.map((option, index) => (
+                <OrderRow
+                  index={index}
+                  isEnabled={isEnabled}
+                  isPreselected={index === preselected}
+                  key={rowKey(option)}
+                  onChoose={handleChoose}
+                  option={option}
+                  spriteScale={spriteScale}
+                  title={disabledReason}
+                />
+              ))}
+            </VStack>
+          )}
 
           {isEnabled || !disabledReason ? null : (
             <VStack gap={0} paddingBlock={2} paddingInline={3} xstyle={boardMenuStyles.notice}>
@@ -100,6 +167,84 @@ export function UnitActionMenu({
         </VStack>
       )}
     </BoardMenuShell>
+  );
+}
+
+/**
+ * Orders the menu asks about twice.
+ *
+ * Everything else a unit can do is either reversible or ends in a unit still
+ * standing on the board. Delete is the one order whose result cannot be
+ * reconsidered — and if it takes the owner's last unit, it ends the match — so
+ * it is the one order that costs a second press.
+ */
+function needsConfirmation(option: UnitActionOption): boolean {
+  return option.action.type === "delete";
+}
+
+/**
+ * The second press: the way out and the way through.
+ *
+ * It carries no warning. The header names the order, the key that commits it is
+ * the one red key in the system, and a menu that asks again is already saying
+ * the order is final; a sentence repeating that is a sentence a player learns
+ * to skip. The one thing delete does that a player cannot see is take a
+ * transport's cargo with it, and the order does not say whether this unit is
+ * loaded, so that warning waits for an order that does rather than being shown
+ * on every delete until it stops being read.
+ *
+ * It replaces the list inside the same menu rather than opening a window over
+ * it, so the board menu stays one object under the cursor and the sheet stays
+ * one sheet under the thumb. The two presentations part company on where the
+ * answers go: the board keeps them as menu keys under the cursor, and the sheet
+ * hands them to its own footer, where a thumb already expects the commands and
+ * where the sheet would otherwise offer a second Cancel of its own.
+ */
+function ConfirmOrder({
+  isEnabled,
+  onCancel,
+  onConfirm,
+  option,
+  presentation,
+}: {
+  isEnabled: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  option: UnitActionOption;
+  presentation: BoardMenuPresentation;
+}) {
+  if (presentation === "sheet") return null;
+
+  return (
+    <VStack gap={0} xstyle={boardMenuStyles.list}>
+      <button
+        // The board menu carries a cursor, and it opens on the harmless answer,
+        // so the key that committed nothing a moment ago still commits nothing.
+        autoFocus
+        onClick={onCancel}
+        onPointerEnter={(event) => event.currentTarget.focus({ preventScroll: true })}
+        type="button"
+        // These keys stand where the orders stood, in a frame that did not
+        // change size, so they are the same key. A row that grew on the second
+        // press would read as the menu moving under the player.
+        {...stylex.props(boardMenuStyles.row, styles.row)}
+      >
+        <Text color="inherit" type="inherit" xstyle={boardMenuStyles.rowName}>
+          Cancel
+        </Text>
+      </button>
+      <button
+        disabled={!isEnabled}
+        onClick={onConfirm}
+        onPointerEnter={(event) => event.currentTarget.focus({ preventScroll: true })}
+        type="button"
+        {...stylex.props(boardMenuStyles.row, styles.row, styles.rowCommit)}
+      >
+        <Text color="inherit" type="inherit" xstyle={boardMenuStyles.rowName}>
+          {option.name}
+        </Text>
+      </button>
+    </VStack>
   );
 }
 
@@ -130,7 +275,8 @@ function OrderRow({
   const target =
     option.action.type === "unload"
       ? option.action.position
-      : option.action.action.type === "attack" || option.action.action.type === "launch"
+      : option.action.type === "move" &&
+          (option.action.action.type === "attack" || option.action.action.type === "launch")
         ? option.action.action.target
         : null;
 
@@ -150,10 +296,14 @@ function OrderRow({
         boardMenuStyles.row,
         styles.row,
         spriteScale === 2 && styles.rowSpacious,
+        needsConfirmation(option) && styles.rowDestructive,
+        needsConfirmation(option) && styles.rowSeparated,
         !isEnabled && boardMenuStyles.rowInert,
       )}
     >
-      <span {...stylex.props(boardMenuStyles.rowName)}>{option.name}</span>
+      <Text color="inherit" type="inherit" xstyle={boardMenuStyles.rowName}>
+        {option.name}
+      </Text>
       {target ? (
         <span {...stylex.props(styles.target)}>
           {target.x}, {target.y}
@@ -163,6 +313,11 @@ function OrderRow({
   );
 }
 
+/** What names one row of the menu: the order, and what it acts on. */
+function rowKey(option: UnitActionOption): string {
+  return `${option.name}-${orderKey(option)}`;
+}
+
 /**
  * A stable key for an order.
  *
@@ -170,6 +325,9 @@ function OrderRow({
  * cargo where applicable) to prevent React reusing the wrong row.
  */
 function orderKey(option: UnitActionOption): string {
+  if (option.action.type === "delete") {
+    return "delete";
+  }
   if (option.action.type === "unload") {
     return `unload-${option.action.cargo_id}-${option.action.position.x},${option.action.position.y}`;
   }
@@ -196,6 +354,32 @@ const styles = stylex.create({
   rowSpacious: {
     minBlockSize: "var(--size-action-row-spacious)",
     paddingInline: "var(--spacing-3)",
+  },
+  // An order that destroys something reads in the error color, so it is not
+  // one more word in a list of words. Under the cursor it keeps the orange
+  // fill every other row wears, and the name inverts to stay legible on it.
+  rowDestructive: {
+    color: { default: "var(--color-error)", ":focus": "var(--color-on-accent)" },
+  },
+  // The commit on the confirmation is the one key in the system whose cursor is
+  // not orange. It is the last press before a unit is gone, the screen exists
+  // only to say so, and a key that looks like every other key does not say it.
+  rowCommit: {
+    backgroundColor: { default: "transparent", ":focus": "var(--color-error)" },
+    color: { default: "var(--color-error)", ":focus": "var(--color-on-error)" },
+  },
+  // The stock large button is shorter than a thumb needs, and these two are the
+  // only commands on the sheet.
+  key: {
+    minBlockSize: "var(--size-action-row-spacious)",
+  },
+  // The rule the list draws between rows is soft enough to walk past. This one
+  // is the frame's own rule, so the last order is visibly apart from Wait
+  // rather than the next line under it.
+  rowSeparated: {
+    borderBlockStartWidth: "var(--border-width)",
+    borderBlockStartStyle: "solid",
+    borderBlockStartColor: "var(--color-border-emphasized)",
   },
   heading: {
     color: "var(--color-text-secondary)",

--- a/web/src/ui/Button.tsx
+++ b/web/src/ui/Button.tsx
@@ -3,13 +3,28 @@ import * as stylex from "@stylexjs/stylex";
 
 export type { ButtonProps } from "@astryxdesign/core/Button";
 
-/** Button with the AWBRN pressed and disabled states. */
-export function Button({ isDisabled, xstyle, ...props }: ButtonProps) {
+/**
+ * Button with the AWBRN outline, depth, pressed state, and disabled state.
+ *
+ * Every command in this system is a key on a menu: a 2px ink outline and a
+ * shadow it goes down into when pressed. The theme states that, but the
+ * component library flattens buttons at a specificity no theme layer can reach,
+ * so the outline and the shadow are stated again here, where they win. Ghost is
+ * the one command that is not a raised key and keeps the flat treatment.
+ */
+export function Button({ isDisabled, variant, xstyle, ...props }: ButtonProps) {
   return (
     <AstryxButton
       {...props}
       isDisabled={isDisabled}
-      xstyle={[styles.root, styles.reducedMotion, isDisabled && styles.disabled, xstyle]}
+      variant={variant}
+      xstyle={[
+        styles.root,
+        variant !== "ghost" && styles.raised,
+        styles.reducedMotion,
+        isDisabled && styles.disabled,
+        xstyle,
+      ]}
     />
   );
 }
@@ -40,6 +55,21 @@ const styles = stylex.create({
     transitionDuration: {
       default: null,
       ":active": "var(--duration-fast-min)",
+    },
+  },
+  // The key itself: the outline the system gives every control, and the shadow
+  // the press goes down into.
+  raised: {
+    borderWidth: "var(--border-width)",
+    borderStyle: "solid",
+    borderColor: {
+      default: "var(--color-border-emphasized)",
+      ":disabled": "var(--color-border-disabled)",
+    },
+    boxShadow: {
+      default: "var(--shadow-low)",
+      ":active": "none",
+      ":disabled": "none",
     },
   },
   reducedMotion: {


### PR DESCRIPTION
  - The UI offers Delete only for ready units.
  - The server rejects deletion after moving, attacking, waiting, or any other action with UnitAlreadyActed.
  - Newly produced units cannot be deleted during the turn they were built.
  - The normative spec and conformance fixtures now reflect this rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete eligible, ready units during play.
  * Added a confirmation step before deleting a unit.
  * Deleting a transport also removes its carried cargo.
  * Delete requests are now available through the web client and game event system.

* **Bug Fixes**
  * Prevented deletion of units that have already acted.
  * Standardized unit and cargo removal reporting across gameplay scenarios.

* **Documentation**
  * Updated deletion rules and examples to reflect readiness requirements and cargo handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->