### PR TITLE
Expose GameSetup to AWVM state

### DIFF
--- a/crates/awbrn-server/src/awvm_adapter.rs
+++ b/crates/awbrn-server/src/awvm_adapter.rs
@@ -41,20 +41,6 @@ pub(crate) struct AcceptedTransition {
 
 impl Authority {
     pub(crate) fn new(setup: &GameSetup) -> Result<Self, SetupError> {
-        if setup.players.is_empty() {
-            return Err(SetupError::InvalidPlayers {
-                reason: "game must contain at least one player".into(),
-            });
-        }
-        if setup.players.len() > u8::MAX as usize {
-            return Err(SetupError::InvalidPlayers {
-                reason: format!(
-                    "game supports at most {} players, got {}",
-                    u8::MAX,
-                    setup.players.len()
-                ),
-            });
-        }
         let faction_players = faction_players(setup);
         Ok(Self {
             state: state_from_setup(setup)?,
@@ -413,14 +399,27 @@ fn commands(
     }
 }
 
-fn state_from_setup(setup: &GameSetup) -> Result<State, SetupError> {
-    let starting_funds = u64::from(
-        setup
-            .players
-            .first()
-            .expect("the server validates a non-empty roster")
-            .starting_funds,
-    );
+/// Converts a game setup to an AWVM state.
+///
+/// This function does not perform server work. It does not compute fog or
+/// record entropy.
+pub fn state_from_setup(setup: &GameSetup) -> Result<State, SetupError> {
+    if setup.players.is_empty() {
+        return Err(SetupError::InvalidPlayers {
+            reason: "game must contain at least one player".into(),
+        });
+    }
+    if setup.players.len() > u8::MAX as usize {
+        return Err(SetupError::InvalidPlayers {
+            reason: format!(
+                "game supports at most {} players, got {}",
+                u8::MAX,
+                setup.players.len()
+            ),
+        });
+    }
+
+    let starting_funds = u64::from(setup.players[0].starting_funds);
     let players = setup
         .players
         .iter()
@@ -454,11 +453,7 @@ fn state_from_setup(setup: &GameSetup) -> Result<State, SetupError> {
             teams
         });
     let faction_players = faction_players(setup);
-    let active_player = players
-        .first()
-        .expect("the server validates a non-empty roster")
-        .id
-        .clone();
+    let active_player = players[0].id.clone();
 
     Ok(State {
         ruleset: RulesetRef {

--- a/crates/awbrn-server/src/lib.rs
+++ b/crates/awbrn-server/src/lib.rs
@@ -11,6 +11,7 @@ mod view;
 mod wasm;
 
 pub use awbrn_types::Co;
+pub use awvm_adapter::state_from_setup;
 pub use command::{GameCommand, PostMoveAction, PowerLevel};
 pub use error::CommandError;
 pub use player::{PlayerId, PlayerRegistry};

--- a/crates/awbrn-server/tests/server.rs
+++ b/crates/awbrn-server/tests/server.rs
@@ -9,7 +9,7 @@ use awbrn_types::{
 use awbrn_server::{
     CaptureEvent, Co, CommandError, GameCommand, GameServer, GameSetup, PlayerId, PlayerSetup,
     PostMoveAction, PowerLevel, ReplayError, ReplayEventError, ServerUnitId, SetupError,
-    StoredActionEvent, reconstruct_from_events,
+    StoredActionEvent, reconstruct_from_events, state_from_setup,
 };
 use awvm::semantic::{ObservedEvent, ObservedUnitRef};
 
@@ -204,15 +204,14 @@ fn p2() -> PlayerId {
 }
 
 #[test]
-fn server_rejects_empty_player_setup() {
-    let err = GameServer::new(GameSetup {
+fn state_conversion_rejects_empty_player_setup() {
+    let setup = GameSetup {
         map: AwbrnMap::new(5, 5, GraphicalTerrain::Plain),
         players: Vec::new(),
         fog_enabled: false,
         rng_seed: 0,
-    })
-    .err()
-    .unwrap();
+    };
+    let err = state_from_setup(&setup).unwrap_err();
 
     assert_eq!(
         err,
@@ -223,8 +222,8 @@ fn server_rejects_empty_player_setup() {
 }
 
 #[test]
-fn server_rejects_more_than_255_players() {
-    let err = GameServer::new(GameSetup {
+fn state_conversion_rejects_more_than_255_players() {
+    let setup = GameSetup {
         map: AwbrnMap::new(5, 5, GraphicalTerrain::Plain),
         players: vec![
             PlayerSetup {
@@ -237,9 +236,8 @@ fn server_rejects_more_than_255_players() {
         ],
         fog_enabled: false,
         rng_seed: 0,
-    })
-    .err()
-    .unwrap();
+    };
+    let err = state_from_setup(&setup).unwrap_err();
 
     assert_eq!(
         err,

--- a/crates/bench/src/benchmarks/server.rs
+++ b/crates/bench/src/benchmarks/server.rs
@@ -144,12 +144,9 @@ fn deployment(players: usize) -> impl Iterator<Item = (Position, Unit, PlayerFac
     })
 }
 
-/// A fresh server at game scale.
-///
-/// Rebuilt per iteration for the command cases, so it is setup rather than
-/// measured work — see the module comment.
-pub fn server(players: usize, fog: bool) -> GameServer {
-    let setup = GameSetup {
+/// A game setup with the map and player roster that every case uses.
+pub fn setup(players: usize, fog: bool) -> GameSetup {
+    GameSetup {
         map: map(players),
         players: FACTIONS
             .iter()
@@ -163,9 +160,15 @@ pub fn server(players: usize, fog: bool) -> GameServer {
             .collect(),
         fog_enabled: fog,
         rng_seed: 0x5eed,
-    };
+    }
+}
 
-    let mut server = GameServer::new(setup).expect("game setup is valid");
+/// A fresh server at game scale.
+///
+/// Rebuilt per iteration for the command cases, so it is setup rather than
+/// measured work — see the module comment.
+pub fn server(players: usize, fog: bool) -> GameServer {
+    let mut server = GameServer::new(setup(players, fog)).expect("game setup is valid");
     // The mover goes first so it is always unit 1, whatever the roster does.
     server.spawn_unit(
         Position::new(MOVER_START.0, MOVER_START.1),


### PR DESCRIPTION
This will be useful for upcoming benchmarks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a publicly available setup conversion utility for creating valid game state from player and fog settings.
  * Improved validation for empty rosters and rosters exceeding the supported player limit.

* **Bug Fixes**
  * Improved safety when selecting the first and active players during state creation.

* **Tests**
  * Updated validation tests to cover setup conversion directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->