### PR TITLE
Open the battle calculator over the board

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ name = "awbrn-wasm"
 version = "0.1.0"
 dependencies = [
  "awbrn-client",
+ "awbrn-content",
  "awbrn-map",
  "awbrn-types",
  "awbw-replay",

--- a/crates/awbrn-wasm/Cargo.toml
+++ b/crates/awbrn-wasm/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 awbrn-client = { path = "../awbrn-client" }
+awbrn-content = { path = "../awbrn-content" }
 awbrn-map = { path = "../awbrn-map" }
 awbrn-types = { path = "../awbrn-types", features = ["bevy"] }
 awbw-replay = { path = "../awbw-replay" }

--- a/crates/awbrn-wasm/src/calculator.rs
+++ b/crates/awbrn-wasm/src/calculator.rs
@@ -1,0 +1,762 @@
+//! The battle calculator's wire edge.
+//!
+//! Two exports, both free functions rather than methods on [`crate::BevyApp`]:
+//! the calculator answers a hypothetical, so it needs no board, no canvas and
+//! no running game. That is what lets the same worker answer while a replay is
+//! paused, while a live match is mid-turn, or before either has loaded.
+//!
+//! Nothing here computes anything. [`battle_forecast`] hands the request to
+//! `awvm::calculator` and renames its fields for JavaScript; [`battle_catalog`]
+//! reads the ruleset tables so the interface's pickers cannot offer a unit,
+//! terrain or commander the rules do not have, and cannot disagree with the
+//! ruleset about what a Mega Tank costs or how many stars a mountain is worth.
+
+use awbrn_types::{
+    BridgeType, Faction, GraphicalTerrain, MissileSiloStatus, PipeSeamType, PipeType,
+    PlayerFaction, Property, PropertyKind, RiverType, RoadType, SeaDirection, ShoalDirection,
+    UnitExt,
+};
+use awvm::calculator::{
+    self, BattleRequest, CalculatorError, Fighter, FundsRange, NetFunds, SideContext, Unscorable,
+};
+use awvm::combat::{DamageRange, Weapon};
+use awvm::commander::PowerLevel;
+use awvm::ruleset::{self, CommanderKind, Domain, Terrain, UnitKind, WeatherKind};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+/// Damage at both ends of its luck, in percentage points of a whole unit.
+///
+/// Uncapped, exactly as the board's own forecast reports it: 101 and 160
+/// against the same target are a bare kill and an overkill, and the difference
+/// is the reason to send something cheaper at one of them.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleBracket {
+    pub low: u16,
+    pub high: u16,
+}
+
+impl From<DamageRange> for BattleBracket {
+    fn from(range: DamageRange) -> Self {
+        Self {
+            low: range.low,
+            high: range.high,
+        }
+    }
+}
+
+/// Funds at both ends of the damage they were priced from.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct FundsBracket {
+    pub low: u64,
+    pub high: u64,
+}
+
+impl From<FundsRange> for FundsBracket {
+    fn from(range: FundsRange) -> Self {
+        Self {
+            low: range.low,
+            high: range.high,
+        }
+    }
+}
+
+/// What the exchange moves, from the attacking player's seat.
+///
+/// `low` is the attacker's worst case — its weakest roll against the strongest
+/// reply — and `high` its best. The two ends are not independently reachable
+/// and must not be recombined.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct NetFundsBracket {
+    pub low: i64,
+    pub high: i64,
+}
+
+impl From<NetFunds> for NetFundsBracket {
+    fn from(net: NetFunds) -> Self {
+        Self {
+            low: net.low,
+            high: net.high,
+        }
+    }
+}
+
+/// Everything one army brings to the exchange that is not the unit.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleSide {
+    /// `null` fights under the ruleset's neutral commander, which is what
+    /// "no CO" means to the combat algebra.
+    #[tsify(optional)]
+    pub commander: Option<CommanderKind>,
+    /// `null` is day-to-day.
+    #[tsify(optional)]
+    pub power: Option<PowerLevel>,
+    pub funds: u64,
+    /// Every capturable tile the army holds, com towers included.
+    pub properties: u64,
+    pub com_towers: u64,
+}
+
+/// One unit in the exchange, and the ground under it.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleFighter {
+    pub unit: UnitKind,
+    /// Health in points on the 0-100 scale, not the 1-10 the board draws.
+    pub health: u8,
+    /// `null` takes the unit's full magazine.
+    #[tsify(optional)]
+    pub ammo: Option<u64>,
+    pub terrain: Terrain,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleRequestWire {
+    pub attacker: BattleSide,
+    pub attacking_unit: BattleFighter,
+    pub defender: BattleSide,
+    pub defending_units: Vec<BattleFighter>,
+}
+
+/// Why a pairing has no numbers.
+///
+/// Reported rather than hidden: a player who asked what an Anti-Air does to a
+/// Battleship is owed the answer "nothing it holds can reach it", and a row
+/// that silently vanished would look like the calculator had failed.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "kebab-case")]
+pub enum BattleImpossible {
+    /// Nothing this attacker holds has a damage entry against the target.
+    NoWeapon,
+    /// The attacker has no weapon at all.
+    Unarmed,
+}
+
+impl From<Unscorable> for BattleImpossible {
+    fn from(reason: Unscorable) -> Self {
+        match reason {
+            Unscorable::NoWeapon => Self::NoWeapon,
+            Unscorable::Unarmed => Self::Unarmed,
+        }
+    }
+}
+
+/// One target, and what the exchange with it costs both sides.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleRow {
+    pub target: BattleFighter,
+    pub name: String,
+    /// Present exactly when `impossible` is absent.
+    #[tsify(optional)]
+    pub result: Option<BattleResult>,
+    #[tsify(optional)]
+    pub impossible: Option<BattleImpossible>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleResult {
+    /// Which weapon fires. A unit out of shells falls back to its secondary,
+    /// and the drop in damage is otherwise unexplained.
+    pub weapon: BattleWeapon,
+    pub damage: BattleBracket,
+    /// Absent when nothing replies at all, which is a different fact from a
+    /// reply that lands nothing.
+    #[tsify(optional)]
+    pub counter: Option<BattleBracket>,
+    pub counter_first: bool,
+    pub destroys: bool,
+    pub may_destroy: bool,
+    pub value_dealt: FundsBracket,
+    #[tsify(optional)]
+    pub value_taken: Option<FundsBracket>,
+    /// The reply again, one rung per health the target may be left standing
+    /// in, so a reader can tell the health spread from the luck. Empty when
+    /// there is no spread: a reply that lands first is scored at full health,
+    /// and a target that never survives never answers.
+    pub counter_steps: Vec<BattleCounterStep>,
+    /// What the target is worth whole, at the health it is standing at.
+    pub target_value: u64,
+    pub net: NetFundsBracket,
+}
+
+/// What the target answers with from one of the healths it may be left in.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleCounterStep {
+    /// The health in points the target is left standing at, at the top of the
+    /// bar the board would draw it in.
+    pub target_health: u8,
+    pub counter: BattleBracket,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "kebab-case")]
+pub enum BattleWeapon {
+    /// The magazine weapon: shells, missiles, torpedoes.
+    Ammo,
+    /// The weapon that never runs out: the machine gun, the bazooka.
+    Unlimited,
+}
+
+impl From<Weapon> for BattleWeapon {
+    fn from(weapon: Weapon) -> Self {
+        match weapon {
+            Weapon::Ammo => Self::Ammo,
+            Weapon::Unlimited => Self::Unlimited,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleReportWire {
+    /// What the attacker is worth at the health it is fighting at.
+    pub attacker_value: u64,
+    pub rows: Vec<BattleRow>,
+}
+
+/// The calculator error category a caller can handle without parsing text.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "kebab-case")]
+pub enum BattleCalculatorErrorKind {
+    Health,
+    Properties,
+    ComTowers,
+    Layout,
+}
+
+/// A calculator failure with a stable category and a readable explanation.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleCalculatorError {
+    pub kind: BattleCalculatorErrorKind,
+    pub message: String,
+}
+
+/// A forecast result that keeps expected calculator failures in the data path.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum BattleForecastResponse {
+    Success { report: BattleReportWire },
+    Failure { error: BattleCalculatorError },
+}
+
+impl From<CalculatorError> for BattleCalculatorError {
+    fn from(error: CalculatorError) -> Self {
+        let kind = match &error {
+            CalculatorError::Health(_) => BattleCalculatorErrorKind::Health,
+            CalculatorError::Properties(_) => BattleCalculatorErrorKind::Properties,
+            CalculatorError::ComTowers { .. } => BattleCalculatorErrorKind::ComTowers,
+            CalculatorError::Layout(_) => BattleCalculatorErrorKind::Layout,
+        };
+        Self {
+            kind,
+            message: error.to_string(),
+        }
+    }
+}
+
+/// Score one attacker against every target it is being weighed against.
+///
+/// Every number comes back from `awvm::calculator`, which lowers the request
+/// into a state and puts it to the same reducer a real order goes through.
+#[wasm_bindgen]
+pub fn battle_forecast(request: BattleRequestWire) -> BattleForecastResponse {
+    let report = calculator::forecast(&BattleRequest {
+        // The engagement is scored under clear skies whatever the board is
+        // under. No commander in this ruleset gates a firepower or defense rule
+        // on weather, so the three settings score the same exchange, and
+        // `weather_never_moves_a_calculator_result` in
+        // `crates/awvm/src/calculator.rs` holds that against the whole
+        // commander table. A caller that carried the board's weather here would
+        // be carrying a value it cannot act on.
+        weather: WeatherKind::Clear,
+        attacker: side(request.attacker),
+        attacking_unit: fighter(request.attacking_unit),
+        defender: side(request.defender),
+        defending_units: request
+            .defending_units
+            .iter()
+            .copied()
+            .map(fighter)
+            .collect(),
+    });
+
+    let report = match report {
+        Ok(report) => report,
+        Err(error) => {
+            return BattleForecastResponse::Failure {
+                error: BattleCalculatorError::from(error),
+            };
+        }
+    };
+
+    BattleForecastResponse::Success {
+        report: BattleReportWire {
+            attacker_value: report.attacker_value,
+            rows: report
+                .outcomes
+                .into_iter()
+                .map(|outcome| BattleRow {
+                    target: BattleFighter {
+                        unit: outcome.target.unit,
+                        health: outcome.target.hp,
+                        ammo: outcome.target.ammo,
+                        terrain: outcome.target.terrain,
+                    },
+                    name: outcome.target.unit.name().to_string(),
+                    impossible: outcome.engagement.as_ref().err().copied().map(Into::into),
+                    result: outcome.engagement.ok().map(|engagement| BattleResult {
+                        weapon: engagement.weapon.into(),
+                        damage: engagement.damage.into(),
+                        counter: engagement.counter.map(Into::into),
+                        counter_first: engagement.counter_first,
+                        destroys: engagement.destroys,
+                        may_destroy: engagement.may_destroy,
+                        value_dealt: engagement.value_dealt.into(),
+                        value_taken: engagement.value_taken.map(Into::into),
+                        counter_steps: engagement
+                            .counter_steps
+                            .into_iter()
+                            .map(|step| BattleCounterStep {
+                                target_health: step.target_hp,
+                                counter: step.counter.into(),
+                            })
+                            .collect(),
+                        target_value: engagement.target_value,
+                        net: engagement.net.into(),
+                    }),
+                })
+                .collect(),
+        },
+    }
+}
+
+fn side(wire: BattleSide) -> SideContext {
+    SideContext {
+        commander: wire.commander,
+        power: wire.power,
+        funds: wire.funds,
+        properties: wire.properties,
+        com_towers: wire.com_towers,
+    }
+}
+
+fn fighter(wire: BattleFighter) -> Fighter {
+    Fighter {
+        unit: wire.unit,
+        hp: wire.health,
+        ammo: wire.ammo,
+        terrain: wire.terrain,
+    }
+}
+
+/// One unit kind, as a picker needs it.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogUnit {
+    pub unit: UnitKind,
+    pub name: String,
+    pub cost: u64,
+    pub domain: CatalogDomain,
+    pub max_ammo: u64,
+    /// Whether the unit fires from beyond one tile, which is also why it draws
+    /// no reply.
+    pub is_indirect: bool,
+}
+
+/// Where a unit travels, which is the only thing a picker needs the domain for:
+/// it decides what ground to open the unit on.
+///
+/// Mirrored rather than re-exported because the ruleset's own domain type is
+/// internal to the rules and carries no TypeScript declaration.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "kebab-case")]
+pub enum CatalogDomain {
+    Ground,
+    Air,
+    Sea,
+}
+
+impl From<Domain> for CatalogDomain {
+    fn from(domain: Domain) -> Self {
+        match domain {
+            Domain::Ground => Self::Ground,
+            Domain::Air => Self::Air,
+            Domain::Sea => Self::Sea,
+        }
+    }
+}
+
+/// One terrain, with the defense it grants and the tile the board draws for it.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogTerrain {
+    pub terrain: Terrain,
+    pub name: String,
+    pub stars: u8,
+    /// The cell of the terrain sheet a picker draws for this ground, so the
+    /// choice is made from the tile the player already knows off the map
+    /// rather than from its name.
+    pub sprite_index: u16,
+}
+
+/// One commander, keyed the way the portrait sheet keys its art.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogCommander {
+    pub commander: CommanderKind,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, tsify::Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct BattleCatalog {
+    pub units: Vec<CatalogUnit>,
+    pub terrains: Vec<CatalogTerrain>,
+    pub commanders: Vec<CatalogCommander>,
+}
+
+/// Everything the calculator's pickers may offer, read off the ruleset.
+///
+/// It is read once and held, so a picker never asks the worker again. The
+/// alternative was three hand-written tables in TypeScript that would silently
+/// disagree with the ruleset the first time a cost changed.
+#[wasm_bindgen]
+pub fn battle_catalog() -> BattleCatalog {
+    BattleCatalog {
+        units: UnitKind::ALL
+            .into_iter()
+            .map(|unit| {
+                let profile = ruleset::profile(unit);
+                CatalogUnit {
+                    unit,
+                    name: unit.name().to_string(),
+                    cost: profile.cost,
+                    domain: profile.domain.into(),
+                    max_ammo: profile.max_ammo,
+                    is_indirect: profile.indirect_range.is_some(),
+                }
+            })
+            .collect(),
+        terrains: Terrain::ALL
+            .into_iter()
+            .filter(|terrain| stands_on(*terrain))
+            .map(|terrain| CatalogTerrain {
+                terrain,
+                name: terrain_name(terrain).to_string(),
+                stars: ruleset::defense_stars(terrain),
+                sprite_index: awbrn_content::spritesheet_index(
+                    WeatherKind::Clear,
+                    tile_art(terrain),
+                )
+                .index(),
+            })
+            .collect(),
+        commanders: CommanderKind::ALL
+            .into_iter()
+            // The neutral commander is what an empty picker already means, so
+            // offering it by name would be the same choice written twice.
+            .filter(|commander| *commander != CommanderKind::Neutral)
+            .map(|commander| CatalogCommander {
+                commander,
+                name: commander_name(commander).to_string(),
+            })
+            .collect(),
+    }
+}
+
+/// Whether a unit can be standing on this terrain when it is shot at.
+///
+/// A pipe and its seam are scenery, and a teleporter is a doorway. A combatant
+/// does not occupy these terrain types, so their defense values do not apply.
+fn stands_on(terrain: Terrain) -> bool {
+    !matches!(
+        terrain,
+        Terrain::Pipe | Terrain::PipeSeam | Terrain::Teleporter
+    )
+}
+
+/// The ruleset spells terrain in its own identifiers; a player reads names.
+///
+/// Properties borrow the names the map editor already uses for them, so the
+/// picker and the board agree on what a building is called.
+fn terrain_name(terrain: Terrain) -> &'static str {
+    match terrain {
+        Terrain::Airport => PropertyKind::Airport.name(),
+        Terrain::Base => PropertyKind::Base.name(),
+        Terrain::City => PropertyKind::City.name(),
+        Terrain::ComTower => PropertyKind::ComTower.name(),
+        Terrain::Hq => PropertyKind::HQ.name(),
+        Terrain::Lab => PropertyKind::Lab.name(),
+        Terrain::Port => PropertyKind::Port.name(),
+        Terrain::Bridge => "Bridge",
+        Terrain::MissileSilo => "Missile Silo",
+        Terrain::Mountain => "Mountain",
+        Terrain::Pipe => "Pipe",
+        Terrain::PipeSeam => "Pipe Seam",
+        Terrain::Plain => "Plain",
+        Terrain::Reef => "Reef",
+        Terrain::River => "River",
+        Terrain::Road => "Road",
+        Terrain::Sea => "Sea",
+        Terrain::Shoal => "Shoal",
+        Terrain::Teleporter => "Teleporter",
+        Terrain::Wood => "Wood",
+    }
+}
+
+/// The tile the picker draws for one terrain kind.
+///
+/// Most terrain the board draws is shaped by its neighbours: a road bends, a
+/// river forks, a sea tile takes its coastline from four directions at once. A
+/// picker has no neighbours, so each kind is shown in its standalone form —
+/// the straight run, the open water, the unowned building. It is the same art
+/// the map uses, which is the point: a player picks the ground by recognising
+/// it rather than by reading its name.
+///
+/// A property is drawn unowned. The army holding a building changes only its
+/// colours, and the defense it grants is the same for whoever stands on it.
+fn tile_art(terrain: Terrain) -> GraphicalTerrain {
+    match terrain {
+        Terrain::Airport => GraphicalTerrain::Property(Property::Airport(Faction::Neutral)),
+        Terrain::Base => GraphicalTerrain::Property(Property::Base(Faction::Neutral)),
+        Terrain::Bridge => GraphicalTerrain::Bridge(BridgeType::Horizontal),
+        Terrain::City => GraphicalTerrain::Property(Property::City(Faction::Neutral)),
+        Terrain::ComTower => GraphicalTerrain::Property(Property::ComTower(Faction::Neutral)),
+        // An HQ is the one building that is never unowned, so the picker shows
+        // the first army's, the way an empty map does.
+        Terrain::Hq => GraphicalTerrain::Property(Property::HQ(PlayerFaction::OrangeStar)),
+        Terrain::Lab => GraphicalTerrain::Property(Property::Lab(Faction::Neutral)),
+        // A silo that has fired is a different tile with the same defense. The
+        // loaded one is what a player is picturing when they pick it.
+        Terrain::MissileSilo => GraphicalTerrain::MissileSilo(MissileSiloStatus::Loaded),
+        Terrain::Mountain => GraphicalTerrain::Mountain,
+        Terrain::Pipe => GraphicalTerrain::Pipe(PipeType::Horizontal),
+        Terrain::PipeSeam => GraphicalTerrain::PipeSeam(PipeSeamType::Horizontal),
+        Terrain::Plain => GraphicalTerrain::Plain,
+        Terrain::Port => GraphicalTerrain::Property(Property::Port(Faction::Neutral)),
+        Terrain::Reef => GraphicalTerrain::Reef,
+        Terrain::River => GraphicalTerrain::River(RiverType::Horizontal),
+        Terrain::Road => GraphicalTerrain::Road(RoadType::Horizontal),
+        Terrain::Sea => GraphicalTerrain::Sea(SeaDirection::Sea),
+        Terrain::Shoal => GraphicalTerrain::Shoal(ShoalDirection::S),
+        Terrain::Teleporter => GraphicalTerrain::Teleporter,
+        Terrain::Wood => GraphicalTerrain::Wood,
+    }
+}
+
+/// Commander display names, taken from the same table that names the portraits.
+///
+/// Keeping one source means the picker cannot say "Von Bolt" beside a portrait
+/// labelled "von-bolt".
+fn commander_name(commander: CommanderKind) -> &'static str {
+    awbrn_content::co_portraits()
+        .iter()
+        .find(|portrait| portrait.key() == commander.as_str())
+        .map_or_else(|| commander.as_str(), |portrait| portrait.display_name())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn battle_catalog_contains_every_offered_terrain() {
+        let catalog = battle_catalog();
+
+        assert!(!catalog.units.is_empty());
+        assert!(!catalog.terrains.is_empty());
+        assert!(!catalog.commanders.is_empty());
+        assert_eq!(
+            catalog.terrains.len(),
+            Terrain::ALL
+                .into_iter()
+                .filter(|terrain| stands_on(*terrain))
+                .count()
+        );
+        for terrain in catalog.terrains {
+            assert!(stands_on(terrain.terrain));
+            assert!(!terrain.name.trim().is_empty());
+        }
+    }
+
+    #[test]
+    fn battle_forecast_preserves_calculator_funds_and_damage() {
+        let attacker = BattleSide {
+            commander: Some(CommanderKind::Colin),
+            power: None,
+            funds: 20_000,
+            properties: 5,
+            com_towers: 1,
+        };
+        let attacking_unit = BattleFighter {
+            unit: UnitKind::Tank,
+            health: 90,
+            ammo: Some(6),
+            terrain: Terrain::Plain,
+        };
+        let defender = BattleSide {
+            commander: Some(CommanderKind::Andy),
+            power: None,
+            funds: 10_000,
+            properties: 4,
+            com_towers: 0,
+        };
+        let defending_unit = BattleFighter {
+            unit: UnitKind::Recon,
+            health: 80,
+            ammo: None,
+            terrain: Terrain::City,
+        };
+        let expected = calculator::forecast(&BattleRequest {
+            weather: WeatherKind::Clear,
+            attacker: side(attacker),
+            attacking_unit: fighter(attacking_unit),
+            defender: side(defender),
+            defending_units: vec![fighter(defending_unit)],
+        })
+        .expect("the ruleset pairing must score");
+        let expected_result = expected.outcomes[0]
+            .engagement
+            .as_ref()
+            .expect("the ruleset pairing must have an engagement");
+
+        let response = battle_forecast(BattleRequestWire {
+            attacker,
+            attacking_unit,
+            defender,
+            defending_units: vec![defending_unit],
+        });
+        let BattleForecastResponse::Success { report: wire } = response else {
+            panic!("the wire pairing must score");
+        };
+        let result = wire.rows[0]
+            .result
+            .as_ref()
+            .expect("the wire row must have a result");
+
+        assert_eq!(result.damage, expected_result.damage.into());
+        assert_eq!(result.counter, expected_result.counter.map(Into::into));
+        assert_eq!(result.value_dealt, expected_result.value_dealt.into());
+        assert_eq!(
+            result.value_taken,
+            expected_result.value_taken.map(Into::into)
+        );
+        assert_eq!(result.net, expected_result.net.into());
+    }
+
+    #[test]
+    fn battle_forecast_returns_calculator_failures_as_data() {
+        let side = BattleSide {
+            commander: None,
+            power: None,
+            funds: 0,
+            properties: 0,
+            com_towers: 0,
+        };
+        let response = battle_forecast(BattleRequestWire {
+            attacker: side,
+            attacking_unit: BattleFighter {
+                unit: UnitKind::Infantry,
+                health: 0,
+                ammo: None,
+                terrain: Terrain::Plain,
+            },
+            defender: side,
+            defending_units: vec![BattleFighter {
+                unit: UnitKind::Infantry,
+                health: 100,
+                ammo: None,
+                terrain: Terrain::Plain,
+            }],
+        });
+
+        let BattleForecastResponse::Failure { error } = response else {
+            panic!("invalid health must return a calculator failure");
+        };
+        assert_eq!(error.kind, BattleCalculatorErrorKind::Health);
+        assert!(!error.message.is_empty());
+    }
+
+    #[test]
+    fn calculator_errors_keep_their_kind_and_message() {
+        let errors = [
+            (
+                CalculatorError::Health(0),
+                BattleCalculatorErrorKind::Health,
+            ),
+            (
+                CalculatorError::Properties(201),
+                BattleCalculatorErrorKind::Properties,
+            ),
+            (
+                CalculatorError::ComTowers {
+                    towers: 2,
+                    properties: 1,
+                },
+                BattleCalculatorErrorKind::ComTowers,
+            ),
+            (
+                CalculatorError::Layout("missing unit".into()),
+                BattleCalculatorErrorKind::Layout,
+            ),
+        ];
+
+        for (error, kind) in errors {
+            let message = error.to_string();
+            let wire = BattleCalculatorError::from(error);
+            assert_eq!(wire.kind, kind);
+            assert_eq!(wire.message, message);
+        }
+    }
+
+    #[test]
+    fn every_commander_has_a_display_name() {
+        for commander in CommanderKind::ALL {
+            if commander == CommanderKind::Neutral {
+                continue;
+            }
+            assert_ne!(
+                commander_name(commander),
+                commander.as_str(),
+                "{commander} has no display name"
+            );
+        }
+    }
+
+    #[test]
+    fn terrain_picker_excludes_scenery() {
+        assert!(!stands_on(Terrain::Pipe));
+        assert!(!stands_on(Terrain::PipeSeam));
+        assert!(!stands_on(Terrain::Teleporter));
+        assert!(stands_on(Terrain::Plain));
+    }
+}

--- a/crates/awbrn-wasm/src/lib.rs
+++ b/crates/awbrn-wasm/src/lib.rs
@@ -23,6 +23,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use wasm_bindgen::prelude::*;
 use web_sys::OffscreenCanvas;
 
+pub mod calculator;
 mod keyboard;
 mod offscreen_window_handle;
 mod web_key_code_generated;

--- a/web/src/engine/game_runner.ts
+++ b/web/src/engine/game_runner.ts
@@ -8,6 +8,9 @@ import {
 import type { AwbwMapData } from "#/awbw/schemas.ts";
 import type { ObservedTransition } from "#/wasm/awbrn_server.js";
 import type {
+  BattleCatalog,
+  BattleForecastResponse,
+  BattleRequestWire,
   DeleteUnitCommandRequested,
   GameEvent,
   MoveCommandRequested,
@@ -25,6 +28,7 @@ export interface GameSurface extends CanvasCourierSurface {}
 
 export class GameRunner implements CanvasCourierController {
   private activeSurface: GameSurface | undefined;
+  private battleCatalogPromise: Promise<BattleCatalog> | undefined;
   private createGamePromise: Promise<GameInstance> | undefined;
   private game: GameInstance | undefined;
   private pendingLiveTransitions: ObservedTransition[] = [];
@@ -93,6 +97,29 @@ export class GameRunner implements CanvasCourierController {
     await game.setPlayerDisplayFaction(playerId, factionId);
   }
 
+  /**
+   * Score a hypothetical engagement.
+   *
+   * It goes to the worker rather than to the game, so it answers whether or not
+   * a board has loaded and never waits on one. The worker is the only place the
+   * engine lives, and asking the rules from anywhere else would mean a second
+   * copy of them in the browser.
+   */
+  async forecastBattle(request: BattleRequestWire): Promise<BattleForecastResponse> {
+    return this.getWorker().forecastBattle(request);
+  }
+
+  /** The units, terrain and commanders the rules define. Fetched once. */
+  loadBattleCatalog(): Promise<BattleCatalog> {
+    this.battleCatalogPromise ??= this.getWorker()
+      .loadBattleCatalog()
+      .catch((error) => {
+        this.battleCatalogPromise = undefined;
+        throw error;
+      });
+    return this.battleCatalogPromise;
+  }
+
   setLiveCommandHandler(handler: ((command: MatchCommand) => void) | undefined): void {
     this.liveCommandHandler = handler;
   }
@@ -100,6 +127,7 @@ export class GameRunner implements CanvasCourierController {
   dispose(): void {
     this.surfaceVersion += 1;
     this.activeSurface = undefined;
+    this.battleCatalogPromise = undefined;
     this.liveCommandHandler = undefined;
     this.transport.dispose();
     this.game = undefined;

--- a/web/src/engine/worker_module.ts
+++ b/web/src/engine/worker_module.ts
@@ -1,4 +1,12 @@
-import init, { type CanvasDisplay, BevyApp } from "#/wasm/awbrn_wasm.js";
+import init, {
+  battle_catalog,
+  battle_forecast,
+  type BattleCatalog,
+  type BattleForecastResponse,
+  type BattleRequestWire,
+  type CanvasDisplay,
+  BevyApp,
+} from "#/wasm/awbrn_wasm.js";
 import type { ObservedTransition } from "#/wasm/awbrn_server.js";
 import wasmPath from "#/wasm/awbrn_wasm_bg.wasm?url";
 import { proxy } from "comlink";
@@ -129,6 +137,34 @@ class WorkerInputBridge {
     return !this.paused;
   }
 }
+
+/**
+ * Score one hypothetical engagement, or a column of them.
+ *
+ * A top-level export rather than a method on the game, because the calculator
+ * asks about an engagement no board holds: it needs no canvas, no replay and no
+ * match, and it answers while a game is paused or before one exists. The
+ * numbers are AWVM's, reached through the same reducer a real order goes
+ * through.
+ */
+export const forecastBattle = async (
+  request: BattleRequestWire,
+): Promise<BattleForecastResponse> => {
+  await initialized;
+  return battle_forecast(request);
+};
+
+/**
+ * Everything the calculator's pickers may offer, read off the ruleset.
+ *
+ * Fetched once and held by the caller. Units, terrain and commanders come from
+ * the same tables that resolve a shot, so a picker cannot offer a unit the
+ * rules lack or disagree with them about what it costs.
+ */
+export const loadBattleCatalog = async (): Promise<BattleCatalog> => {
+  await initialized;
+  return battle_catalog();
+};
 
 export const createGame = async (
   canvas: OffscreenCanvas,

--- a/web/src/matches/components/BattleCalculator.tsx
+++ b/web/src/matches/components/BattleCalculator.tsx
@@ -1,0 +1,1458 @@
+import { Button } from "#/ui/Button.tsx";
+import { Dialog } from "@astryxdesign/core/Dialog";
+import { Grid } from "@astryxdesign/core/Grid";
+import { NumberInput } from "@astryxdesign/core/NumberInput";
+import { HStack, VStack } from "@astryxdesign/core/Stack";
+import {
+  borderVars,
+  colorVars,
+  fontWeightVars,
+  radiusVars,
+  shadowVars,
+  spacingVars,
+  textSizeVars,
+  typographyVars,
+} from "@astryxdesign/core/theme/tokens.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { Close as CloseIcon } from "pixelarticons/react/Close";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CoPortrait } from "#/components/CoPortrait.tsx";
+import { loadCoPortraitCatalog, type CoPortraitCatalog } from "#/components/co_portraits.ts";
+import {
+  terrainSpriteStyle,
+  terrainTileStyle,
+  uiAtlasSpriteStyle,
+  unitSpriteSize,
+  unitSpriteStyle,
+} from "#/components/game_sprites.ts";
+import { SpritePicker, type SpritePickerOption } from "./SpritePicker.tsx";
+import type { GameRunner } from "#/engine/game_runner.ts";
+import {
+  FULL_HEALTH_POINTS,
+  HEALTH_BARS_MAX,
+  barsToPoints,
+  defaultTerrain,
+  engagementLabel,
+  formatDamage,
+  formatFunds,
+  formatFundsBracket,
+  formatNet,
+  impossibleLabel,
+  pointsToBars,
+  retypeFighter,
+  seatsFrom,
+  sideFrom,
+  terrainEntry,
+  unitEntry,
+  type CalculatorSide,
+} from "./battle_calculator.ts";
+import type {
+  BattleCatalog,
+  BattleCalculatorError,
+  BattleFighter,
+  BattleReportWire,
+  BattleSide,
+  CatalogDomain,
+  PlayerRosterSnapshot,
+  PowerLevel,
+  Terrain,
+  UnitKind,
+} from "#/wasm/awbrn_wasm.js";
+
+/**
+ * The engagement a player is imagining, priced.
+ *
+ * The board already forecasts the attacks a unit can make right now. This is
+ * the other half of the same question and the reason a player still opens
+ * AWBW's calculator in a second tab: what an attack would cost if the unit were
+ * built, if it stood somewhere else, if the tower were taken, if the power were
+ * up. None of that is on the board, so none of it can be asked of the board.
+ *
+ * Its shape is the reference tool's own: two armies fully specified side by
+ * side, a swap on the centreline between them, and the exchange read across it.
+ * Each column carries everything that moves a damage figure for the army
+ * standing in it — the commander, the power, the treasury, the properties, the
+ * towers, and the unit itself — so the two are compared by reading across
+ * rather than by remembering what the other one said.
+ *
+ * Weather is absent on purpose, and is not sent either. No commander in the
+ * ruleset gates a firepower or defense rule on it, so the three settings score
+ * the same exchange; offering the player a control would only invite them to
+ * click all three and conclude the panel is broken.
+ *
+ * Every figure is AWVM's. The panel holds no formula, no table of costs and no
+ * opinion about whether a trade is good; the numbers are what a player came for
+ * and judging them is the thing they came to do.
+ */
+
+/** How the panel is drawn, following the input that opened it. */
+export type BattleCalculatorPresentation = "board" | "sheet";
+
+/**
+ * When the board frame is too small to hold the panel, and the panel becomes a
+ * sheet instead.
+ *
+ * Height is in the rule because the board is 3:2 and its width is capped by the
+ * window's height, so a short window makes a short board however wide the
+ * screen is. A panel taller than the frame it sits in is a panel whose last
+ * line is cut in half, and a bottom sheet is a better answer than a scroll the
+ * player did not ask for.
+ */
+export const BATTLE_CALCULATOR_SHEET_MEDIA = "(max-width: 1279px), (max-height: 899px)";
+
+/** As deep as a sheet may stand before it stops being a sheet. */
+const SHEET_MAX_BLOCK_SIZE = "min(86svh, 46rem)";
+
+interface BattleCalculatorProps {
+  onDismiss: () => void;
+  /** Hands the keyboard back to the board once the panel has closed. */
+  onRestoreFocus: () => void;
+  presentation: BattleCalculatorPresentation;
+  /** The armies as the board currently has them. `null` seeds a blank sheet. */
+  roster: PlayerRosterSnapshot | null;
+  runner: GameRunner | null;
+  /** Which seat the player occupies, when they occupy one. */
+  viewerSlotIndex?: number | null;
+}
+
+/** What the panel opens on when no board has reported an army. */
+const FALLBACK_UNIT: UnitKind = "infantry";
+const FALLBACK_ATTACKER_FACTION = "os";
+const FALLBACK_DEFENDER_FACTION = "bm";
+
+/**
+ * The picker value that means no commander at all.
+ *
+ * It is not a commander the ruleset has, so it cannot be one of its keys. The
+ * combat algebra reads it as the neutral commander, which is a commander with
+ * no rules rather than an army fighting without one.
+ */
+const NO_COMMANDER = "none";
+
+/**
+ * The two power stars, as the source tool draws them beside a commander.
+ *
+ * The atlas also holds `NormalPower` and `SuperPower`, but that art is
+ * lettering: it draws the words POWER and SUPER at 66px wide, which is a
+ * banner rather than a key on a menu strip. These are 14px marks that sit in
+ * a control at their own size, and red for the power against blue for the
+ * super is the source tool's own pairing rather than a choice made here.
+ */
+const POWER_MARK = uiAtlasSpriteStyle("CO/Power.png");
+const SUPER_POWER_MARK = uiAtlasSpriteStyle("CO/SuperPower.png");
+
+/** The marks a player already reads these five quantities by. */
+const COIN = uiAtlasSpriteStyle("Coin.png");
+const PROPERTY = uiAtlasSpriteStyle("BuildingsCaptured.png");
+const COM_TOWER = uiAtlasSpriteStyle("commtowericon.png");
+const HP = uiAtlasSpriteStyle("HP.png");
+const AMMO = uiAtlasSpriteStyle("Ammo.png");
+
+export function BattleCalculator({
+  onDismiss,
+  onRestoreFocus,
+  presentation,
+  roster,
+  runner,
+  viewerSlotIndex,
+}: BattleCalculatorProps) {
+  const [catalog, setCatalog] = useState<BattleCatalog | null>(null);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [portraits] = useState<CoPortraitCatalog>(() => loadCoPortraitCatalog());
+
+  const seats = useMemo(
+    () => seatsFrom(roster, viewerSlotIndex ?? null),
+    [roster, viewerSlotIndex],
+  );
+
+  const [attackerSide, setAttackerSide] = useState<CalculatorSide>(() => sideFrom(seats.attacker));
+  const [defenderSide, setDefenderSide] = useState<CalculatorSide>(() => sideFrom(seats.defender));
+  const [attacker, setAttacker] = useState<BattleFighter>(() => blankFighter());
+  const [defender, setDefender] = useState<BattleFighter>(() => blankFighter());
+  const [report, setReport] = useState<BattleReportWire | null>(null);
+  const [reportError, setReportError] = useState<string | null>(null);
+
+  // Which seat each army is standing in. The board seats them once; the swap
+  // key is the player asking the other half of the question — what this trade
+  // costs when it is made against them instead of by them.
+  const [isSwapped, setIsSwapped] = useState(false);
+  const seatedAttackerFaction =
+    seats.attacker?.displayFactionCode ?? seats.attacker?.factionCode ?? FALLBACK_ATTACKER_FACTION;
+  const seatedDefenderFaction =
+    seats.defender?.displayFactionCode ?? seats.defender?.factionCode ?? FALLBACK_DEFENDER_FACTION;
+  const attackerFaction = isSwapped ? seatedDefenderFaction : seatedAttackerFaction;
+  const defenderFaction = isSwapped ? seatedAttackerFaction : seatedDefenderFaction;
+
+  useEffect(() => {
+    if (!runner) return;
+    let cancelled = false;
+
+    runner
+      .loadBattleCatalog()
+      .then((loaded) => {
+        if (!cancelled) setCatalog(loaded);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setCatalogError(error instanceof Error ? error.message : "The rules could not be read.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runner]);
+
+  // Every edit is a new question, and the answer is one message to the worker
+  // that already holds the engine. Requests are not debounced: the reducer
+  // scores an engagement in microseconds, and a figure that lagged a keystroke
+  // behind would be a figure a player could read and act on while it was still
+  // describing the previous board.
+  //
+  // The defender is sent as a column of one. The wire scores a list because the
+  // reducer does, and the panel asks about a single pairing.
+  useEffect(() => {
+    const attackerContext = completeSide(attackerSide);
+    const defenderContext = completeSide(defenderSide);
+    if (!runner || !attackerContext || !defenderContext) {
+      setReport(null);
+      setReportError(null);
+      return;
+    }
+    let cancelled = false;
+    setReport(null);
+    setReportError(null);
+
+    runner
+      .forecastBattle({
+        attacker: attackerContext,
+        attackingUnit: attacker,
+        defender: defenderContext,
+        defendingUnits: [defender],
+      })
+      .then((response) => {
+        if (cancelled) return;
+        if (response.status === "failure") {
+          setReport(null);
+          setReportError(errorMessage(response.error));
+          return;
+        }
+        setReport(response.report);
+        setReportError(null);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setReport(null);
+        setReportError(unexpectedErrorMessage(error, "The engagement could not be scored."));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attacker, attackerSide, defender, defenderSide, runner]);
+
+  /**
+   * Turn the engagement around.
+   *
+   * Both armies, both premises and both units change seats at once, because a
+   * trade read from one side only is half an answer: a player who has just
+   * been told an attack costs them 2,100 wants to know what the reply costs
+   * before they commit to it. It is the reference calculator's one command
+   * this panel did not have.
+   */
+  const swapSeats = useCallback(() => {
+    setIsSwapped((previous) => !previous);
+    setAttackerSide(defenderSide);
+    setDefenderSide(attackerSide);
+    setAttacker(defender);
+    setDefender(attacker);
+  }, [attacker, attackerSide, defender, defenderSide]);
+
+  // The catalogues are the ruleset's and do not change while the panel is
+  // open; only the colours the sprites are drawn in do. Building them once per
+  // army rather than once per control is what keeps a keystroke in a treasury
+  // field from rebuilding two hundred sprites.
+  const attackerUnits = useMemo(
+    () => unitOptionsFor(catalog, attackerFaction),
+    [attackerFaction, catalog],
+  );
+  const defenderUnits = useMemo(
+    () => unitOptionsFor(catalog, defenderFaction),
+    [catalog, defenderFaction],
+  );
+  const terrains = useMemo(() => terrainOptionsFor(catalog), [catalog]);
+  const commanders = useMemo(() => commanderOptionsFor(catalog, portraits), [catalog, portraits]);
+
+  const kit: PanelKit = {
+    isSheet: presentation === "sheet",
+    attacker,
+    attackerFaction,
+    attackerSide,
+    attackerUnits,
+    catalog,
+    commanders,
+    defender,
+    defenderFaction,
+    defenderSide,
+    defenderUnits,
+    failure: catalogError ?? reportError,
+    isScoring:
+      runner !== null &&
+      completeSide(attackerSide) !== null &&
+      completeSide(defenderSide) !== null &&
+      report === null &&
+      reportError === null,
+    missingFigures: missingFigureInstruction(attackerSide, defenderSide),
+    onAttackerChange: setAttackerSide,
+    onAttackerUnitChange: setAttacker,
+    onDefenderChange: setDefenderSide,
+    onDefenderUnitChange: setDefender,
+    onDismiss,
+    onRestoreFocus,
+    onSwap: swapSeats,
+    portraits,
+    report,
+    terrains,
+  };
+
+  return <DuelPanel kit={kit} />;
+}
+
+/* ------------------------------- DUEL ----------------------------- *
+ * The reference calculator's framing, taken seriously.
+ *
+ * AWBW's own tool is symmetric: two armies fully specified side by side, a
+ * swap between them, and the exchange read across the middle.
+ *
+ * What is bold here is the scale. The board's own forecast sets its figures
+ * at the HUD floor; this sets them well above it, because in the source game
+ * a damage number is not a table cell. Silkscreen is a bitmap face and scales
+ * up the way the game's own numerals do — the floor rule sets a minimum and
+ * never a maximum.
+ *
+ * Each column carries what the unit standing in it does: the attacker's
+ * damage under the attacker, the reply under the defender. That is the
+ * reference tool's own arrangement and the one every player already reads,
+ * so it is not re-derived here. "Deals" and "Takes" are still said from the
+ * attacking seat, exactly as the order menu says them.
+ * ------------------------------------------------------------------ */
+
+function DuelPanel({ kit }: { kit: PanelKit }) {
+  const row = kit.report?.rows?.[0];
+  const result = row?.result;
+  const attackerName = unitName(kit.catalog, kit.attacker.unit);
+  const targetName = row?.name ?? unitName(kit.catalog, kit.defender.unit);
+
+  return (
+    <PanelFrame kit={kit}>
+      <VStack gap={0} isScrollable xstyle={styles.body}>
+        <Grid align="start" xstyle={styles.duelGrid}>
+          <DuelColumn kit={kit} role="Attacking" />
+
+          {/* The axis the exchange happens across, and the one command that
+              turns it around. It sits on the centreline rather than in the
+              head, because swapping is a thing done to the two columns. */}
+          <VStack align="center" gap={0} justify="center" xstyle={styles.axis}>
+            <span {...stylex.props(styles.axisRule)} />
+            <button
+              onClick={kit.onSwap}
+              title="Swap the two armies"
+              type="button"
+              {...stylex.props(styles.swap)}
+            >
+              <span aria-hidden="true">⇄</span>
+              <span {...stylex.props(styles.hiddenLabel)}>Swap the two armies</span>
+            </button>
+          </VStack>
+
+          <DuelColumn kit={kit} role="Defending" />
+        </Grid>
+
+        <span {...stylex.props(styles.hiddenLabel)}>
+          {engagementLabel(attackerName, targetName, kit.defender, result, row?.impossible)}
+        </span>
+
+        {result ? (
+          <Grid aria-hidden="true" align="start" columns={2} gap={2} xstyle={styles.duelOutput}>
+            <VStack align="center" gap={0.5} xstyle={styles.duelFigure}>
+              <span {...stylex.props(styles.duelLabel)}>Deals</span>
+              <span {...stylex.props(styles.duelPercent)}>{formatDamage(result.damage)}</span>
+              <span {...stylex.props(styles.duelFunds)}>
+                {formatFundsBracket(result.valueDealt)}
+              </span>
+            </VStack>
+
+            {/* The reply, split the way the reference tool splits it. One
+                range folds two different spreads together — how much of the
+                target survives, and the luck it answers with — and a player
+                reading 27 – 36% cannot tell which part is which. The rungs
+                separate them: one per health it may be left standing in,
+                each carrying the luck alone. Below two rungs there is no
+                spread to show, so the single range says it better. */}
+            <VStack align="center" gap={0.5} xstyle={styles.duelFigure}>
+              <span {...stylex.props(styles.duelLabel)}>
+                {result.counterFirst ? "Takes 1st" : "Takes"}
+              </span>
+              {result.counterSteps.length > 1 ? (
+                <VStack as="ul" gap={0.5} xstyle={styles.rungs}>
+                  {result.counterSteps.map((step) => (
+                    <HStack align="center" as="li" gap={2} key={step.targetHealth}>
+                      <span {...stylex.props(styles.rungAt)}>
+                        @{pointsToBars(step.targetHealth)} HP
+                      </span>
+                      <span {...stylex.props(styles.rungPercent)}>
+                        {formatDamage(step.counter)}
+                      </span>
+                    </HStack>
+                  ))}
+                </VStack>
+              ) : (
+                <span {...stylex.props(styles.duelPercent, !result.counter && styles.muted)}>
+                  {result.counter ? formatDamage(result.counter) : "—"}
+                </span>
+              )}
+              <span {...stylex.props(styles.duelFunds)}>
+                {result.valueTaken ? formatFundsBracket(result.valueTaken) : "—"}
+              </span>
+            </VStack>
+          </Grid>
+        ) : (
+          <Grid columns={1} xstyle={styles.duelOutput}>
+            <span {...stylex.props(styles.panelLabel)}>
+              {row
+                ? impossibleLabel(row.impossible ?? "no-weapon")
+                : (kit.missingFigures ?? (kit.isScoring ? "Scoring…" : "No score available."))}
+            </span>
+          </Grid>
+        )}
+
+        <HStack align="center" gap={2} justify="center" wrap="wrap" xstyle={styles.duelNet}>
+          <span {...stylex.props(styles.duelLabel)}>Net</span>
+          <span {...stylex.props(styles.netValue)}>{result ? formatNet(result.net) : "—"}</span>
+          {result?.destroys ? (
+            <span {...stylex.props(styles.panelLabel)}>Destroys</span>
+          ) : result?.mayDestroy ? (
+            <span {...stylex.props(styles.panelLabel)}>May destroy</span>
+          ) : null}
+        </HStack>
+      </VStack>
+    </PanelFrame>
+  );
+}
+
+/**
+ * One army, fully specified.
+ *
+ * The seat is named and the army is not. Which army is standing in a seat is
+ * already told by the portrait, by the colours its unit sprite is drawn in,
+ * and by the match the panel opened over; spelling out "Orange Star" beside
+ * all three buys a line of height to repeat what is already on screen twice.
+ *
+ * The faction wash stays. It is not doing informational work the way a
+ * faction chip on a roster row does — the seat is named in words above it and
+ * the portrait and unit sprite are already the army's — so it echoes what is
+ * on screen rather than being the only thing saying it.
+ */
+function DuelColumn({ kit, role }: { kit: PanelKit; role: "Attacking" | "Defending" }) {
+  const isAttacker = role === "Attacking";
+  const side = isAttacker ? kit.attackerSide : kit.defenderSide;
+  const onChange = isAttacker ? kit.onAttackerChange : kit.onDefenderChange;
+  const factionCode = isAttacker ? kit.attackerFaction : kit.defenderFaction;
+  const fighter = isAttacker ? kit.attacker : kit.defender;
+
+  return (
+    <VStack
+      as="section"
+      gap={1}
+      xstyle={[
+        styles.duelColumn,
+        styles.factionWash(
+          `var(--color-faction-${factionCode}-wash, ${colorVars["--color-background-muted"]})`,
+        ),
+        !isAttacker && styles.defenderColumn,
+      ]}
+    >
+      <VStack as="span" gap={0} xstyle={styles.role}>
+        {isAttacker ? "Attacker" : "Defender"}
+      </VStack>
+
+      <SpritePicker
+        label={`${role} commander`}
+        onChange={(value) => onChange({ ...side, commander: value as CalculatorSide["commander"] })}
+        options={kit.commanders}
+        shape="commander"
+        triggerArt={
+          <CoPortrait
+            catalog={kit.portraits}
+            coKey={side.commander ?? "no-co"}
+            fallbackLabel={`${role} commander`}
+            hasFrame={false}
+            size={48}
+          />
+        }
+        triggerLabel={side.commander === undefined ? "No CO" : undefined}
+        value={side.commander ?? NO_COMMANDER}
+      />
+
+      <PowerSelect
+        isDisabled={side.commander === undefined}
+        label={`${role} power`}
+        onChange={(next) => onChange({ ...side, power: next })}
+        value={side.power ?? "d2d"}
+      />
+
+      <TreasuryFields isDefender={!isAttacker} onChange={onChange} role={role} side={side} />
+
+      <HStack gap={1} wrap="wrap" xstyle={styles.duelUnit}>
+        <FighterFields
+          catalog={kit.catalog}
+          factionCode={factionCode}
+          fighter={fighter}
+          onChange={isAttacker ? kit.onAttackerUnitChange : kit.onDefenderUnitChange}
+          role={isAttacker ? "Attacker" : "Target"}
+          terrainOptions={kit.terrains}
+          unitOptions={isAttacker ? kit.attackerUnits : kit.defenderUnits}
+        />
+      </HStack>
+    </VStack>
+  );
+}
+
+/** Everything the panel's parts need, gathered once. */
+interface PanelKit {
+  attacker: BattleFighter;
+  attackerFaction: string;
+  attackerSide: CalculatorSide;
+  attackerUnits: SpritePickerOption[];
+  catalog: BattleCatalog | null;
+  commanders: SpritePickerOption[];
+  defender: BattleFighter;
+  defenderFaction: string;
+  defenderSide: CalculatorSide;
+  defenderUnits: SpritePickerOption[];
+  failure: string | null;
+  isScoring: boolean;
+  /** Whether the panel is a sheet on the viewport rather than a window on the board. */
+  isSheet: boolean;
+  onAttackerChange: (side: CalculatorSide) => void;
+  onAttackerUnitChange: (fighter: BattleFighter) => void;
+  onDefenderChange: (side: CalculatorSide) => void;
+  onDefenderUnitChange: (fighter: BattleFighter) => void;
+  onDismiss: () => void;
+  onRestoreFocus: () => void;
+  /** Turn the engagement around: both armies change seats at once. */
+  onSwap: () => void;
+  missingFigures: string | null;
+  portraits: CoPortraitCatalog;
+  report: BattleReportWire | null;
+  terrains: SpritePickerOption[];
+}
+
+/**
+ * The shell the panel stands in, in whichever of the two shapes it was asked
+ * for, and the keyboard contract the board menus already hold.
+ *
+ * Both shapes are the ones the board's own menus use, and for the same reasons.
+ * A sheet is the system's dialog: it takes the top layer, dims the board behind
+ * it, locks the page's scroll, traps the keyboard and hands a single Escape to
+ * whatever is layered over it. A window on the board is deliberately none of
+ * those things — a player reads the map while they use it — so it is the one
+ * that has to keep the promises itself.
+ *
+ * Either way the board takes its keyboard back when the panel goes, so a player
+ * who opened it mid-turn is exactly where they were.
+ */
+function PanelFrame({ children, kit }: { children: React.ReactNode; kit: PanelKit }) {
+  useEffect(() => {
+    document
+      .querySelector<HTMLElement>(
+        '[aria-label="Battle calculator"][data-autofocus], [aria-label="Battle calculator"] [data-autofocus]',
+      )
+      ?.focus();
+
+    return () => {
+      if (document.activeElement === null || document.activeElement === document.body) {
+        kit.onRestoreFocus();
+      }
+    };
+    // The restore runs once, when the panel goes away.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const panel = (
+    <>
+      <HStack align="center" gap={2} justify="between" wrap="wrap" xstyle={styles.header}>
+        <span {...stylex.props(styles.panelLabel)}>Battle calculator</span>
+        <Button
+          clickAction={kit.onDismiss}
+          icon={<CloseIcon aria-hidden height={16} width={16} />}
+          label="Close"
+          size="sm"
+          variant="secondary"
+        />
+      </HStack>
+
+      {children}
+
+      <HStack align="center" gap={2} justify="between" wrap="wrap" xstyle={styles.footer}>
+        {kit.failure ? (
+          <span role="alert" {...stylex.props(styles.failure)}>
+            {kit.failure}
+          </span>
+        ) : (
+          <span {...stylex.props(styles.hint)}>
+            Read the top of Deals with the bottom of Takes.
+          </span>
+        )}
+      </HStack>
+    </>
+  );
+
+  if (kit.isSheet) {
+    return (
+      <Dialog
+        aria-label="Battle calculator"
+        isOpen
+        maxHeight={SHEET_MAX_BLOCK_SIZE}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) kit.onDismiss();
+        }}
+        padding={0}
+        // A form rather than an informational dialog: a press outside is not an
+        // answer to a panel the player has spent eight controls describing an
+        // engagement in, so only Escape and the close key take it away.
+        purpose="form"
+        position={{ bottom: 0, left: 0, right: 0 }}
+        width="100%"
+        xstyle={styles.sheet}
+      >
+        {/* The sheet takes the focus a modal has to place somewhere. Without a
+            target the browser falls to the first control in the panel, which
+            then wears a focus ring nobody asked for. */}
+        <VStack data-autofocus gap={0} tabIndex={-1} xstyle={styles.sheetBody}>
+          {panel}
+        </VStack>
+      </Dialog>
+    );
+  }
+
+  return (
+    <VStack
+      aria-label="Battle calculator"
+      data-autofocus
+      gap={0}
+      onKeyDown={(event) => {
+        // A picker, a list or a menu standing over the panel owns Escape while
+        // it is open: a player dismissing the unit grid is asking to close the
+        // grid, and taking the whole calculator away with it would throw out
+        // the engagement they spent four controls describing. Everything that
+        // opens over the panel opens in the top layer, and a control holding
+        // one open says so on itself, so the two together are the whole test:
+        // the key landed inside a layer, or on the trigger that opened it.
+        // The sheet needs none of this: the dialog defers to the top layer on
+        // its own.
+        if (event.key !== "Escape") return;
+        if (
+          event.target instanceof Element &&
+          event.target.closest('[popover], [aria-expanded="true"]')
+        ) {
+          return;
+        }
+        event.preventDefault();
+        kit.onDismiss();
+      }}
+      role="dialog"
+      tabIndex={-1}
+      xstyle={styles.boardPanel}
+    >
+      {panel}
+    </VStack>
+  );
+}
+
+/**
+ * One army's premise, on a single line.
+ *
+ * Each figure says what it is with the icon the roster already uses for it —
+ * the coin, the building, the tower — standing inside the field rather than in
+ * a row of words above it. A player has been reading these three marks on
+ * every army panel since they arrived, and a written label bought two lines of
+ * height to repeat what the coin says. The name is still on the field for
+ * anyone hearing it read.
+ */
+function TreasuryFields({
+  isDefender,
+  onChange,
+  role,
+  side,
+}: {
+  isDefender: boolean;
+  onChange: (side: CalculatorSide) => void;
+  role: string;
+  side: CalculatorSide;
+}) {
+  return (
+    <Grid
+      align="center"
+      columnGap={2}
+      rowGap={1}
+      xstyle={[styles.treasury, isDefender && styles.defenderTreasury]}
+    >
+      <VStack gap={0} xstyle={styles.leftToRight}>
+        <NumberInput
+          isLabelHidden
+          label={`${role} funds`}
+          min={0}
+          onChange={(value) => onChange({ ...side, funds: Math.max(0, value ?? 0) })}
+          size="sm"
+          startIcon={<StatIcon art={COIN} />}
+          step={1000}
+          value={side.funds}
+        />
+      </VStack>
+      {/* A tower is a property, so the count includes it. Bounding each field
+          by the other is what keeps the pair from describing an army holding
+          three towers and one building. */}
+      <VStack gap={0} xstyle={styles.leftToRight}>
+        <NumberInput
+          isLabelHidden
+          label={`${role} properties, com towers included`}
+          max={200}
+          min={side.comTowers ?? 0}
+          onChange={(value) =>
+            onChange({ ...side, properties: clamp(value, side.comTowers ?? 0, 200) })
+          }
+          size="sm"
+          startIcon={<StatIcon art={PROPERTY} />}
+          value={side.properties}
+        />
+      </VStack>
+      <VStack gap={0} xstyle={styles.leftToRight}>
+        <NumberInput
+          isLabelHidden
+          label={`${role} com towers`}
+          max={side.properties ?? 200}
+          min={0}
+          onChange={(value) =>
+            onChange({ ...side, comTowers: clamp(value, 0, side.properties ?? 200) })
+          }
+          size="sm"
+          startIcon={<StatIcon art={COM_TOWER} />}
+          value={side.comTowers}
+        />
+      </VStack>
+    </Grid>
+  );
+}
+
+/** What the three power keys offer, in the order a charge fills. */
+const POWER_KEYS = [
+  { value: "d2d", label: "Day to day", art: null },
+  { value: "cop", label: "CO power", art: POWER_MARK },
+  { value: "scop", label: "Super CO power", art: SUPER_POWER_MARK },
+] as const;
+
+/**
+ * Which power an army is running, said in the game's own lettering.
+ *
+ * A player has read POWER and SUPER across the screen every time either one
+ * fired, and has never once read COP or SCOP anywhere but a forum post. The
+ * banners are the source game's own art at its own size, so the control is
+ * read rather than decoded. Day-to-day keeps a word, because it is the absence
+ * of a banner and there is no art for a thing not happening.
+ *
+ * It is a radio group rather than three toggles: the three states are one
+ * choice, and two of them showing off at once would describe a match no board
+ * can be in.
+ */
+function PowerSelect({
+  isDisabled,
+  label,
+  onChange,
+  value,
+}: {
+  isDisabled: boolean;
+  label: string;
+  onChange: (power: PowerLevel | undefined) => void;
+  value: PowerLevel | "d2d";
+}) {
+  const keys = useRef<(HTMLButtonElement | null)[]>([]);
+  const at = POWER_KEYS.findIndex((key) => key.value === value);
+
+  return (
+    <HStack
+      aria-disabled={isDisabled || undefined}
+      aria-label={label}
+      as="div"
+      gap={0}
+      onKeyDown={(event) => {
+        const step = event.key === "ArrowRight" ? 1 : event.key === "ArrowLeft" ? -1 : 0;
+        if (step === 0 || isDisabled) return;
+        event.preventDefault();
+        const next = (at + step + POWER_KEYS.length) % POWER_KEYS.length;
+        const key = POWER_KEYS[next];
+        if (!key) return;
+        onChange(key.value === "d2d" ? undefined : (key.value as PowerLevel));
+        keys.current[next]?.focus();
+      }}
+      role="radiogroup"
+      xstyle={[styles.powerGroup, isDisabled && styles.powerGroupDisabled]}
+    >
+      {POWER_KEYS.map((key, index) => (
+        <button
+          aria-checked={key.value === value}
+          disabled={isDisabled}
+          key={key.value}
+          onClick={() => onChange(key.value === "d2d" ? undefined : (key.value as PowerLevel))}
+          ref={(element) => {
+            keys.current[index] = element;
+          }}
+          role="radio"
+          tabIndex={key.value === value ? 0 : -1}
+          type="button"
+          {...stylex.props(styles.powerKey, key.value === value && styles.powerKeySelected)}
+        >
+          <span aria-hidden="true" style={key.art ?? undefined} {...stylex.props(styles.spriteArt)}>
+            {key.art ? null : "D2D"}
+          </span>
+          <span {...stylex.props(styles.hiddenLabel)}>{key.label}</span>
+        </button>
+      ))}
+    </HStack>
+  );
+}
+
+/**
+ * A unit, its condition, and the ground under it.
+ *
+ * The same four controls for the attacker and for the defender, because they
+ * are the same four facts: which unit, how much of it is left, what it is
+ * standing on, and what it has left to fire.
+ */
+function FighterFields({
+  catalog,
+  factionCode,
+  fighter,
+  onChange,
+  role,
+  terrainOptions,
+  unitOptions,
+}: {
+  catalog: BattleCatalog | null;
+  factionCode: string;
+  fighter: BattleFighter;
+  onChange: (fighter: BattleFighter) => void;
+  role: string;
+  terrainOptions: SpritePickerOption[];
+  unitOptions: SpritePickerOption[];
+}) {
+  const entry = unitEntry(catalog?.units ?? [], fighter.unit);
+  const bars = pointsToBars(fighter.health);
+  const ground = terrainEntry(catalog?.terrains ?? [], fighter.terrain);
+
+  return (
+    <HStack gap={0} xstyle={styles.fighterFields}>
+      {/* The picker carries the sprite that used to stand beside it, so the
+          art is the control rather than a caption on one.
+
+          Both triggers draw their art at one and both grids draw it at two.
+          The row is where a name has to survive next to three other controls,
+          and a sprite at two takes the width the name needs; the grid is where
+          the choice is actually made, and there the art leads. */}
+      <SpritePicker
+        label={`${role} unit`}
+        onChange={(value) => {
+          const next = unitEntry(catalog?.units ?? [], value as UnitKind);
+          if (next) onChange(retypeFighter(fighter, next));
+        }}
+        options={unitOptions}
+        shape="unit"
+        triggerArt={<UnitSprite factionCode={factionCode} scale={1} unit={fighter.unit} />}
+        triggerXstyle={styles.unitField}
+        value={fighter.unit}
+      />
+
+      {/* Health is a count from one to ten, so it is typed or stepped like
+          one. A list of ten fixed choices made the shortest question on the
+          row into the widest control on it, and made "nine" a thing to find
+          rather than a thing to enter. */}
+      <NumberInput
+        isLabelHidden
+        label={`${role} health`}
+        max={HEALTH_BARS_MAX}
+        min={1}
+        onChange={(value) =>
+          onChange({ ...fighter, health: barsToPoints(clamp(value ?? 1, 1, 10)) })
+        }
+        size="sm"
+        startIcon={<StatIcon art={HP} />}
+        value={bars}
+        xstyle={styles.healthField}
+      />
+
+      {/* The trigger shows the tile square alone and the grid shows the whole
+          cell. What rises above a tile is half its art and twice its height,
+          and a row that made room for a mountain peak would carry that height
+          across the whole column for the sake of eight tiles that have one. */}
+      <SpritePicker
+        label={`${role} terrain`}
+        onChange={(value) => onChange({ ...fighter, terrain: value as Terrain })}
+        options={terrainOptions}
+        shape="terrain"
+        triggerArt={
+          ground ? (
+            <span
+              aria-hidden="true"
+              style={terrainTileStyle(ground.spriteIndex)}
+              {...stylex.props(styles.spriteArt)}
+            />
+          ) : null
+        }
+        triggerXstyle={styles.terrainField}
+        value={fighter.terrain}
+      />
+
+      {/* Ammo is asked only of units that carry a magazine, and it is asked
+          because it changes which weapon fires: a Tank out of shells answers
+          another Tank with its machine gun, which is a different attack and not
+          only a weaker one. */}
+      {entry && entry.maxAmmo > 0 ? (
+        <NumberInput
+          isLabelHidden
+          label={`${role} ammo`}
+          max={entry.maxAmmo}
+          min={0}
+          onChange={(value) => onChange({ ...fighter, ammo: clamp(value ?? 0, 0, entry.maxAmmo) })}
+          size="sm"
+          startIcon={<StatIcon art={AMMO} />}
+          value={fighter.ammo ?? entry.maxAmmo}
+          xstyle={styles.ammoField}
+        />
+      ) : null}
+    </HStack>
+  );
+}
+
+/**
+ * The mark standing inside a field, naming what the field counts.
+ *
+ * Decoration to a reader: the field it sits in carries the name in words, so
+ * an icon that also announced itself would say the same thing twice.
+ */
+function StatIcon({ art }: { art: React.CSSProperties | null }) {
+  if (!art) return null;
+  return <span aria-hidden="true" style={art} {...stylex.props(styles.spriteArt)} />;
+}
+
+/** A unit in an army's colours, at a whole multiple of its own pixels. */
+function UnitSprite({
+  factionCode,
+  scale,
+  unit,
+}: {
+  factionCode: string;
+  scale: 1 | 2;
+  unit: UnitKind;
+}) {
+  const sprite = unitSpriteStyle(unit, factionCode, scale);
+  if (!sprite) return null;
+
+  return (
+    <span aria-hidden="true" {...stylex.props(styles.sprite)} style={unitSpriteSize(scale)}>
+      <span style={sprite} {...stylex.props(styles.spriteArt)} />
+    </span>
+  );
+}
+
+/**
+ * What each picker may offer, built once per army rather than per control.
+ *
+ * The units are filed under where they travel, which is the division the
+ * game's own build menus use and the one a player is already thinking in: a
+ * question about a Battleship is never answered by scrolling past the Recon.
+ */
+function unitOptionsFor(catalog: BattleCatalog | null, factionCode: string): SpritePickerOption[] {
+  return (
+    [...(catalog?.units ?? [])]
+      // The ruleset names its units in its own order, which is alphabetical and
+      // puts an Anti-Air, a B-Copter and a Battleship in a row. Gathering each
+      // domain is what makes the headings mean anything.
+      .sort(
+        (left, right) =>
+          DOMAIN_ORDER.indexOf(left.domain) - DOMAIN_ORDER.indexOf(right.domain) ||
+          left.name.localeCompare(right.name),
+      )
+      .map((unit) => ({
+        value: unit.unit,
+        label: unit.name,
+        detail: formatFunds(unit.cost),
+        art: <UnitSprite factionCode={factionCode} scale={2} unit={unit.unit} />,
+        group: DOMAIN_NAMES[unit.domain],
+      }))
+  );
+}
+
+/** Where a unit travels, in the order the build menus ask for it. */
+const DOMAIN_ORDER: CatalogDomain[] = ["ground", "air", "sea"];
+
+const DOMAIN_NAMES: Record<CatalogDomain, string> = {
+  ground: "Ground",
+  air: "Air",
+  sea: "Sea",
+};
+
+function terrainOptionsFor(catalog: BattleCatalog | null): SpritePickerOption[] {
+  return (catalog?.terrains ?? []).map((terrain) => ({
+    value: terrain.terrain,
+    label: terrain.name,
+    // The stars are the whole reason terrain is in this panel, so they are the
+    // figure on the cell rather than a suffix on the name.
+    detail: `${terrain.stars}★`,
+    art: (
+      <span
+        aria-hidden="true"
+        style={terrainSpriteStyle(terrain.spriteIndex, 2)}
+        {...stylex.props(styles.spriteArt)}
+      />
+    ),
+  }));
+}
+
+/**
+ * The commanders a player may pick, which is all of them and only them.
+ *
+ * "No CO" is not among them. It is a state a match can arrive in and the panel
+ * still shows it when a board reports it, but it is not an answer to "who is
+ * commanding": nobody weighing an attack wants to know what it would cost with
+ * the commanders taken away, and offering it puts a cell that empties the
+ * question in the middle of the twenty-nine that answer it.
+ */
+function commanderOptionsFor(
+  catalog: BattleCatalog | null,
+  portraits: CoPortraitCatalog,
+): SpritePickerOption[] {
+  return (catalog?.commanders ?? []).map((entry) => ({
+    value: entry.commander,
+    label: entry.name,
+    art: (
+      <CoPortrait
+        catalog={portraits}
+        coKey={entry.commander}
+        fallbackLabel={entry.name}
+        hasFrame={false}
+        size={64}
+      />
+    ),
+  }));
+}
+
+function blankFighter(): BattleFighter {
+  return {
+    unit: FALLBACK_UNIT,
+    health: FULL_HEALTH_POINTS,
+    ammo: undefined,
+    terrain: defaultTerrain("ground"),
+  };
+}
+
+function completeSide(side: CalculatorSide): BattleSide | null {
+  if (side.funds === undefined || side.properties === undefined || side.comTowers === undefined) {
+    return null;
+  }
+  return { ...side, funds: side.funds, properties: side.properties, comTowers: side.comTowers };
+}
+
+function errorMessage(error: BattleCalculatorError): string {
+  const instruction = {
+    health: "Check unit health.",
+    properties: "Check the property count.",
+    "com-towers": "Check the com tower count.",
+    layout: "Check the engagement.",
+  }[error.kind];
+  return `${instruction} ${error.message}`;
+}
+
+function unexpectedErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function missingFigureInstruction(
+  attacker: CalculatorSide,
+  defender: CalculatorSide,
+): string | null {
+  const missing = [
+    ...missingFiguresFor("attacker", attacker),
+    ...missingFiguresFor("defender", defender),
+  ];
+  return missing.length === 0 ? null : `Enter ${missing.join(", ")}.`;
+}
+
+function missingFiguresFor(role: string, side: CalculatorSide): string[] {
+  return [
+    side.funds === undefined ? `${role} funds` : null,
+    side.properties === undefined ? `${role} properties` : null,
+    side.comTowers === undefined ? `${role} com towers` : null,
+  ].filter((figure): figure is string => figure !== null);
+}
+
+function unitName(catalog: BattleCatalog | null, unit: UnitKind): string {
+  return unitEntry(catalog?.units ?? [], unit)?.name ?? unit;
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(Math.max(value, low), high);
+}
+
+const styles = stylex.create({
+  header: {
+    flex: "0 0 auto",
+    paddingBlock: spacingVars["--spacing-1"],
+    paddingInline: spacingVars["--spacing-2"],
+    backgroundColor: colorVars["--color-background-muted"],
+    borderBlockEndWidth: borderVars["--border-width"],
+    borderBlockEndStyle: "solid",
+    borderBlockEndColor: colorVars["--color-border-emphasized"],
+  },
+  footer: {
+    flex: "0 0 auto",
+    paddingBlock: spacingVars["--spacing-1"],
+    paddingInline: spacingVars["--spacing-2"],
+    backgroundColor: colorVars["--color-background-muted"],
+    borderBlockStartWidth: borderVars["--border-width"],
+    borderBlockStartStyle: "solid",
+    borderBlockStartColor: colorVars["--color-border-emphasized"],
+  },
+  panelLabel: {
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    color: colorVars["--color-text-secondary"],
+  },
+  role: {
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    color: colorVars["--color-text-primary"],
+  },
+  hint: {
+    fontSize: textSizeVars["--font-size-sm"],
+    color: colorVars["--color-text-secondary"],
+  },
+  failure: {
+    fontSize: textSizeVars["--font-size-sm"],
+    color: colorVars["--color-error"],
+  },
+  body: {
+    flex: "1 1 auto",
+    minBlockSize: 0,
+    overscrollBehavior: "contain",
+  },
+  muted: { opacity: 0.5 },
+  netValue: {
+    fontFamily: typographyVars["--font-family-body"],
+    fontWeight: fontWeightVars["--font-weight-bold"],
+    fontSize: textSizeVars["--font-size-base"],
+    letterSpacing: "0.04em",
+    fontVariantNumeric: "tabular-nums",
+    color: colorVars["--color-text-primary"],
+    whiteSpace: "nowrap",
+  },
+  treasury: {
+    inlineSize: "100%",
+    gridTemplateColumns: "minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr)",
+    columnGap: spacingVars["--spacing-1"],
+  },
+  defenderTreasury: {
+    direction: { default: "rtl", "@media (max-width: 559px)": "ltr" },
+  },
+  leftToRight: {
+    direction: "ltr",
+  },
+  duelGrid: {
+    flex: "0 0 auto",
+    gridTemplateColumns: {
+      default: "minmax(0, 1fr) auto minmax(0, 1fr)",
+      "@media (max-width: 559px)": "minmax(0, 1fr)",
+    },
+  },
+  duelColumn: {
+    alignItems: "flex-start",
+    minInlineSize: 0,
+    padding: spacingVars["--spacing-2"],
+  },
+  defenderColumn: {
+    alignItems: { default: "flex-end", "@media (max-width: 559px)": "flex-start" },
+  },
+  factionWash: (color: string) => ({ backgroundColor: color }),
+  duelUnit: {
+    maxInlineSize: "100%",
+  },
+  axis: {
+    position: "relative",
+    alignSelf: "stretch",
+    inlineSize: { default: spacingVars["--spacing-7"], "@media (max-width: 559px)": "auto" },
+    blockSize: { default: "auto", "@media (max-width: 559px)": spacingVars["--spacing-8"] },
+  },
+  axisRule: {
+    position: "absolute",
+    insetBlock: { default: 0, "@media (max-width: 559px)": "auto" },
+    insetInline: { default: "auto", "@media (max-width: 559px)": 0 },
+    insetBlockStart: { default: 0, "@media (max-width: 559px)": "50%" },
+    insetInlineStart: { default: "50%", "@media (max-width: 559px)": 0 },
+    inlineSize: {
+      default: borderVars["--border-width"],
+      "@media (max-width: 559px)": "auto",
+    },
+    blockSize: {
+      default: "auto",
+      "@media (max-width: 559px)": borderVars["--border-width"],
+    },
+    backgroundColor: colorVars["--color-border-emphasized"],
+  },
+  swap: {
+    position: "relative",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    inlineSize: spacingVars["--spacing-6"],
+    blockSize: spacingVars["--spacing-6"],
+    padding: 0,
+    borderWidth: borderVars["--border-width"],
+    borderStyle: "solid",
+    borderColor: colorVars["--color-border-emphasized"],
+    borderRadius: radiusVars["--radius-element"],
+    backgroundColor: colorVars["--color-background-surface"],
+    boxShadow: { default: shadowVars["--shadow-low"], ":active": "none" },
+    color: colorVars["--color-text-primary"],
+    fontSize: textSizeVars["--font-size-base"],
+    cursor: "pointer",
+    transform: {
+      default: "none",
+      ":active": `translate(${spacingVars["--spacing-0-5"]}, ${spacingVars["--spacing-0-5"]})`,
+    },
+    outline: {
+      default: "none",
+      ":focus-visible": `${borderVars["--border-width"]} solid ${colorVars["--color-accent"]}`,
+    },
+    outlineOffset: { default: 0, ":focus-visible": `calc(-1 * ${borderVars["--border-width"]})` },
+  },
+  duelOutput: {
+    flex: "0 0 auto",
+    padding: spacingVars["--spacing-2"],
+    borderBlockStartWidth: borderVars["--border-width"],
+    borderBlockStartStyle: "solid",
+    borderBlockStartColor: colorVars["--color-border-emphasized"],
+    backgroundColor: colorVars["--color-background-muted"],
+  },
+  duelFigure: { minInlineSize: 0 },
+  duelPercent: {
+    fontFamily: typographyVars["--font-family-body"],
+    fontWeight: fontWeightVars["--font-weight-bold"],
+    fontSize: {
+      default: textSizeVars["--font-size-xl"],
+      "@media (max-width: 559px)": textSizeVars["--font-size-lg"],
+    },
+    lineHeight: 1.1,
+    letterSpacing: 0,
+    fontVariantNumeric: "tabular-nums",
+    color: colorVars["--color-text-primary"],
+    whiteSpace: "nowrap",
+  },
+  duelLabel: {
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    color: colorVars["--color-text-secondary"],
+    fontVariantNumeric: "tabular-nums",
+  },
+  duelFunds: {
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    color: colorVars["--color-text-secondary"],
+    fontVariantNumeric: "tabular-nums",
+  },
+  rungs: {
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+  },
+  rungAt: {
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    fontVariantNumeric: "tabular-nums",
+    color: colorVars["--color-text-secondary"],
+    whiteSpace: "nowrap",
+  },
+  rungPercent: {
+    fontFamily: typographyVars["--font-family-body"],
+    fontWeight: fontWeightVars["--font-weight-bold"],
+    fontSize: {
+      default: textSizeVars["--font-size-lg"],
+      "@media (max-width: 559px)": textSizeVars["--font-size-base"],
+    },
+    lineHeight: 1.15,
+    fontVariantNumeric: "tabular-nums",
+    color: colorVars["--color-text-primary"],
+    whiteSpace: "nowrap",
+  },
+  duelNet: {
+    flex: "0 0 auto",
+    paddingBlock: spacingVars["--spacing-1"],
+    paddingInline: spacingVars["--spacing-2"],
+    borderBlockStartWidth: borderVars["--border-width"],
+    borderBlockStartStyle: "solid",
+    borderBlockStartColor: colorVars["--color-border"],
+    backgroundColor: colorVars["--color-background-muted"],
+  },
+  // The panel as a window the board opened: the standard panel, lifted to the
+  // level this system reserves for content that overlays other content. It
+  // takes the board's height rather than asking for its own, so the map is
+  // never pushed off the frame.
+  boardPanel: {
+    position: "absolute",
+    insetBlockStart: spacingVars["--spacing-2"],
+    insetInlineEnd: spacingVars["--spacing-2"],
+    inlineSize: `calc(100% - 2 * ${spacingVars["--spacing-2"]})`,
+    maxInlineSize: "min(100%, 60rem)",
+    maxBlockSize: `calc(100% - 2 * ${spacingVars["--spacing-2"]})`,
+    minBlockSize: 0,
+    borderWidth: borderVars["--border-width"],
+    borderStyle: "solid",
+    borderColor: colorVars["--color-border-emphasized"],
+    borderRadius: radiusVars["--radius-container"],
+    backgroundColor: colorVars["--color-background-surface"],
+    boxShadow: shadowVars["--shadow-high"],
+    color: colorVars["--color-text-primary"],
+    outline: "none",
+    overflow: "hidden",
+    zIndex: 3,
+  },
+  sheet: {
+    // A sheet takes the whole bottom edge; the stock dialog width cap would
+    // leave it floating in the middle of the screen instead.
+    maxWidth: "100%",
+    borderRadius: `${radiusVars["--radius-container"]} ${radiusVars["--radius-container"]} 0 0`,
+    borderBlockEndWidth: 0,
+    // The board behind the sheet is dimmed, not defocused. A blurred backdrop
+    // is the one soft edge this system does not have anywhere else.
+    "::backdrop": { backdropFilter: "none" },
+  },
+  sheetBody: {
+    minBlockSize: 0,
+    blockSize: "100%",
+    outline: "none",
+    // The sheet ends at the bottom edge of the device, not at the bottom edge
+    // of the screen.
+    paddingBlockEnd: "env(safe-area-inset-bottom)",
+  },
+  fighterFields: {
+    display: "flex",
+    alignItems: "center",
+    gap: spacingVars["--spacing-2"],
+    minInlineSize: 0,
+    flexWrap: "wrap",
+  },
+  // The name of a control whose art already says what it is, kept for anyone
+  // hearing it read.
+  hiddenLabel: {
+    position: "absolute",
+    inlineSize: 1,
+    blockSize: 1,
+    padding: 0,
+    margin: -1,
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
+  // Three keys under one outline, parted by the same rule. It is the game's
+  // own menu strip: a row of commands with the cursor sitting on one of them.
+  powerGroup: {
+    display: "flex",
+    alignItems: "stretch",
+    alignSelf: "flex-start",
+    maxInlineSize: "100%",
+    borderWidth: borderVars["--border-width"],
+    borderStyle: "solid",
+    borderColor: colorVars["--color-border-emphasized"],
+    borderRadius: radiusVars["--radius-element"],
+    backgroundColor: colorVars["--color-background-surface"],
+    overflow: "hidden",
+  },
+  // A disabled command in this game is still a key on the menu, so it keeps
+  // its outline and lies flat rather than disappearing.
+  powerGroupDisabled: {
+    opacity: 0.5,
+    cursor: "not-allowed",
+  },
+  powerKey: {
+    display: "flex",
+    flex: "0 0 auto",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingBlock: spacingVars["--spacing-1"],
+    paddingInline: spacingVars["--spacing-2"],
+    borderWidth: 0,
+    borderInlineStartWidth: { default: borderVars["--border-width"], ":first-child": 0 },
+    borderInlineStartStyle: "solid",
+    borderInlineStartColor: colorVars["--color-border-emphasized"],
+    backgroundColor: {
+      default: "transparent",
+      ":hover": { "@media (hover: hover)": colorVars["--color-background-muted"] },
+    },
+    color: colorVars["--color-text-secondary"],
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    cursor: "pointer",
+    outline: {
+      default: null,
+      ":focus-visible": `2px solid ${colorVars["--color-accent"]}`,
+    },
+    outlineOffset: { default: null, ":focus-visible": "-2px" },
+    ":disabled": { cursor: "not-allowed" },
+  },
+  powerKeySelected: {
+    backgroundColor: {
+      default: colorVars["--color-accent"],
+      ":hover": { "@media (hover: hover)": colorVars["--color-accent"] },
+    },
+    color: colorVars["--color-text-primary"],
+  },
+  sprite: {
+    position: "relative",
+    display: "block",
+    flex: "0 0 auto",
+  },
+  spriteArt: {
+    display: "block",
+    flex: "0 0 auto",
+  },
+  // The four field widths are fixed rather than fluid because the two armies
+  // are read across the centreline: a control sized to its own contents would
+  // put the defender's health somewhere other than opposite the attacker's.
+  //
+  // Sized to hold the art, the name and the caret. "Battleship" and "Missile
+  // Silo" are the two names that still run past this and lose their last
+  // letters to an ellipsis; both stay unmistakable from the sprite beside them,
+  // and both are read whole in the grid the trigger opens.
+  unitField: {
+    inlineSize: `calc(${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-2"]})`,
+  },
+  // A mark, two digits and a stepper. Health runs one to ten and never wider.
+  healthField: {
+    inlineSize: `calc(${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-8"]})`,
+  },
+  terrainField: {
+    inlineSize: `calc(${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-6"]})`,
+  },
+  ammoField: {
+    inlineSize: `calc(${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-8"]})`,
+  },
+});

--- a/web/src/matches/components/SpritePicker.tsx
+++ b/web/src/matches/components/SpritePicker.tsx
@@ -1,0 +1,501 @@
+import { inputWrapperStyles } from "@astryxdesign/core/Field";
+import { Grid } from "@astryxdesign/core/Grid";
+import { Popover } from "@astryxdesign/core/Popover";
+import { HStack, VStack } from "@astryxdesign/core/Stack";
+import {
+  borderVars,
+  colorVars,
+  radiusVars,
+  spacingVars,
+  textSizeVars,
+  typographyVars,
+} from "@astryxdesign/core/theme/tokens.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { ChevronDown as ChevronDownIcon } from "pixelarticons/react/ChevronDown";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+
+/**
+ * Four columns, sized to the cells rather than to the room a desk has: a
+ * popover wider than its own content is a panel with a margin down the side,
+ * and this one stands over a calculator that is itself compact.
+ */
+const PANEL_INLINE_SIZE = "min(calc(100vw - var(--spacing-6)), 30rem)";
+
+/**
+ * A choice made from the art the game already draws.
+ *
+ * A unit, a commander and a tile are things a player recognises before they
+ * read: an Advance Wars player knows the Mega Tank silhouette and the mountain
+ * cell without either being named, and has known them since long before they
+ * opened this panel. A dropdown throws that away and asks them to read
+ * twenty-five names in one column instead, which is the slowest way to answer
+ * a question they could have answered by looking.
+ *
+ * So the choice is a grid of the real sprites, in the army's own colours, the
+ * way the game's own build menu asks it. The names stay under the art rather
+ * than being replaced by it, because a grid of unlabelled sprites is a memory
+ * test, and the figure that decides the choice — what a unit costs, what a
+ * tile shelters — is on the cell beside them.
+ */
+
+export interface SpritePickerOption {
+  value: string;
+  /** What the thing is called. Also what typing jumps to. */
+  label: string;
+  /**
+   * The one figure that decides between two options a player is torn over: a
+   * unit's cost, a tile's defense. Absent where there is no such figure.
+   */
+  detail?: string;
+  art: ReactNode;
+  /** The heading this option files under, for a grid worth dividing. */
+  group?: string;
+}
+
+interface SpritePickerProps {
+  /** The accessible name of the choice, e.g. "Target unit". */
+  label: string;
+  onChange: (value: string) => void;
+  options: SpritePickerOption[];
+  /** How wide one cell is, which is set by the art and the longest name. */
+  shape: keyof typeof cellStyles;
+  /** What the trigger shows: the art of the current choice, and its name. */
+  triggerArt: ReactNode;
+  /**
+   * What to call the current value when the grid does not offer it.
+   *
+   * A panel seeded from a real board can hold a state the player is not being
+   * asked to choose. The trigger reports it rather than showing the raw value
+   * the engine keyed it by.
+   */
+  triggerLabel?: string;
+  /** How wide the closed trigger is, so a row of them lines up down a column. */
+  triggerXstyle?: stylex.StyleXStyles;
+  value: string;
+}
+
+/** How long a typed run keeps counting as one word. */
+const TYPEAHEAD_WINDOW_MS = 600;
+
+export function SpritePicker({
+  label,
+  onChange,
+  options,
+  shape,
+  triggerArt,
+  triggerLabel,
+  triggerXstyle,
+  value,
+}: SpritePickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const name = triggerLabel ?? options.find((option) => option.value === value)?.label ?? value;
+
+  return (
+    <Popover
+      alignment="start"
+      // Built when it opens, not held hidden behind a closed trigger. The grid
+      // puts the keyboard on the current choice as it mounts, and a grid that
+      // mounted with the panel would have done that once, to nobody, before
+      // the player had chosen anything.
+      content={
+        isOpen ? (
+          <SpriteGrid
+            label={label}
+            onChange={(next) => {
+              onChange(next);
+              setIsOpen(false);
+            }}
+            options={options}
+            shape={shape}
+            value={value}
+          />
+        ) : null
+      }
+      hasAutoFocus={false}
+      isOpen={isOpen}
+      label={label}
+      onOpenChange={setIsOpen}
+      placement="below"
+      width={PANEL_INLINE_SIZE}
+    >
+      {(trigger) => (
+        <button
+          {...trigger}
+          aria-label={`${label}: ${name}`}
+          type="button"
+          {...stylex.props(inputWrapperStyles.base, styles.trigger, triggerXstyle)}
+        >
+          <span {...stylex.props(styles.triggerArt)}>{triggerArt}</span>
+          <span {...stylex.props(styles.triggerLabel)}>{name}</span>
+          <ChevronDownIcon aria-hidden height={14} width={14} />
+        </button>
+      )}
+    </Popover>
+  );
+}
+
+/**
+ * The open grid.
+ *
+ * It is one listbox however many headings divide it, so the arrow keys walk
+ * the whole catalogue: a player moving right off the last ground unit lands on
+ * the first air unit rather than stopping at a heading they did not put there.
+ */
+function SpriteGrid({
+  label,
+  onChange,
+  options,
+  shape,
+  value,
+}: {
+  label: string;
+  onChange: (value: string) => void;
+  options: SpritePickerOption[];
+  shape: keyof typeof cellStyles;
+  value: string;
+}) {
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((option) => option.value === value),
+  );
+  const [activeIndex, setActiveIndex] = useState(selectedIndex);
+  const cellRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const typed = useRef<{ at: number; text: string }>({ at: 0, text: "" });
+
+  // The grid opens on the current choice rather than on its first cell, so the
+  // keyboard starts where the player already is and one arrow key means "the
+  // next unit" rather than "back to Infantry".
+  useLayoutEffect(() => {
+    cellRefs.current[selectedIndex]?.focus();
+    // Only on open. Moving the selection afterwards closes the grid.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    cellRefs.current[activeIndex]?.focus();
+  }, [activeIndex]);
+
+  const columns = useGridColumns(cellRefs, options.length);
+  const groups = options.reduce<
+    { label: string | undefined; options: { option: SpritePickerOption; index: number }[] }[]
+  >((runs, option, index) => {
+    const previous = runs.at(-1);
+    if (previous && previous.label === option.group) {
+      previous.options.push({ option, index });
+    } else {
+      runs.push({ label: option.group, options: [{ option, index }] });
+    }
+    return runs;
+  }, []);
+
+  const move = (to: number) => {
+    setActiveIndex(Math.max(0, Math.min(options.length - 1, to)));
+  };
+
+  return (
+    <Grid
+      aria-label={label}
+      onKeyDown={(event) => {
+        // Escape is the browser's: the grid is a native popover and closes
+        // itself. What the panel behind it does about the same key is the
+        // panel's business, and it decides by looking at where the key landed.
+        const step: Record<string, number> = {
+          ArrowRight: 1,
+          ArrowLeft: -1,
+          ArrowDown: columns,
+          ArrowUp: -columns,
+        };
+        if (event.key in step) {
+          event.preventDefault();
+          move(activeIndex + (step[event.key] ?? 0));
+          return;
+        }
+        if (event.key === "Home" || event.key === "End") {
+          event.preventDefault();
+          move(event.key === "Home" ? 0 : options.length - 1);
+          return;
+        }
+        if (event.key.length === 1 && /\S/.test(event.key)) {
+          const now = Date.now();
+          const text =
+            (now - typed.current.at > TYPEAHEAD_WINDOW_MS ? "" : typed.current.text) + event.key;
+          typed.current = { at: now, text };
+          const match = options.findIndex((option) =>
+            option.label.toLowerCase().startsWith(text.toLowerCase()),
+          );
+          if (match >= 0) {
+            event.preventDefault();
+            move(match);
+          }
+        }
+      }}
+      role="listbox"
+      xstyle={styles.grid}
+    >
+      {groups.map((group, groupIndex) => (
+        <Grid
+          aria-label={group.label ?? label}
+          key={`${group.label ?? "options"}-${groupIndex}`}
+          role="group"
+          xstyle={styles.optionGroup}
+        >
+          {group.label === undefined ? null : (
+            <VStack
+              aria-hidden="true"
+              as="span"
+              gap={0}
+              xstyle={[styles.groupHeading, groupIndex > 0 && styles.groupHeadingLater]}
+            >
+              {group.label}
+            </VStack>
+          )}
+          {group.options.map(({ option, index }) => (
+            <Cell
+              isActive={index === activeIndex}
+              isSelected={option.value === value}
+              key={option.value}
+              onChange={onChange}
+              option={option}
+              ref={(element) => {
+                cellRefs.current[index] = element;
+              }}
+              shape={shape}
+            />
+          ))}
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+
+function Cell({
+  isActive,
+  isSelected,
+  onChange,
+  option,
+  ref,
+  shape,
+}: {
+  isActive: boolean;
+  isSelected: boolean;
+  onChange: (value: string) => void;
+  option: SpritePickerOption;
+  ref: (element: HTMLButtonElement | null) => void;
+  shape: keyof typeof cellStyles;
+}) {
+  return (
+    <button
+      aria-selected={isSelected}
+      onClick={() => onChange(option.value)}
+      ref={ref}
+      role="option"
+      tabIndex={isActive ? 0 : -1}
+      type="button"
+      {...stylex.props(styles.cell, cellStyles[shape], isSelected && styles.cellSelected)}
+    >
+      <HStack as="span" gap={0} xstyle={styles.cellArt}>
+        {option.art}
+      </HStack>
+      <VStack as="span" gap={0} xstyle={styles.cellLabel}>
+        {option.label}
+      </VStack>
+      {option.detail === undefined ? null : (
+        <VStack
+          as="span"
+          gap={0}
+          xstyle={[styles.cellDetail, isSelected && styles.cellDetailSelected]}
+        >
+          {option.detail}
+        </VStack>
+      )}
+    </button>
+  );
+}
+
+/**
+ * How many cells the grid fits on a line, measured rather than assumed.
+ *
+ * The grid fills to whatever the popover is given, so the number of columns is
+ * a fact about the rendered page and not a constant this file could hold. Down
+ * and up arrows have to agree with what the player sees.
+ */
+function useGridColumns(
+  cellRefs: React.RefObject<(HTMLButtonElement | null)[]>,
+  optionCount: number,
+): number {
+  const [columns, setColumns] = useState(1);
+
+  useEffect(() => {
+    const cells = cellRefs.current.filter((cell): cell is HTMLButtonElement => cell !== null);
+    const first = cells[0];
+    if (!first) return;
+
+    const measure = () => {
+      const top = first.offsetTop;
+      const count = cells.filter((cell) => cell.offsetTop === top).length;
+      setColumns(Math.max(1, count));
+    };
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(first);
+    return () => {
+      observer.disconnect();
+    };
+  }, [cellRefs, optionCount]);
+
+  return columns;
+}
+
+const styles = stylex.create({
+  // The closed picker wears the same frame as the fields beside it, because it
+  // is one of them: a control holding a value the player set.
+  trigger: {
+    minInlineSize: 0,
+    cursor: "pointer",
+    color: colorVars["--color-text-primary"],
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    textAlign: "start",
+  },
+  triggerArt: {
+    display: "flex",
+    flex: "0 0 auto",
+    alignItems: "flex-end",
+    justifyContent: "center",
+  },
+  triggerLabel: {
+    flex: "1 1 auto",
+    minInlineSize: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  grid: {
+    // The popover sizes itself; the grid takes all of it, or auto-fill counts
+    // its columns against a shrink-to-fit width and lays out one short of what
+    // the panel could hold.
+    inlineSize: "100%",
+    // "Battleship" and "Transport" set whole at the HUD face, plus the padding
+    // either side of them. A cell too narrow for the longest name breaks the
+    // word across two lines, and a bitmap face broken mid-word stops being
+    // readable at all.
+    gridTemplateColumns: `repeat(auto-fill, minmax(calc(${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-2"]}), 1fr))`,
+    gap: spacingVars["--spacing-1"],
+    // Deep enough to show three rows whole, so a grid that scrolls says so by
+    // cutting the fourth rather than by appearing complete.
+    maxBlockSize: "min(50vh, 20rem)",
+    overflowY: "auto",
+    overscrollBehavior: "contain",
+  },
+  optionGroup: {
+    display: "contents",
+  },
+  groupHeading: {
+    gridColumn: "1 / -1",
+    paddingBlockEnd: spacingVars["--spacing-1"],
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    color: colorVars["--color-text-secondary"],
+    borderBlockEndWidth: borderVars["--border-width"],
+    borderBlockEndStyle: "solid",
+    borderBlockEndColor: colorVars["--color-border-emphasized"],
+  },
+  groupHeadingLater: {
+    marginBlockStart: spacingVars["--spacing-2"],
+  },
+  // One key on the menu. It takes the outline every piece of chrome in this
+  // system wears and no shadow: twenty-five raised keys in a grid is a texture,
+  // not a set of choices.
+  cell: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: spacingVars["--spacing-1"],
+    paddingBlock: spacingVars["--spacing-1"],
+    paddingInline: spacingVars["--spacing-1"],
+    borderWidth: borderVars["--border-width"],
+    borderStyle: "solid",
+    borderColor: colorVars["--color-border-emphasized"],
+    borderRadius: radiusVars["--radius-element"],
+    backgroundColor: {
+      default: colorVars["--color-background-surface"],
+      ":hover": { "@media (hover: hover)": colorVars["--color-background-muted"] },
+    },
+    color: colorVars["--color-text-primary"],
+    cursor: "pointer",
+    // The cursor moves onto a key; the key does not move under the cursor.
+    outline: {
+      default: null,
+      ":focus-visible": `2px solid ${colorVars["--color-accent"]}`,
+    },
+    outlineOffset: { default: null, ":focus-visible": "2px" },
+  },
+  // The game's own cursor: an orange fill sitting flush on the chrome.
+  cellSelected: {
+    backgroundColor: {
+      default: colorVars["--color-accent"],
+      ":hover": { "@media (hover: hover)": colorVars["--color-accent"] },
+    },
+  },
+  cellArt: {
+    display: "flex",
+    flex: "1 1 auto",
+    alignItems: "flex-end",
+    justifyContent: "center",
+  },
+  cellLabel: {
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    textAlign: "center",
+    // Two-word names wrap between their words; the cell is sized so that no
+    // single word has to. A bitmap face broken mid-word stops being a name and
+    // becomes two pieces of texture.
+    overflowWrap: "normal",
+    hyphens: "none",
+  },
+  cellDetail: {
+    fontFamily: typographyVars["--font-family-code"],
+    fontSize: textSizeVars["--font-size-sm"],
+    letterSpacing: "0.06em",
+    fontVariantNumeric: "tabular-nums",
+    color: colorVars["--color-text-secondary"],
+  },
+  // On the orange cursor the secondary ink loses its contrast, so the figure
+  // joins the name at full strength rather than being tinted to survive.
+  cellDetailSelected: {
+    color: colorVars["--color-text-primary"],
+  },
+});
+
+/**
+ * How tall a cell's art is, per catalogue.
+ *
+ * A terrain cell is twice the height of a unit cell because a tile carries
+ * what rises above it — a mountain peak, an HQ roof — and cropping that away
+ * would leave a player picking mountains from a picture of grass.
+ */
+const cellStyles = stylex.create({
+  // A unit sprite at two, a name that may take two lines, and its cost. Each
+  // cell is as tall as what it holds and no taller: the grid is a menu the
+  // player is reading across, not a gallery.
+  unit: {
+    minBlockSize: `calc(${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-10"]})`,
+  },
+  // A tile is a 16x32 cell, because half of it is what rises above the tile:
+  // the peak, the roof, the tower. Drawn at two it is the tallest art here.
+  terrain: {
+    minBlockSize: `calc(${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-6"]})`,
+  },
+  // A portrait is square, and every commander's name fits on one line.
+  commander: {
+    minBlockSize: `calc(${spacingVars["--spacing-12"]} + ${spacingVars["--spacing-10"]})`,
+  },
+});

--- a/web/src/matches/components/battle_calculator.test.ts
+++ b/web/src/matches/components/battle_calculator.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import type {
+  BattleResult,
+  CatalogUnit,
+  PlayerRosterEntry,
+  PlayerRosterSnapshot,
+} from "#/wasm/awbrn_wasm.js";
+import {
+  barsToPoints,
+  commanderFrom,
+  defaultTerrain,
+  engagementLabel,
+  formatDamage,
+  formatFunds,
+  formatFundsBracket,
+  formatNet,
+  impossibleLabel,
+  newFighter,
+  pointsToBars,
+  retypeFighter,
+  seatsFrom,
+  sideFrom,
+} from "./battle_calculator.ts";
+
+function unit(overrides: Partial<CatalogUnit> = {}): CatalogUnit {
+  return {
+    unit: "tank",
+    name: "Tank",
+    cost: 7000,
+    domain: "ground",
+    maxAmmo: 9,
+    isIndirect: false,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<PlayerRosterEntry> = {}): PlayerRosterEntry {
+  return {
+    playerId: 0,
+    userId: 0,
+    turnOrder: 0,
+    team: undefined,
+    eliminated: false,
+    actualFactionCode: "os",
+    actualFactionName: "Orange Star",
+    displayFactionCode: "os",
+    displayFactionName: "Orange Star",
+    factionCode: "os",
+    factionName: "Orange Star",
+    coKey: undefined,
+    coName: undefined,
+    tagCoKey: undefined,
+    tagCoName: undefined,
+    powerCharge: undefined,
+    copCost: undefined,
+    scopCost: undefined,
+    powerStarCharge: undefined,
+    activePower: undefined,
+    stats: {
+      funds: undefined,
+      income: undefined,
+      unitCount: undefined,
+      unitValue: undefined,
+      properties: undefined,
+      comTowers: undefined,
+    },
+    ...overrides,
+  };
+}
+
+function roster(players: PlayerRosterEntry[], activePlayerId?: number): PlayerRosterSnapshot {
+  return {
+    matchId: 1,
+    mapId: 1,
+    day: 4,
+    activePlayerId,
+    players,
+  };
+}
+
+function result(overrides: Partial<BattleResult> = {}): BattleResult {
+  return {
+    weapon: "ammo",
+    damage: { low: 55, high: 64 },
+    counter: { low: 18, high: 22 },
+    counterFirst: false,
+    destroys: false,
+    mayDestroy: false,
+    valueDealt: { low: 3850, high: 4480 },
+    valueTaken: { low: 1260, high: 1540 },
+    counterSteps: [],
+    targetValue: 7000,
+    net: { low: 2310, high: 3220 },
+    ...overrides,
+  };
+}
+
+describe("health", () => {
+  it("rounds a partial bar up, the way the board draws it", () => {
+    expect(pointsToBars(61)).toBe(7);
+    expect(pointsToBars(70)).toBe(7);
+    expect(pointsToBars(100)).toBe(10);
+  });
+
+  it("never reports a standing unit as gone", () => {
+    expect(pointsToBars(1)).toBe(1);
+  });
+
+  it("converts a bar back to the points the reducer counts", () => {
+    expect(barsToPoints(7)).toBe(70);
+  });
+});
+
+describe("fighters", () => {
+  it("opens a naval unit on water rather than on a plain", () => {
+    expect(defaultTerrain("sea")).toBe("sea");
+    expect(defaultTerrain("ground")).toBe("plain");
+  });
+
+  it("starts a new unit whole and loaded", () => {
+    const fighter = newFighter(unit());
+    expect(fighter.health).toBe(100);
+    expect(fighter.ammo).toBe(9);
+  });
+
+  it("gives an unarmed unit no magazine to edit", () => {
+    expect(newFighter(unit({ unit: "apc", maxAmmo: 0 })).ammo).toBeUndefined();
+  });
+
+  it("keeps condition and ground when the unit is swapped, but not the magazine", () => {
+    const damaged = { unit: "tank" as const, health: 60, ammo: 2, terrain: "mountain" as const };
+    const swapped = retypeFighter(damaged, unit({ unit: "neo-tank", maxAmmo: 6 }));
+
+    expect(swapped.health).toBe(60);
+    expect(swapped.terrain).toBe("mountain");
+    // Six is what a Neo Tank carries; inheriting two would have been a lie in
+    // the other direction, and inheriting nine an impossibility.
+    expect(swapped.ammo).toBe(6);
+  });
+});
+
+describe("seating", () => {
+  it("puts the viewer in the attacking seat", () => {
+    const seats = seatsFrom(roster([entry({ playerId: 0 }), entry({ playerId: 1 })], 1), 0);
+    expect(seats.attacker?.playerId).toBe(0);
+    expect(seats.defender?.playerId).toBe(1);
+  });
+
+  it("falls back to whoever is acting when the viewer is a spectator", () => {
+    const seats = seatsFrom(roster([entry({ playerId: 0 }), entry({ playerId: 1 })], 1), null);
+    expect(seats.attacker?.playerId).toBe(1);
+    expect(seats.defender?.playerId).toBe(0);
+  });
+
+  it("does not seat an ally as the defender", () => {
+    const seats = seatsFrom(
+      roster(
+        [
+          entry({ playerId: 0, team: "a" }),
+          entry({ playerId: 1, team: "a" }),
+          entry({ playerId: 2, team: "b" }),
+        ],
+        0,
+      ),
+      0,
+    );
+    expect(seats.defender?.playerId).toBe(2);
+  });
+
+  it("has no seats before a board reports", () => {
+    expect(seatsFrom(null, null)).toEqual({ attacker: null, defender: null });
+  });
+});
+
+describe("side context", () => {
+  it("reads the army's own commander, money and holdings", () => {
+    const side = sideFrom(
+      entry({
+        coKey: "colin",
+        activePower: "scop",
+        stats: {
+          funds: 24_000,
+          income: 9000,
+          unitCount: 12,
+          unitValue: 40_000,
+          properties: 9,
+          comTowers: 2,
+        },
+      }),
+    );
+
+    expect(side).toEqual({
+      commander: "colin",
+      power: "scop",
+      funds: 24_000,
+      properties: 9,
+      comTowers: 2,
+    });
+  });
+
+  it("keeps withheld figures hidden", () => {
+    expect(sideFrom(entry())).toMatchObject({
+      funds: undefined,
+      properties: undefined,
+      comTowers: undefined,
+    });
+  });
+
+  it("preserves a reported zero", () => {
+    expect(
+      sideFrom(entry({ stats: { ...entry().stats, funds: 0, properties: 0, comTowers: 0 } })),
+    ).toMatchObject({ funds: 0, properties: 0, comTowers: 0 });
+  });
+
+  it("treats the portrait sheet's placeholder as no commander", () => {
+    expect(commanderFrom("no-co")).toBeUndefined();
+    expect(commanderFrom(undefined)).toBeUndefined();
+    expect(commanderFrom("hawke")).toBe("hawke");
+  });
+});
+
+describe("wording", () => {
+  it("collapses a range of one value to a single figure", () => {
+    expect(formatDamage({ low: 55, high: 55 })).toBe("55%");
+    expect(formatDamage({ low: 55, high: 64 })).toBe("55 – 64%");
+  });
+
+  it("groups funds the way money is read", () => {
+    expect(formatFunds(12_400)).toBe("12,400");
+    expect(formatFundsBracket({ low: 3850, high: 3850 })).toBe("3,850");
+    expect(formatFundsBracket({ low: 3850, high: 4480 })).toBe("3,850 – 4,480");
+  });
+
+  it("always signs the net, on both ends", () => {
+    expect(formatNet({ low: 2310, high: 3220 })).toBe("+2,310 – +3,220");
+    expect(formatNet({ low: -900, high: -900 })).toBe("−900");
+    // The bad end losing money and the good end making it is exactly the case a
+    // player is deciding on, so both signs appear in one figure.
+    expect(formatNet({ low: -900, high: 1200 })).toBe("−900 – +1,200");
+  });
+
+  it("says why a pairing has no numbers", () => {
+    expect(impossibleLabel("unarmed")).toBe("Cannot reach this target");
+    expect(impossibleLabel("no-weapon")).toBe("Attacker has no weapon entry for this target");
+  });
+});
+
+describe("the row said as a sentence", () => {
+  const target = { unit: "tank" as const, health: 100, ammo: 9, terrain: "plain" as const };
+
+  it("carries both halves of the exchange and the net", () => {
+    const label = engagementLabel("Md Tank", "Tank", target, result(), undefined);
+    expect(label).toContain("Tank at 10 HP");
+    expect(label).toContain("dealing 55 – 64%");
+    expect(label).toContain("worth 3,850 – 4,480 funds");
+    expect(label).toContain("taking 18 – 22% back");
+    expect(label).toContain("Net +2,310 – +3,220 funds");
+  });
+
+  it("distinguishes no reply from a reply that lands nothing", () => {
+    const silent = engagementLabel(
+      "Artillery",
+      "Tank",
+      target,
+      result({ counter: undefined, valueTaken: undefined }),
+      undefined,
+    );
+    expect(silent).toContain("with no reply");
+
+    const zero = engagementLabel(
+      "Artillery",
+      "Tank",
+      target,
+      result({ counter: { low: 0, high: 4 }, valueTaken: { low: 0, high: 280 } }),
+      undefined,
+    );
+    expect(zero).toContain("taking 0 – 4% back");
+    expect(zero).not.toContain("no reply");
+  });
+
+  it("marks a commander who answers first, because the order is not visible", () => {
+    expect(
+      engagementLabel("Infantry", "Mech", target, result({ counterFirst: true }), undefined),
+    ).toContain("first");
+  });
+
+  it("says a kill without waiting for the reader to compare two numbers", () => {
+    expect(
+      engagementLabel(
+        "Bomber",
+        "Tank",
+        target,
+        result({ destroys: true, counter: undefined }),
+        undefined,
+      ),
+    ).toContain("destroying it");
+    expect(
+      engagementLabel("Tank", "Recon", target, result({ mayDestroy: true }), undefined),
+    ).toContain("possibly destroying it");
+  });
+
+  it("reports an impossible pairing rather than an empty row", () => {
+    expect(engagementLabel("Anti-Air", "Battleship", target, undefined, "no-weapon")).toContain(
+      "Attacker has no weapon entry for this target",
+    );
+  });
+});

--- a/web/src/matches/components/battle_calculator.ts
+++ b/web/src/matches/components/battle_calculator.ts
@@ -1,0 +1,274 @@
+import type {
+  BattleBracket,
+  BattleFighter,
+  BattleImpossible,
+  BattleResult,
+  BattleSide,
+  CatalogDomain,
+  CatalogTerrain,
+  CatalogUnit,
+  CommanderKind,
+  FundsBracket,
+  NetFundsBracket,
+  PlayerRosterEntry,
+  PlayerRosterSnapshot,
+  Terrain,
+  UnitKind,
+} from "#/wasm/awbrn_wasm.js";
+
+/** Calculator context that can show values the board has hidden. */
+export type CalculatorSide = Omit<BattleSide, "funds" | "properties" | "comTowers"> & {
+  funds: number | undefined;
+  properties: number | undefined;
+  comTowers: number | undefined;
+};
+
+/**
+ * What the calculator is, apart from how it looks.
+ *
+ * Every number the panel prints comes back from AWVM. What lives here is the
+ * shape of the question — which two armies are being compared, what a blank
+ * calculator starts as, and how a figure is worded — none of which is a rule
+ * and all of which is worth testing without a browser.
+ */
+
+/** Health as the board draws it: ten bars, of ten points each. */
+export const FULL_HEALTH_POINTS = 100;
+export const HEALTH_STEP = 10;
+
+/** A whole unit, in the bars the board draws it in. */
+export const HEALTH_BARS_MAX = 10;
+
+/** What a bar is worth in the points the reducer counts. */
+export function barsToPoints(bars: number): number {
+  return bars * HEALTH_STEP;
+}
+
+/**
+ * The bar a health lands on, rounded up.
+ *
+ * A unit seeded off a real board can hold any exact value, and 61 points is a
+ * unit the board draws as seven bars. Rounding down would show a unit as
+ * weaker than the map does.
+ */
+export function pointsToBars(points: number): number {
+  return Math.max(1, Math.min(10, Math.ceil(points / HEALTH_STEP)));
+}
+
+/** Which power a side is running. `null` is day-to-day. */
+export type PowerChoice = "cop" | "scop" | null;
+
+/**
+ * The ground a unit is put on when nothing has said otherwise.
+ *
+ * Chosen per domain because a picker that opened every unit on a plain would
+ * open a Battleship on dry land, and the first number a player read would be
+ * one they had to correct before it meant anything.
+ */
+export function defaultTerrain(domain: CatalogDomain): Terrain {
+  switch (domain) {
+    case "sea":
+      return "sea";
+    // Air units are not on the ground at all. The plain is the neutral choice
+    // for them the way the road is for nothing else: it is what the map is
+    // mostly made of.
+    case "air":
+      return "plain";
+    default:
+      return "plain";
+  }
+}
+
+/** A fresh fighter of this kind, at full strength on ground that suits it. */
+export function newFighter(unit: CatalogUnit): BattleFighter {
+  return {
+    unit: unit.unit,
+    health: FULL_HEALTH_POINTS,
+    ammo: unit.maxAmmo > 0 ? unit.maxAmmo : undefined,
+    terrain: defaultTerrain(unit.domain),
+  };
+}
+
+/**
+ * Keep a fighter's condition while changing what it is.
+ *
+ * Swapping a Tank for a Neo Tank is a question about the same engagement, so
+ * the health and the ground stay. The magazine cannot: the two units carry
+ * different amounts, and a Neo Tank inheriting a Tank's nine shells would be
+ * carrying more than it has.
+ */
+export function retypeFighter(fighter: BattleFighter, unit: CatalogUnit): BattleFighter {
+  return {
+    unit: unit.unit,
+    health: fighter.health,
+    ammo: unit.maxAmmo > 0 ? unit.maxAmmo : undefined,
+    terrain: fighter.terrain,
+  };
+}
+
+/** A side with no commander, no money and no ground held. */
+export function emptySide(): CalculatorSide {
+  return { commander: undefined, power: undefined, funds: 0, properties: 0, comTowers: 0 };
+}
+
+/**
+ * The two armies the panel opens on, read off the board.
+ *
+ * The attacker is the army whose turn it is to act, because that is the seat
+ * the player is sitting in and the seat every figure is reported from. The
+ * defender is the first army that is not on the attacker's team — an ally is
+ * not who a player is weighing an attack against, and in a team game the
+ * neighbouring seat often is one.
+ */
+export function seatsFrom(
+  roster: PlayerRosterSnapshot | null,
+  viewerSlotIndex: number | null,
+): { attacker: PlayerRosterEntry | null; defender: PlayerRosterEntry | null } {
+  const players = roster?.players ?? [];
+  if (players.length === 0) return { attacker: null, defender: null };
+
+  const attacker =
+    players.find((player) => player.playerId === viewerSlotIndex) ??
+    players.find((player) => player.playerId === roster?.activePlayerId) ??
+    players[0] ??
+    null;
+  const defender =
+    players.find(
+      (player) =>
+        player.playerId !== attacker?.playerId &&
+        (player.team === undefined || player.team !== attacker?.team),
+    ) ??
+    players.find((player) => player.playerId !== attacker?.playerId) ??
+    null;
+
+  return { attacker, defender };
+}
+
+/**
+ * One army's combat context, as the board currently has it.
+ *
+ * Everything here is a value a commander rule reads. Funds and property counts
+ * are withheld from a player under fog. A withheld figure stays empty until
+ * the player enters a value. A reported zero stays zero.
+ */
+export function sideFrom(entry: PlayerRosterEntry | null): CalculatorSide {
+  if (!entry) return emptySide();
+
+  return {
+    commander: commanderFrom(entry.coKey),
+    power: entry.activePower ?? undefined,
+    funds: entry.stats.funds,
+    properties: entry.stats.properties,
+    comTowers: entry.stats.comTowers,
+  };
+}
+
+/**
+ * The commander a roster entry names.
+ *
+ * AWVM and the portrait sheet share one kebab vocabulary, except for the
+ * no-commander placeholder the sheet calls `no-co`, which is the absence this
+ * returns rather than a commander of that name.
+ */
+export function commanderFrom(coKey: string | undefined): CommanderKind | undefined {
+  if (!coKey || coKey === "no-co" || coKey === "neutral") return undefined;
+  return coKey as CommanderKind;
+}
+
+/** `65 – 75%`, or one figure when no commander in the exchange grants luck. */
+export function formatDamage(bracket: BattleBracket): string {
+  return bracket.low === bracket.high ? `${bracket.low}%` : `${bracket.low} – ${bracket.high}%`;
+}
+
+/** Funds, grouped the way money is read. */
+export function formatFunds(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/** A bracket of funds, collapsed to one figure when both ends agree. */
+export function formatFundsBracket(bracket: FundsBracket): string {
+  return bracket.low === bracket.high
+    ? formatFunds(bracket.low)
+    : `${formatFunds(bracket.low)} – ${formatFunds(bracket.high)}`;
+}
+
+/**
+ * What the exchange moves, always signed.
+ *
+ * The sign is the whole point of the figure and is never implied by position or
+ * colour: a trade that loses money says so with a minus, on both ends.
+ */
+export function formatNet(net: NetFundsBracket): string {
+  return net.low === net.high ? signed(net.low) : `${signed(net.low)} – ${signed(net.high)}`;
+}
+
+function signed(value: number): string {
+  const sign = value < 0 ? "−" : "+";
+  return `${sign}${formatFunds(Math.abs(value))}`;
+}
+
+/** Why a pairing has no numbers, said the way a player would say it. */
+export function impossibleLabel(reason: BattleImpossible): string {
+  return reason === "unarmed"
+    ? "Cannot reach this target"
+    : "Attacker has no weapon entry for this target";
+}
+
+/**
+ * The whole engagement in one sentence.
+ *
+ * The visible row spends its width on figures a player scans between, in
+ * columns that only mean something to someone who can see them lined up. This
+ * is the same prediction as prose, and it carries the pairing the columns
+ * cannot: the good outcome is the top of what is dealt with the bottom of what
+ * is taken.
+ */
+export function engagementLabel(
+  attackerName: string,
+  targetName: string,
+  target: BattleFighter,
+  result: BattleResult | undefined,
+  reason: BattleImpossible | undefined,
+): string {
+  const who = `${targetName} at ${pointsToBars(target.health)} HP`;
+  if (!result) {
+    return `${attackerName} against ${who}: ${(reason && impossibleLabel(reason)) ?? "no forecast"}`;
+  }
+
+  const outcome = result.destroys
+    ? ", destroying it"
+    : result.mayDestroy
+      ? ", possibly destroying it"
+      : "";
+  const reply = result.counter
+    ? `, taking ${formatDamage(result.counter)}${result.counterFirst ? " first" : " back"} and losing ${formatFundsBracket(result.valueTaken ?? { low: 0, high: 0 })} funds`
+    : result.destroys
+      ? ""
+      : ", with no reply";
+
+  return `${attackerName} against ${who}: dealing ${formatDamage(result.damage)}${outcome}, worth ${formatFundsBracket(result.valueDealt)} funds${reply}. Net ${formatNet(result.net)} funds.`;
+}
+
+/** Whether a unit carries a magazine worth asking about. */
+export function hasMagazine(catalog: CatalogUnit[], unit: UnitKind): boolean {
+  return (catalog.find((entry) => entry.unit === unit)?.maxAmmo ?? 0) > 0;
+}
+
+/** The catalog entry for a kind, which every picker needs and none may guess. */
+export function unitEntry(catalog: CatalogUnit[], unit: UnitKind): CatalogUnit | undefined {
+  return catalog.find((entry) => entry.unit === unit);
+}
+
+/**
+ * The catalog entry for one ground, which carries the tile the board draws.
+ *
+ * The sprite index is the ruleset's answer rather than a table this file could
+ * hold: a picker that guessed which cell of the sheet a com tower lives in
+ * would draw the wrong building the first time the sheet was regenerated.
+ */
+export function terrainEntry(
+  catalog: CatalogTerrain[],
+  terrain: Terrain,
+): CatalogTerrain | undefined {
+  return catalog.find((entry) => entry.terrain === terrain);
+}

--- a/web/src/matches/screens/MatchActivePage.tsx
+++ b/web/src/matches/screens/MatchActivePage.tsx
@@ -18,6 +18,7 @@ import {
   spacingVars,
   typeScaleVars,
 } from "@astryxdesign/core/theme/tokens.stylex";
+import { Calculator as CalculatorIcon } from "pixelarticons/react/Calculator";
 import * as stylex from "@stylexjs/stylex";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCanvasCourierSurface } from "#/canvas_courier/index.ts";
@@ -34,6 +35,10 @@ import { useMatchWebSocket, type MatchWebSocketStatus } from "#/matches/match_we
 import type { InitialBoardMessage, MatchWebSocketMessage } from "#/matches/match_protocol.ts";
 import { matchDetailQueryOptions } from "#/matches/matches.queries.ts";
 import type { MatchParticipantSnapshot } from "#/matches/schemas.ts";
+import {
+  BATTLE_CALCULATOR_SHEET_MEDIA,
+  BattleCalculator,
+} from "#/matches/components/BattleCalculator.tsx";
 import { BuildMenu } from "#/matches/components/BuildMenu.tsx";
 import { UnitActionMenu } from "#/matches/components/UnitActionMenu.tsx";
 import { RosterList, RosterRow } from "#/replay/RosterRow.tsx";
@@ -361,6 +366,7 @@ export function MatchActivePage({
             players={livePlayers}
             productionOptions={productionOptions}
             unitActions={unitActions}
+            playerRoster={playerRoster}
             reconnect={reconnect}
             runner={runner}
             status={status}
@@ -434,6 +440,7 @@ function ActiveMatchBoard({
   onBuildUnit,
   onEndTurn,
   players,
+  playerRoster,
   productionOptions,
   unitActions,
   reconnect,
@@ -452,6 +459,7 @@ function ActiveMatchBoard({
   onBuildUnit: (unit: UnitKind, x: number, y: number) => void;
   onEndTurn: () => void;
   players: LiveMatchPlayer[];
+  playerRoster: PlayerRosterSnapshot | null;
   productionOptions: ProductionOptionsChanged | null;
   unitActions: UnitActionsChanged | null;
   reconnect: () => void;
@@ -478,6 +486,11 @@ function ActiveMatchBoard({
   const isCompactViewport = useMediaQuery(BUILD_SHEET_MEDIA);
   const pressRef = useRef<BoardPress | null>(null);
   const [press, setPress] = useState<BoardPress | null>(null);
+  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false);
+  // The calculator's own breakpoint. It is not the build menu's: a sheet under
+  // a thumb is one question, and a panel that outgrows the board frame is
+  // another.
+  const isCalculatorCompact = useMediaQuery(BATTLE_CALCULATOR_SHEET_MEDIA);
   const productionSite = productionOptions?.site;
 
   // The last press on the board, so the menu can open where the player pointed
@@ -654,6 +667,20 @@ function ActiveMatchBoard({
           />
         )}
 
+        {/* The engagement a player is imagining, over the board they are
+            imagining it on. It commits nothing: the action menu stays the only
+            thing that can spend a unit. */}
+        {isCalculatorOpen ? (
+          <BattleCalculator
+            onDismiss={() => setIsCalculatorOpen(false)}
+            onRestoreFocus={focus}
+            presentation={isCalculatorCompact ? "sheet" : "board"}
+            roster={playerRoster}
+            runner={runner}
+            viewerSlotIndex={viewerSlotIndex ?? null}
+          />
+        ) : null}
+
         {/* The terrain window stands on the battlefield, the way the game's own
             does, so reading a tile costs the page no height. */}
         <TileInfoBar />
@@ -714,6 +741,14 @@ function ActiveMatchBoard({
         <HStack align="center" gap={2} wrap="wrap">
           {/* While the board holds the screen this strip is behind it, and the
               way back out is the key on the board itself. */}
+          <Button
+            clickAction={() => setIsCalculatorOpen(true)}
+            icon={<CalculatorIcon aria-hidden height={16} width={16} />}
+            isDisabled={isCalculatorOpen}
+            label="Calculator"
+            size="sm"
+            variant="secondary"
+          />
           {isFullscreen ? null : <GameFullscreenButton onEnter={enterFullscreen} />}
           {status === "disconnected" || status === "error" ? (
             <Button clickAction={reconnect} label="Reconnect" size="sm" variant="secondary" />

--- a/web/src/replay/ReplayPage.tsx
+++ b/web/src/replay/ReplayPage.tsx
@@ -9,6 +9,7 @@ import { Heading } from "@astryxdesign/core/Heading";
 import { HStack, VStack } from "@astryxdesign/core/Stack";
 import { Text } from "@astryxdesign/core/Text";
 import { borderVars, colorVars, spacingVars } from "@astryxdesign/core/theme/tokens.stylex";
+import { Calculator as CalculatorIcon } from "pixelarticons/react/Calculator";
 import * as stylex from "@stylexjs/stylex";
 import { useEffect, useState } from "react";
 import { resolveAwbwUsername } from "#/awbw/api.ts";
@@ -20,6 +21,12 @@ import { useReplayRunner } from "#/engine/runtime_context.tsx";
 import { useGameActions, useGameStore } from "#/engine/store.ts";
 import { getFactionByCode } from "#/factions.ts";
 import { rosterLayout } from "#/ui/rosterLayout.stylex.ts";
+import { Button } from "#/ui/Button.tsx";
+import { useMediaQuery } from "@astryxdesign/core/hooks";
+import {
+  BATTLE_CALCULATOR_SHEET_MEDIA,
+  BattleCalculator,
+} from "#/matches/components/BattleCalculator.tsx";
 import { RosterList, RosterRow } from "./RosterRow";
 
 export function ReplayPage() {
@@ -30,6 +37,8 @@ export function ReplayPage() {
   const [playerNames, setPlayerNames] = useState<Record<number, string>>({});
   const [replayFile, setReplayFile] = useState<File | null>(null);
   const [replayError, setReplayError] = useState<string | null>(null);
+  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false);
+  const isCalculatorCompact = useMediaQuery(BATTLE_CALCULATOR_SHEET_MEDIA);
   const runner = useReplayRunner();
   const {
     canvasRef,
@@ -144,7 +153,10 @@ export function ReplayPage() {
             ref={surfaceRef}
             xstyle={[
               styles.gameSurface,
-              !playerRoster && styles.gameSurfaceEmpty,
+              // With no replay the frame only has to say where the board goes,
+              // unless the calculator is standing on it: a panel is not a
+              // placeholder, and it needs the room a board would have had.
+              !playerRoster && !isCalculatorOpen && styles.gameSurfaceEmpty,
               isFullscreen && styles.gameSurfaceFullscreen,
               fullscreenMode === "immersive" && styles.gameSurfaceImmersive,
             ]}
@@ -165,6 +177,18 @@ export function ReplayPage() {
                   {replayLoader}
                 </VStack>
               </Center>
+            ) : null}
+
+            {/* The engagement a reviewer is imagining, over the battle they
+                are imagining it in. It changes nothing about the replay. */}
+            {isCalculatorOpen ? (
+              <BattleCalculator
+                onDismiss={() => setIsCalculatorOpen(false)}
+                onRestoreFocus={focus}
+                presentation={isCalculatorCompact ? "sheet" : "board"}
+                roster={playerRoster}
+                runner={runner}
+              />
             ) : null}
 
             {/* The terrain window stands on the battlefield itself, so reading
@@ -194,13 +218,25 @@ export function ReplayPage() {
             </HStack>
             {/* Full screen is only an offer once there is a battle to watch,
                 and while the board holds the screen the way back out is the key
-                on the board itself. */}
-            {playerRoster ? (
-              <HStack align="center" gap={2} wrap="wrap">
-                {isFullscreen ? null : <GameFullscreenButton onEnter={enterFullscreen} />}
-                {replayLoader}
-              </HStack>
-            ) : null}
+                on the board itself. The calculator does not wait on a replay:
+                it asks about an engagement no board holds, and a player who
+                came to check a matchup has nothing to load first. */}
+            <HStack align="center" gap={2} wrap="wrap">
+              <Button
+                clickAction={() => setIsCalculatorOpen(true)}
+                icon={<CalculatorIcon aria-hidden height={16} width={16} />}
+                isDisabled={isCalculatorOpen}
+                label="Calculator"
+                size="sm"
+                variant="secondary"
+              />
+              {playerRoster ? (
+                <>
+                  {isFullscreen ? null : <GameFullscreenButton onEnter={enterFullscreen} />}
+                  {replayLoader}
+                </>
+              ) : null}
+            </HStack>
           </HStack>
         </Card>
 


### PR DESCRIPTION
- Export `battle_forecast` and `battle_catalog` as free wasm functions: the calculator needs no canvas and no running game, so it answers while a replay is paused, mid-turn in a live match, or before either has loaded.
- Build the panel on the reference tool's own framing — two armies specified side by side, a swap on the centreline, the exchange read across it — with every figure coming from AWVM rather than from a formula in the browser.
- Stand it on the board as a window, or as the system's own dialog on a viewport too small to hold one, the way the board menus already do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a battle calculator for forecasting engagements, including damage, counterattacks, funds, outcomes, and impossible-matchup indicators.
  - Added unit, terrain, commander, property, health, ammunition, and terrain selection controls with responsive board and sheet layouts.
  - Added calculator access from active matches and replay screens.
  - Added keyboard-accessible sprite pickers with grouped options and typeahead selection.
- **Improvements**
  - Added responsive focus management, request cancellation, input validation, and clear error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->