### PR TITLE
Report properties and com towers on the roster snapshot

### DIFF
--- a/assets/data/ui_atlas.json
+++ b/assets/data/ui_atlas.json
@@ -1,13 +1,13 @@
 {
   "size": {
-    "width": 159,
-    "height": 159
+    "width": 160,
+    "height": 160
   },
   "sprites": [
     {
       "name": "Ammo.png",
-      "x": 121,
-      "y": 150,
+      "x": 140,
+      "y": 31,
       "width": 7,
       "height": 5
     },
@@ -34,15 +34,29 @@
     },
     {
       "name": "BuildingsCaptured.png",
-      "x": 144,
-      "y": 104,
+      "x": 148,
+      "y": 140,
       "width": 11,
       "height": 11
     },
     {
+      "name": "CO/Power.png",
+      "x": 128,
+      "y": 104,
+      "width": 14,
+      "height": 14
+    },
+    {
+      "name": "CO/SuperPower.png",
+      "x": 144,
+      "y": 104,
+      "width": 14,
+      "height": 14
+    },
+    {
       "name": "Capturing.png",
-      "x": 136,
-      "y": 78,
+      "x": 151,
+      "y": 20,
       "width": 8,
       "height": 8
     },
@@ -56,14 +70,14 @@
     {
       "name": "Coin.png",
       "x": 148,
-      "y": 140,
+      "y": 122,
       "width": 10,
       "height": 10
     },
     {
       "name": "Dive.png",
-      "x": 147,
-      "y": 67,
+      "x": 102,
+      "y": 150,
       "width": 8,
       "height": 8
     },
@@ -97,113 +111,113 @@
     },
     {
       "name": "Fuel.png",
-      "x": 112,
+      "x": 84,
       "y": 150,
       "width": 7,
       "height": 8
     },
     {
       "name": "HP.png",
-      "x": 149,
-      "y": 20,
+      "x": 152,
+      "y": 77,
       "width": 7,
       "height": 6
     },
     {
       "name": "HasCargo.png",
-      "x": 147,
-      "y": 77,
+      "x": 112,
+      "y": 150,
       "width": 8,
       "height": 8
     },
     {
       "name": "Healthv2/0.png",
-      "x": 74,
-      "y": 150,
+      "x": 151,
+      "y": 30,
       "width": 8,
       "height": 7
     },
     {
       "name": "Healthv2/1.png",
-      "x": 84,
-      "y": 150,
-      "width": 8,
-      "height": 7
-    },
-    {
-      "name": "Healthv2/2.png",
       "x": 46,
       "y": 150,
       "width": 8,
       "height": 7
     },
     {
-      "name": "Healthv2/3.png",
+      "name": "Healthv2/2.png",
       "x": 56,
       "y": 150,
       "width": 8,
       "height": 7
     },
     {
-      "name": "Healthv2/4.png",
+      "name": "Healthv2/3.png",
       "x": 1,
       "y": 151,
       "width": 8,
       "height": 7
     },
     {
-      "name": "Healthv2/5.png",
+      "name": "Healthv2/4.png",
       "x": 11,
       "y": 151,
       "width": 8,
       "height": 7
     },
     {
-      "name": "Healthv2/6.png",
+      "name": "Healthv2/5.png",
       "x": 21,
       "y": 151,
       "width": 8,
       "height": 7
     },
     {
-      "name": "Healthv2/7.png",
+      "name": "Healthv2/6.png",
       "x": 31,
       "y": 151,
       "width": 8,
       "height": 7
     },
     {
+      "name": "Healthv2/7.png",
+      "x": 135,
+      "y": 1,
+      "width": 8,
+      "height": 7
+    },
+    {
       "name": "Healthv2/8.png",
-      "x": 129,
-      "y": 20,
+      "x": 135,
+      "y": 10,
       "width": 8,
       "height": 7
     },
     {
       "name": "Healthv2/9.png",
-      "x": 129,
-      "y": 29,
+      "x": 145,
+      "y": 1,
       "width": 8,
       "height": 7
     },
     {
       "name": "Healthv2/Question.png",
-      "x": 139,
-      "y": 20,
+      "x": 145,
+      "y": 10,
       "width": 8,
       "height": 7
     },
     {
       "name": "LowAmmo.png",
-      "x": 139,
-      "y": 29,
+      "x": 93,
+      "y": 150,
       "width": 7,
       "height": 8
     },
     {
       "name": "LowFuel.png",
-      "x": 148,
-      "y": 29,
+      "x": 152,
+      "y": 67,
       "width": 7,
       "height": 8
     },
@@ -223,7 +237,7 @@
     },
     {
       "name": "Stun.png",
-      "x": 102,
+      "x": 74,
       "y": 150,
       "width": 8,
       "height": 8
@@ -293,22 +307,22 @@
     },
     {
       "name": "TerrainStar.png",
-      "x": 136,
-      "y": 67,
+      "x": 140,
+      "y": 20,
       "width": 9,
       "height": 9
     },
     {
       "name": "commtowericon.png",
-      "x": 148,
-      "y": 122,
+      "x": 129,
+      "y": 20,
       "width": 9,
       "height": 11
     },
     {
       "name": "fire.png",
-      "x": 128,
-      "y": 104,
+      "x": 136,
+      "y": 67,
       "width": 14,
       "height": 13
     },

--- a/crates/awbrn-client/src/features/event_bus.rs
+++ b/crates/awbrn-client/src/features/event_bus.rs
@@ -434,6 +434,13 @@ pub struct PlayerRosterStats {
     pub unit_count: Option<u32>,
     pub unit_value: Option<u32>,
     pub income: Option<u32>,
+    /// Every capturable tile the army holds, com towers included. It is the
+    /// figure `income` is derived from, reported alongside it because a
+    /// commander who reads the property count reads this and not the money.
+    pub properties: Option<u32>,
+    /// How many of those properties are com towers, which is the one property
+    /// kind that changes what a unit deals and takes.
+    pub com_towers: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/awbrn-client/src/features/player_roster.rs
+++ b/crates/awbrn-client/src/features/player_roster.rs
@@ -6,7 +6,9 @@ use crate::loading::LiveMatchPlayer;
 use awbrn_content::{CoPortraitMetadata, co_portrait_by_awbw_id, co_portraits};
 use awbrn_game::replay::{AwbwUnitId, ReplayState};
 use awbrn_game::world::{Faction, GraphicalHp, TerrainTile, Unit, ViewerVisibility};
-use awbrn_types::{Faction as TerrainFaction, GraphicalTerrain, PlayerFaction, UnitExt};
+use awbrn_types::{
+    Faction as TerrainFaction, GraphicalTerrain, PlayerFaction, PropertyKind, UnitExt,
+};
 use awbw_replay::AwbwReplay;
 use awbw_replay::game_models::AwbwPlayer;
 use awvm::semantic::{Observation, ObservedPlayer};
@@ -399,6 +401,13 @@ pub fn player_roster_snapshot(world: &mut World) -> Option<PlayerRosterSnapshot>
         .iter()
         .map(|player| (player.player_id, 0_u32))
         .collect::<HashMap<_, _>>();
+    // Counted on the same pass as the income, because a com tower is a property
+    // that also happens to change what every unit in the army deals.
+    let mut tower_counts = config
+        .players
+        .iter()
+        .map(|player| (player.player_id, 0_u32))
+        .collect::<HashMap<_, _>>();
 
     {
         let mut unit_query = world.query::<(&AwbwUnitId, &Faction, Option<&GraphicalHp>, &Unit)>();
@@ -429,6 +438,9 @@ pub fn player_roster_snapshot(world: &mut World) -> Option<PlayerRosterSnapshot>
             };
             if let Some(player_id) = player_id_for_faction(&config, faction) {
                 *income_counts.entry(player_id).or_default() += 1;
+                if property.kind() == PropertyKind::ComTower {
+                    *tower_counts.entry(player_id).or_default() += 1;
+                }
             }
         }
     }
@@ -448,6 +460,8 @@ pub fn player_roster_snapshot(world: &mut World) -> Option<PlayerRosterSnapshot>
                         unit_count: None,
                         unit_value: None,
                         income: None,
+                        properties: None,
+                        com_towers: None,
                     }
                 } else {
                     PlayerRosterStats {
@@ -470,6 +484,18 @@ pub fn player_roster_snapshot(world: &mut World) -> Option<PlayerRosterSnapshot>
                                 .copied()
                                 .unwrap_or_default()
                                 .saturating_mul(config.funds_per_property),
+                        ),
+                        properties: Some(
+                            income_counts
+                                .get(&player.player_id)
+                                .copied()
+                                .unwrap_or_default(),
+                        ),
+                        com_towers: Some(
+                            tower_counts
+                                .get(&player.player_id)
+                                .copied()
+                                .unwrap_or_default(),
                         ),
                     }
                 };

--- a/crates/xtask-assets/src/main.rs
+++ b/crates/xtask-assets/src/main.rs
@@ -812,6 +812,8 @@ fn run_ui() -> Result<()> {
     let mut sprites = collect_ui_sprites(&ui_root)?;
     let effect_sprites = collect_ui_effect_sprites(&effects_root)?;
     sprites.extend(effect_sprites);
+    let power_sprites = collect_co_power_sprites(&assets_root.join("Textures/CO"))?;
+    sprites.extend(power_sprites);
     sprites.sort_by(|a, b| a.name.cmp(&b.name));
     let (atlas_width, atlas_height, placements) = pack_ui_sprites(&sprites)?;
 
@@ -963,6 +965,34 @@ fn collect_ui_effect_sprites(effects_root: &Path) -> Result<Vec<UiSprite>> {
 
         sprites.push(UiSprite {
             name: format!("Effects/{file_name}"),
+            image: rgba,
+            width,
+            height,
+        });
+    }
+
+    Ok(sprites)
+}
+
+/// The two power stars the CO meter fills with.
+///
+/// They live under `Textures/CO` rather than `Textures/UI`, but they are
+/// interface marks rather than portraits: the source tool draws them beside a
+/// commander to say which power is charged. The atlas is where every other
+/// interface mark already is, so they join it under their own prefix.
+fn collect_co_power_sprites(co_root: &Path) -> Result<Vec<UiSprite>> {
+    // Red is the CO power, blue the super. That is the source tool's own
+    // pairing and not a choice made here.
+    let star_files = [("redstar.gif", "Power"), ("bluestar.gif", "SuperPower")];
+    let mut sprites = Vec::new();
+
+    for (file_name, sprite_name) in star_files {
+        let path = co_root.join(file_name);
+        let rgba = load_rgba_image(&path)?;
+        let (width, height) = rgba.dimensions();
+
+        sprites.push(UiSprite {
+            name: format!("CO/{sprite_name}.png"),
             image: rgba,
             width,
             height,

--- a/web/src/components/CoPortrait.tsx
+++ b/web/src/components/CoPortrait.tsx
@@ -9,11 +9,25 @@ interface CoPortraitProps {
   catalog: CoPortraitCatalog | null;
   coKey: string | null | undefined;
   fallbackLabel: string;
+  /**
+   * Whether the portrait draws its own frame.
+   *
+   * Off where the portrait already sits inside something outlined — a picker
+   * cell, a field — because two borders in a row is the tell of a component
+   * that stopped asking where it lives.
+   */
+  hasFrame?: boolean;
   /** Rendered height in px. The portrait keeps its own aspect ratio. */
   size?: number;
 }
 
-export function CoPortrait({ catalog, coKey, fallbackLabel, size }: CoPortraitProps) {
+export function CoPortrait({
+  catalog,
+  coKey,
+  fallbackLabel,
+  hasFrame = true,
+  size,
+}: CoPortraitProps) {
   const portrait = resolveCoPortrait(catalog ?? loadCoPortraitCatalog(), coKey);
 
   if (!portrait) {
@@ -37,7 +51,7 @@ export function CoPortrait({ catalog, coKey, fallbackLabel, size }: CoPortraitPr
       role="img"
       style={style}
       title={portrait.displayName}
-      {...stylex.props(styles.portrait)}
+      {...stylex.props(styles.portrait, hasFrame && styles.framed)}
     />
   );
 }
@@ -50,6 +64,8 @@ const styles = stylex.create({
     boxSizing: "content-box",
     backgroundRepeat: "no-repeat",
     imageRendering: "pixelated",
+  },
+  framed: {
     borderWidth: borderVars["--border-width"],
     borderStyle: "solid",
     borderColor: colorVars["--color-border-emphasized"],

--- a/web/src/components/game_sprites.ts
+++ b/web/src/components/game_sprites.ts
@@ -84,6 +84,31 @@ export function terrainSpriteStyle(index: number, scale = 1): CSSProperties {
   };
 }
 
+/**
+ * The tile square of one terrain cell, without what rises above it.
+ *
+ * A terrain cell is 16 wide and 32 tall because the upper half holds the peak,
+ * the roof or the tower that overhangs the tile behind it. Somewhere the whole
+ * cell has to be drawn, or a mountain is a picture of grass. Somewhere else —
+ * a control on a row beside other controls — only the square is wanted, and
+ * the square alone still tells a city from a sea from a wood.
+ */
+export function terrainTileStyle(index: number, scale = 1): CSSProperties {
+  const column = index % TERRAIN_SHEET.columns;
+  const row = Math.floor(index / TERRAIN_SHEET.columns);
+  const tile = TERRAIN_SHEET.cellHeight / 2;
+
+  return {
+    width: `${TERRAIN_SHEET.cellWidth * scale}px`,
+    height: `${tile * scale}px`,
+    backgroundImage: `url(${tilesTextureUrl})`,
+    backgroundSize: `${TERRAIN_SHEET.cellWidth * TERRAIN_SHEET.columns * scale}px ${TERRAIN_SHEET.cellHeight * TERRAIN_SHEET.rows * scale}px`,
+    backgroundPosition: `-${column * TERRAIN_SHEET.cellWidth * scale}px -${(row * TERRAIN_SHEET.cellHeight + tile) * scale}px`,
+    backgroundRepeat: "no-repeat",
+    imageRendering: "pixelated",
+  };
+}
+
 export function getUiAtlasSprite(name: string): AtlasSprite | null {
   return UI_SPRITES.get(name) ?? null;
 }

--- a/web/src/matches/screens/MatchActivePage.tsx
+++ b/web/src/matches/screens/MatchActivePage.tsx
@@ -791,6 +791,8 @@ function seatEntry(participant: MatchParticipantSnapshot, index: number): Player
       income: undefined,
       unitCount: undefined,
       unitValue: undefined,
+      properties: undefined,
+      comTowers: undefined,
     },
   };
 }

--- a/web/src/replay/power_meter.test.ts
+++ b/web/src/replay/power_meter.test.ts
@@ -25,7 +25,14 @@ function entry(power: Partial<PlayerRosterEntry>): PlayerRosterEntry {
     scopCost: undefined,
     powerStarCharge: undefined,
     activePower: undefined,
-    stats: { funds: undefined, income: undefined, unitCount: undefined, unitValue: undefined },
+    stats: {
+      funds: undefined,
+      income: undefined,
+      unitCount: undefined,
+      unitValue: undefined,
+      properties: undefined,
+      comTowers: undefined,
+    },
     ...power,
   };
 }


### PR DESCRIPTION
- Count com towers on the same pass as the income, and report the property count beside the funds it is derived from, so a consumer that reasons about combat reads the figures the commander algebra actually takes.
- Pack the two CO power stars into the UI atlas, which is where every other interface mark already is.
- Add `terrainTileStyle` for the tile square without the art that overhangs it, and let a `CoPortrait` drop its frame where it already sits inside one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual support for CO power and super-power indicators.
  * Player statistics can now display owned properties and communication towers when available.
  * Added flexible CO portrait framing and improved terrain tile rendering.

* **Bug Fixes**
  * Updated UI sprite positioning and atlas dimensions for more accurate visual rendering.

* **Tests**
  * Updated replay test data to cover property and communication tower statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->