### PR TITLE
Prepare AWVM actions (perf)

### DIFF
--- a/crates/awvm/src/lib.rs
+++ b/crates/awvm/src/lib.rs
@@ -60,7 +60,7 @@ pub mod violation;
 /// server, or a replay viewer to the reducer.
 pub mod prelude {
     pub use crate::event::{AttackTarget, Event};
-    pub use crate::query::{ActionSet, MoveField, QueryError, Step};
+    pub use crate::query::{ActionSet, MoveField, ObservedQuery, QueryError, Step};
     pub use crate::random::{Entropy, Luck, RandomError, RandomTape, RandomToken, Recording};
     pub use crate::ruleset::{CommanderKind, Terrain, UnitKind, WeatherKind};
     pub use crate::semantic::{
@@ -69,7 +69,9 @@ pub mod prelude {
         Visibility, observe, observe_events, observe_transition,
     };
     pub use crate::transition::{
-        Command, ExecuteError, ExecuteOutcome, Execution, execute, execute_with,
+        Command, ExecuteError, ExecuteOutcome, Execution, PrepareMovementOutcome, PrepareOutcome,
+        PreparedCommand, PreparedMovement, execute, execute_prepared, execute_prepared_with,
+        execute_with, prepare_command, prepare_movement,
     };
     pub use crate::violation::Violation;
 }

--- a/crates/awvm/src/query.rs
+++ b/crates/awvm/src/query.rs
@@ -10,10 +10,10 @@
 //!
 //! Everything here is derived from the reducer, not restated alongside it:
 //!
-//! * [`actions_at`] and [`attack_targets`] *run* the reducer against a probe
-//!   entropy source and report what it accepted. They cannot drift, because
-//!   there is no second copy of the rule to drift from — a command this module
-//!   offers is one `execute` has already accepted against this state.
+//! * [`actions_at`] and [`attack_targets`] use the reducer's preparation
+//!   checks for every movement action. These queries do not clone or change
+//!   the state, and they cannot drift because they do not contain a second
+//!   copy of the action rules.
 //! * [`reachable`] is the one exception. A probe per tile would answer whether
 //!   a path is legal but not produce one, and a caller needs the path to build
 //!   the command, so the search is written out here. `tests/query.rs` holds it
@@ -23,7 +23,7 @@
 //! None of this is authoritative. A server still executes the command it
 //! receives; this exists so a client can offer commands the server will take.
 
-use std::collections::{BinaryHeap, HashSet};
+use std::collections::HashSet;
 
 use crate::combat::Forecast;
 use crate::commander::{self, Domain};
@@ -35,8 +35,8 @@ use crate::semantic::{
     Pos, State, TeamId, Unit, UnitId, UnitKindId, Viewpoint, Visibility, WeatherKind,
 };
 use crate::transition::{
-    Command, ExecuteOutcome, board_position, execute_with, forecast_tile_attack,
-    forecast_unit_attack,
+    Command, ExecuteError, ExecuteOutcome, PrepareMovementOutcome, PrepareOutcome, board_position,
+    execute_with, forecast_tile_attack, forecast_unit_attack, prepare_movement,
 };
 use crate::violation::Violation;
 
@@ -55,17 +55,17 @@ pub enum QueryError {
     UnknownOwner { unit: UnitId, owner: PlayerId },
     #[error("this observation does not describe a whole board: {0}")]
     Unprojectable(&'static str),
+    #[error(transparent)]
+    Transition(#[from] ExecuteError),
 }
 
 /// An entropy source for probing, which answers every draw with the lowest
 /// value the reducer said was legal.
 ///
-/// A probe must never fail for want of a token: an attack asked about with an
-/// empty tape reports [`crate::transition::ExecuteError::UnsupportedCommand`],
-/// which would read as "illegal" and hide a legal attack. Taking the domain's
-/// minimum is always in range by construction, and the resulting state is
-/// discarded — only the accept-or-reject verdict is kept, and no rule in the
-/// specification makes legality depend on the roll.
+/// A probe must never fail for want of a token. Taking the domain's minimum is
+/// always in range, and the resulting state is discarded. Only the
+/// accept-or-reject verdict is kept, and no rule makes legality depend on the
+/// roll.
 struct Probe;
 
 impl Entropy for Probe {
@@ -317,45 +317,49 @@ pub fn reachable(state: &State, unit: UnitId) -> Result<MoveField, QueryError> {
         previous: None,
     });
 
-    // Ordinary Dijkstra. Entry costs are non-negative — zero only on
-    // teleporters — so the first time a tile leaves the frontier its cost is
-    // final.
-    let mut frontier = BinaryHeap::new();
-    frontier.push(Frontier {
-        cost: 0,
-        position: origin,
-    });
-    while let Some(Frontier { cost, position }) = frontier.pop() {
-        if steps[index_of(position)].is_some_and(|step| step.cost < cost) {
-            continue;
-        }
-        // A disclosed enemy blocks the route through its tile. Allied units
-        // may be crossed but remain invalid destinations.
-        if position != origin && occupancy.blocks_route(position) {
-            continue;
-        }
-        for next in position.orthogonal() {
-            if next.x >= width || next.y >= height {
+    // Dial's algorithm uses the small integer movement allowance as its bucket
+    // range. Zero-cost teleporter edges return to the current bucket and are
+    // exhausted before the search advances.
+    let bucket_count = usize::try_from(budget)
+        .ok()
+        .and_then(|budget| budget.checked_add(1))
+        .expect("the ruleset movement allowance and zero bucket fit usize");
+    let mut buckets = vec![Vec::new(); bucket_count];
+    buckets[0].push(origin);
+    for current_cost in 0..bucket_count {
+        while let Some(position) = buckets[current_cost].pop() {
+            if steps[index_of(position)].is_some_and(|step| step.cost != current_cost as u64) {
                 continue;
             }
-            let Some(entry) = entry_cost(state, subject, next, weather) else {
-                continue;
-            };
-            let Some(total) = cost.checked_add(entry).filter(|total| *total <= budget) else {
-                continue;
-            };
-            if steps[index_of(next)].is_some_and(|step| step.cost <= total) {
+            // A disclosed enemy blocks the route through its tile. Allied
+            // units may be crossed but remain invalid destinations.
+            if position != origin && occupancy.blocks_route(position) {
                 continue;
             }
-            steps[index_of(next)] = Some(Step {
-                cost: total,
-                can_stop: !is_teleporter(state, next) && !occupancy.blocks_stop(next),
-                previous: Some(position),
-            });
-            frontier.push(Frontier {
-                cost: total,
-                position: next,
-            });
+            for next in position.orthogonal() {
+                if next.x >= width || next.y >= height {
+                    continue;
+                }
+                let next_index = index_of(next);
+                let Some(entry) = entry_costs[next_index] else {
+                    continue;
+                };
+                let Some(total) = (current_cost as u64)
+                    .checked_add(entry)
+                    .filter(|total| *total <= budget)
+                else {
+                    continue;
+                };
+                if steps[next_index].is_some_and(|step| step.cost <= total) {
+                    continue;
+                }
+                steps[next_index] = Some(Step {
+                    cost: total,
+                    can_stop: !is_teleporter(state, next) && !occupancy.blocks_stop(next),
+                    previous: Some(position),
+                });
+                buckets[usize::try_from(total).expect("a movement cost fits usize")].push(next);
+            }
         }
     }
 
@@ -389,8 +393,7 @@ pub fn observed_reachable(
     observation: &Observation,
     unit: UnitId,
 ) -> Result<MoveField, QueryError> {
-    let state = reify(observation)?;
-    reachable(&state, unit)
+    ObservedQuery::new(observation)?.reachable(unit)
 }
 
 /// What `unit` may do if it moves to `destination`.
@@ -400,9 +403,7 @@ pub fn observed_reachable(
 /// normally one of [`MoveField::reach`]; an unreachable one yields an empty
 /// set, because the shared movement prefix rejects it first.
 ///
-/// This runs one reduction per candidate command — a dozen or so state clones.
-/// That is a per-selection cost in an interface, not a per-frame one, and
-/// caching belongs to the caller, which knows when its state changed.
+/// Every field uses preparation. The query does not clone or change the state.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ActionSet {
     /// Move there and end the unit's turn.
@@ -471,6 +472,62 @@ pub struct ObservedActionSet {
     pub launch: Vec<Pos>,
 }
 
+/// Recipient-safe queries over one reified observation.
+///
+/// Construct this once and reuse it for a movement field and its action
+/// destinations. This prevents each action query from rebuilding the same
+/// provisional state.
+#[derive(Debug)]
+pub struct ObservedQuery {
+    state: State,
+    may_command: bool,
+}
+
+impl ObservedQuery {
+    /// Reify one observation for subsequent queries.
+    pub fn new(observation: &Observation) -> Result<Self, QueryError> {
+        Ok(Self {
+            state: reify(observation)?,
+            may_command: recipient_may_command(observation),
+        })
+    }
+
+    /// Compute the recipient-safe movement field for `unit`.
+    pub fn reachable(&self, unit: UnitId) -> Result<MoveField, QueryError> {
+        reachable(&self.state, unit)
+    }
+
+    /// Query one destination and compute its path when necessary.
+    pub fn actions_at(
+        &self,
+        unit: UnitId,
+        destination: Pos,
+    ) -> Result<ObservedActionSet, QueryError> {
+        if !self.may_command {
+            return Ok(ObservedActionSet::default());
+        }
+        Ok(by_position(
+            &self.state,
+            actions_at(&self.state, unit, destination)?,
+        ))
+    }
+
+    /// Query a path obtained from a movement field without rebuilding it.
+    pub fn actions_for_path(
+        &self,
+        unit: UnitId,
+        path: Vec<Pos>,
+    ) -> Result<ObservedActionSet, QueryError> {
+        if !self.may_command {
+            return Ok(ObservedActionSet::default());
+        }
+        Ok(by_position(
+            &self.state,
+            actions_for_path(&self.state, unit, path)?,
+        ))
+    }
+}
+
 /// The legal attacks from one candidate movement destination.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObservedAttacksFrom {
@@ -528,8 +585,7 @@ pub fn observed_actions_at(
         return Ok(ObservedActionSet::default());
     }
 
-    let state = reify(observation)?;
-    Ok(by_position(&state, actions_at(&state, unit, destination)?))
+    ObservedQuery::new(observation)?.actions_at(unit, destination)
 }
 
 /// What `unit` may attack from each candidate movement destination.
@@ -926,62 +982,102 @@ fn reified_units(observation: &Observation) -> Vec<Unit> {
 }
 
 /// Enumerate every command `unit` could issue ending at `destination`.
+///
+/// Call [`actions_for_path`] when the caller already has a [`MoveField`]. This
+/// convenience form computes a field to obtain the path.
 pub fn actions_at(state: &State, unit: UnitId, destination: Pos) -> Result<ActionSet, QueryError> {
-    let subject = lookup(state, unit)?;
-    let player = subject.owner.clone();
-    if !matches!(subject.location, Location::Board { .. }) {
-        return Err(QueryError::UnitNotOnBoard(unit));
-    }
-
     let Some(path) = reachable(state, unit)?.path_to(destination) else {
         return Ok(ActionSet::default());
     };
-    let simple = |make: fn(PlayerId, UnitId, Vec<Pos>) -> Command| {
-        is_accepted(state, make(player.clone(), unit, path.clone()))
+    actions_for_path(state, unit, path)
+}
+
+/// Enumerate actions for a path without computing a movement field.
+///
+/// The path is validated against `state` before any action is offered. This
+/// makes a path from an older movement field safe to submit: a state change
+/// produces an empty set instead of bypassing current movement rules.
+pub fn actions_for_path(
+    state: &State,
+    unit: UnitId,
+    path: Vec<Pos>,
+) -> Result<ActionSet, QueryError> {
+    let subject = lookup(state, unit)?;
+    if !matches!(subject.location, Location::Board { .. }) {
+        return Err(QueryError::UnitNotOnBoard(unit));
+    }
+    let player = subject.owner.clone();
+    let movement = match prepare_movement(state, &player, unit, path) {
+        Ok(PrepareMovementOutcome::Prepared(movement)) => movement,
+        Ok(PrepareMovementOutcome::Rejected(_)) => return Ok(ActionSet::default()),
+        Err(error) => return Err(error.into()),
     };
+    actions_for_movement(movement)
+}
+
+fn actions_for_movement(
+    movement: crate::transition::PreparedMovement<'_>,
+) -> Result<ActionSet, QueryError> {
+    let state = movement.state();
+    let destination = movement.plan().destination();
     let occupant = occupant(state, destination);
+    let join = occupant.is_some_and(|target| {
+        matches!(
+            movement.clone().prepare_join(target),
+            Ok(PrepareOutcome::Prepared(_))
+        )
+    });
+    let load = occupant.is_some_and(|transport| {
+        matches!(
+            movement.clone().prepare_load(transport),
+            Ok(PrepareOutcome::Prepared(_))
+        )
+    });
+    let attack = attack_targets_for_movement(&movement)?;
+    let repair = repair_targets(&movement);
+    let launch = launch_targets(&movement);
+    let wait = matches!(
+        movement.clone().prepare_wait(),
+        Ok(PrepareOutcome::Prepared(_))
+    );
+    let capture = matches!(
+        movement.clone().prepare_capture(),
+        Ok(PrepareOutcome::Prepared(_))
+    );
+    let supply = matches!(
+        movement.clone().prepare_supply(),
+        Ok(PrepareOutcome::Prepared(_))
+    );
+    let hide = matches!(
+        movement.clone().prepare_hide(),
+        Ok(PrepareOutcome::Prepared(_))
+    );
+    let reveal = matches!(
+        movement.clone().prepare_reveal(),
+        Ok(PrepareOutcome::Prepared(_))
+    );
+    let explode = matches!(movement.prepare_explode(), Ok(PrepareOutcome::Prepared(_)));
 
     Ok(ActionSet {
-        wait: simple(|player, unit, path| Command::MoveWait { player, unit, path }),
-        capture: simple(|player, unit, path| Command::MoveCapture { player, unit, path }),
-        supply: simple(|player, unit, path| Command::MoveSupply { player, unit, path }),
-        hide: simple(|player, unit, path| Command::MoveHide { player, unit, path }),
-        reveal: simple(|player, unit, path| Command::MoveReveal { player, unit, path }),
-        explode: simple(|player, unit, path| Command::MoveExplode { player, unit, path }),
-        join: occupant.is_some_and(|target| {
-            is_accepted(
-                state,
-                Command::MoveJoin {
-                    player: player.clone(),
-                    unit,
-                    path: path.clone(),
-                    target,
-                },
-            )
-        }),
-        load: occupant.is_some_and(|transport| {
-            is_accepted(
-                state,
-                Command::MoveLoad {
-                    player: player.clone(),
-                    unit,
-                    path: path.clone(),
-                    transport,
-                },
-            )
-        }),
-        attack: attack_targets_along(state, unit, &path)?,
-        repair: repair_targets(state, &player, unit, &path),
-        launch: launch_targets(state, &player, unit, &path),
+        wait,
+        capture,
+        supply,
+        hide,
+        reveal,
+        explode,
+        join,
+        load,
+        attack,
+        repair,
+        launch,
     })
 }
 
 /// Everything `unit` may attack from `from`, having moved there if it must.
 ///
-/// Candidates are narrowed by range first — the geometry is cheap and the
-/// reduction is not — and each survivor is then put to the reducer, so fire
-/// mode, ammunition, visibility, target legality and every commander effect on
-/// all of them are answered by the code that answers at execution time.
+/// Candidates are narrowed by range first. Preparation then checks fire mode,
+/// ammunition, visibility, target legality, and commander effects without
+/// resolving combat.
 pub fn attack_targets(
     state: &State,
     unit: UnitId,
@@ -999,21 +1095,25 @@ pub fn attack_targets(
             None => return Ok(Vec::new()),
         }
     };
-    attack_targets_along(state, unit, &path)
+    let movement = match prepare_movement(state, &subject.owner, unit, path) {
+        Ok(PrepareMovementOutcome::Prepared(movement)) => movement,
+        Ok(PrepareMovementOutcome::Rejected(_)) => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+    attack_targets_for_movement(&movement)
 }
 
-fn attack_targets_along(
-    state: &State,
-    unit: UnitId,
-    path: &[Pos],
+fn attack_targets_for_movement(
+    movement: &crate::transition::PreparedMovement<'_>,
 ) -> Result<Vec<AttackTarget>, QueryError> {
+    let state = movement.state();
+    let unit = movement.unit();
     let subject = lookup(state, unit)?;
-    let player = subject.owner.clone();
     let profile = ruleset::profile(subject.kind);
     if profile.fire_mode == FireMode::None {
         return Ok(Vec::new());
     }
-    let from = *path.last().expect("a path holds at least its origin");
+    let from = movement.plan().destination();
 
     // Range bounds the search; everything else is the reducer's to decide.
     let (minimum, maximum) = match profile.indirect_range {
@@ -1033,15 +1133,10 @@ fn attack_targets_along(
         let distance = from.distance(position);
         distance >= minimum && distance <= maximum
     };
-    let probe = |target: AttackTarget| {
-        is_accepted(
-            state,
-            Command::MoveAttack {
-                player: player.clone(),
-                unit,
-                path: path.to_vec(),
-                target,
-            },
+    let accepts = |target: AttackTarget| {
+        matches!(
+            movement.clone().prepare_attack(target),
+            Ok(PrepareOutcome::Prepared(_))
         )
     };
 
@@ -1054,7 +1149,7 @@ fn attack_targets_along(
             continue;
         }
         let target = AttackTarget::Unit { unit: candidate.id };
-        if probe(target) {
+        if accepts(target) {
             targets.push(target);
         }
     }
@@ -1063,7 +1158,7 @@ fn attack_targets_along(
             continue;
         }
         let target = AttackTarget::Tile { position };
-        if probe(target) {
+        if accepts(target) {
             targets.push(target);
         }
     }
@@ -1071,8 +1166,10 @@ fn attack_targets_along(
 }
 
 /// Friendly units `unit` may repair after moving along `path`.
-fn repair_targets(state: &State, player: &PlayerId, unit: UnitId, path: &[Pos]) -> Vec<UnitId> {
-    let from = *path.last().expect("a path holds at least its origin");
+fn repair_targets(movement: &crate::transition::PreparedMovement<'_>) -> Vec<UnitId> {
+    let state = movement.state();
+    let unit = movement.unit();
+    let from = movement.plan().destination();
     state
         .units
         .iter()
@@ -1083,22 +1180,18 @@ fn repair_targets(state: &State, player: &PlayerId, unit: UnitId, path: &[Pos]) 
         })
         .map(|candidate| candidate.id)
         .filter(|target| {
-            is_accepted(
-                state,
-                Command::MoveRepair {
-                    player: player.clone(),
-                    unit,
-                    path: path.to_vec(),
-                    target: *target,
-                },
+            matches!(
+                movement.clone().prepare_repair(*target),
+                Ok(PrepareOutcome::Prepared(_))
             )
         })
         .collect()
 }
 
 /// Every tile a silo under the end of `path` may be fired at.
-fn launch_targets(state: &State, player: &PlayerId, unit: UnitId, path: &[Pos]) -> Vec<Pos> {
-    let destination = *path.last().expect("a path holds at least its origin");
+fn launch_targets(movement: &crate::transition::PreparedMovement<'_>) -> Vec<Pos> {
+    let state = movement.state();
+    let destination = movement.plan().destination();
     // Launching is rare and the scan is over the whole board, so refuse early
     // unless the tile underfoot actually carries a silo.
     if state
@@ -1112,14 +1205,9 @@ fn launch_targets(state: &State, player: &PlayerId, unit: UnitId, path: &[Pos]) 
         .board
         .positions()
         .filter(|target| {
-            is_accepted(
-                state,
-                Command::MoveLaunch {
-                    player: player.clone(),
-                    unit,
-                    path: path.to_vec(),
-                    target: *target,
-                },
+            matches!(
+                movement.clone().prepare_launch(*target),
+                Ok(PrepareOutcome::Prepared(_))
             )
         })
         .collect()
@@ -1332,26 +1420,4 @@ fn occupant(state: &State, position: Pos) -> Option<UnitId> {
 
 fn lookup(state: &State, unit: UnitId) -> Result<&Unit, QueryError> {
     state.units.get(unit).ok_or(QueryError::UnitNotFound(unit))
-}
-
-/// A frontier entry ordered so [`BinaryHeap`] pops the cheapest first.
-#[derive(Clone, Copy, PartialEq, Eq)]
-struct Frontier {
-    cost: u64,
-    position: Pos,
-}
-
-impl Ord for Frontier {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        other
-            .cost
-            .cmp(&self.cost)
-            .then_with(|| self.position.cmp(&other.position))
-    }
-}
-
-impl PartialOrd for Frontier {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
 }

--- a/crates/awvm/src/transition.rs
+++ b/crates/awvm/src/transition.rs
@@ -182,6 +182,57 @@ pub enum ExecuteOutcome {
     Rejected(Violation),
 }
 
+/// A movement that was resolved against one state but has no selected action.
+///
+/// The borrowed state binds the plan to the state that produced it. A caller
+/// can inspect several actions without validating the path again.
+#[derive(Clone, Debug)]
+pub struct PreparedMovement<'a> {
+    state: &'a State,
+    unit: UnitId,
+    movement: MovedUnit,
+}
+
+/// A command that was resolved against one state but was not applied.
+#[derive(Debug)]
+pub struct PreparedCommand<'a> {
+    command: PreparedCommandKind<'a>,
+}
+
+#[derive(Debug)]
+struct Prepared<'a, A> {
+    movement: PreparedMovement<'a>,
+    action: A,
+}
+
+#[derive(Debug)]
+enum PreparedCommandKind<'a> {
+    Wait(Prepared<'a, movement::Wait>),
+    Capture(Prepared<'a, property::Capture>),
+    Supply(Prepared<'a, transport::Supply>),
+    Concealment(Prepared<'a, movement::ConcealmentAction>),
+    Join(Prepared<'a, transport::Join>),
+    Load(Prepared<'a, transport::Load>),
+    Attack(Prepared<'a, attack::Attack>),
+    Repair(Prepared<'a, transport::Repair>),
+    Launch(Prepared<'a, special::Launch>),
+    Explode(Prepared<'a, special::Explode>),
+}
+
+/// The semantic result of preparing a supported command.
+#[derive(Debug)]
+pub enum PrepareOutcome<'a> {
+    Prepared(PreparedCommand<'a>),
+    Rejected(Violation),
+}
+
+/// The semantic result of preparing the movement shared by several commands.
+#[derive(Debug)]
+pub enum PrepareMovementOutcome<'a> {
+    Prepared(PreparedMovement<'a>),
+    Rejected(Violation),
+}
+
 /// Adapter-owned diagnostic detail for an invalid authoritative state.
 ///
 /// The stable category is [`ExecuteError::InvalidState`]; this prose is not a
@@ -270,6 +321,256 @@ pub fn execute_with(
         Err(ReducerError::UnsupportedRuleset) => Err(ExecuteError::UnsupportedRuleset),
         Err(ReducerError::InvalidState(error)) => Err(ExecuteError::InvalidState(error)),
         Err(ReducerError::InvalidRandom(error)) => Err(ExecuteError::InvalidRandom(error)),
+    }
+}
+
+/// Resolve a command without cloning or changing its input state.
+///
+/// Preparation supports all movement commands. Other commands return
+/// [`ExecuteError::UnsupportedCommand`]. Preparation performs the same
+/// deterministic checks as [`execute`], but it delays the state clone,
+/// mutation, and random draws until [`execute_prepared`] is called.
+pub fn prepare_command(
+    state: &State,
+    command: Command,
+) -> Result<PrepareOutcome<'_>, ExecuteError> {
+    prepare_outcome(prepare(state, command))
+}
+
+/// Resolve movement without choosing the action at its destination.
+pub fn prepare_movement<'a>(
+    state: &'a State,
+    player: &PlayerId,
+    unit: UnitId,
+    path: Vec<Pos>,
+) -> Result<PrepareMovementOutcome<'a>, ExecuteError> {
+    match prepare_movement_inner(state, player, unit, path) {
+        Ok(prepared) => Ok(PrepareMovementOutcome::Prepared(prepared)),
+        Err(ReducerError::Violation(violation)) => Ok(PrepareMovementOutcome::Rejected(violation)),
+        Err(error) => Err(execute_error(error)),
+    }
+}
+
+impl<'a> PreparedMovement<'a> {
+    /// Resolve waiting at this movement's destination.
+    pub fn prepare_wait(self) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(movement::prepare_wait(self).map(PreparedCommandKind::Wait))
+    }
+
+    /// Resolve capture at this movement's destination.
+    pub fn prepare_capture(self) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(property::prepare_capture(self).map(PreparedCommandKind::Capture))
+    }
+
+    /// Resolve supplying from this movement's destination.
+    pub fn prepare_supply(self) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(transport::prepare_supply(self).map(PreparedCommandKind::Supply))
+    }
+
+    /// Resolve entering hidden state at this movement's destination.
+    pub fn prepare_hide(self) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(
+            movement::prepare_concealment(self, true).map(PreparedCommandKind::Concealment),
+        )
+    }
+
+    /// Resolve entering exposed state at this movement's destination.
+    pub fn prepare_reveal(self) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(
+            movement::prepare_concealment(self, false).map(PreparedCommandKind::Concealment),
+        )
+    }
+
+    /// Resolve joining another unit at this movement's destination.
+    pub fn prepare_join(self, target: UnitId) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(transport::prepare_join(self, target).map(PreparedCommandKind::Join))
+    }
+
+    /// Resolve loading into a transport at this movement's destination.
+    pub fn prepare_load(self, transport: UnitId) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(transport::prepare_load(self, transport).map(PreparedCommandKind::Load))
+    }
+
+    /// Resolve attacking a unit or tile from this movement's destination.
+    pub fn prepare_attack(self, target: AttackTarget) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(attack::prepare_attack(self, target).map(PreparedCommandKind::Attack))
+    }
+
+    /// Resolve repairing another unit from this movement's destination.
+    pub fn prepare_repair(self, target: UnitId) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(transport::prepare_repair(self, target).map(PreparedCommandKind::Repair))
+    }
+
+    /// Resolve launching a silo at a target tile.
+    pub fn prepare_launch(self, target: Pos) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(special::prepare_launch(self, target).map(PreparedCommandKind::Launch))
+    }
+
+    /// Resolve exploding at this movement's destination.
+    pub fn prepare_explode(self) -> Result<PrepareOutcome<'a>, ExecuteError> {
+        prepare_outcome(special::prepare_explode(self).map(PreparedCommandKind::Explode))
+    }
+
+    pub(crate) const fn state(&self) -> &State {
+        self.state
+    }
+
+    pub(crate) const fn unit(&self) -> UnitId {
+        self.unit
+    }
+
+    pub(crate) const fn plan(&self) -> &MovedUnit {
+        &self.movement
+    }
+}
+
+fn prepare_outcome(
+    result: Result<PreparedCommandKind<'_>, ReducerError>,
+) -> Result<PrepareOutcome<'_>, ExecuteError> {
+    match result {
+        Ok(command) => Ok(PrepareOutcome::Prepared(PreparedCommand { command })),
+        Err(ReducerError::Violation(violation)) => Ok(PrepareOutcome::Rejected(violation)),
+        Err(error) => Err(execute_error(error)),
+    }
+}
+
+fn prepare(state: &State, command: Command) -> Result<PreparedCommandKind<'_>, ReducerError> {
+    match command {
+        Command::MoveWait { player, unit, path } => {
+            movement::prepare_wait(prepare_movement_inner(state, &player, unit, path)?)
+                .map(PreparedCommandKind::Wait)
+        }
+        Command::MoveCapture { player, unit, path } => {
+            property::prepare_capture(prepare_movement_inner(state, &player, unit, path)?)
+                .map(PreparedCommandKind::Capture)
+        }
+        Command::MoveSupply { player, unit, path } => {
+            transport::prepare_supply(prepare_movement_inner(state, &player, unit, path)?)
+                .map(PreparedCommandKind::Supply)
+        }
+        Command::MoveHide { player, unit, path } => {
+            movement::prepare_concealment(prepare_movement_inner(state, &player, unit, path)?, true)
+                .map(PreparedCommandKind::Concealment)
+        }
+        Command::MoveReveal { player, unit, path } => movement::prepare_concealment(
+            prepare_movement_inner(state, &player, unit, path)?,
+            false,
+        )
+        .map(PreparedCommandKind::Concealment),
+        Command::MoveExplode { player, unit, path } => {
+            special::prepare_explode(prepare_movement_inner(state, &player, unit, path)?)
+                .map(PreparedCommandKind::Explode)
+        }
+        Command::MoveJoin {
+            player,
+            unit,
+            path,
+            target,
+        } => transport::prepare_join(prepare_movement_inner(state, &player, unit, path)?, target)
+            .map(PreparedCommandKind::Join),
+        Command::MoveLoad {
+            player,
+            unit,
+            path,
+            transport,
+        } => transport::prepare_load(
+            prepare_movement_inner(state, &player, unit, path)?,
+            transport,
+        )
+        .map(PreparedCommandKind::Load),
+        Command::MoveAttack {
+            player,
+            unit,
+            path,
+            target,
+        } => attack::prepare_attack(prepare_movement_inner(state, &player, unit, path)?, target)
+            .map(PreparedCommandKind::Attack),
+        Command::MoveRepair {
+            player,
+            unit,
+            path,
+            target,
+        } => transport::prepare_repair(prepare_movement_inner(state, &player, unit, path)?, target)
+            .map(PreparedCommandKind::Repair),
+        Command::MoveLaunch {
+            player,
+            unit,
+            path,
+            target,
+        } => special::prepare_launch(prepare_movement_inner(state, &player, unit, path)?, target)
+            .map(PreparedCommandKind::Launch),
+        _ => Err(ReducerError::UnsupportedCommand),
+    }
+}
+
+fn prepare_movement_inner<'a>(
+    state: &'a State,
+    player: &PlayerId,
+    unit: UnitId,
+    path: Vec<Pos>,
+) -> Result<PreparedMovement<'a>, ReducerError> {
+    let turn = ActiveTurn::open(state, player)?;
+    turn.prepare_move(unit, path)
+}
+
+fn execute_error(error: ReducerError) -> ExecuteError {
+    match error {
+        ReducerError::UnsupportedCommand => ExecuteError::UnsupportedCommand,
+        ReducerError::UnsupportedRuleset => ExecuteError::UnsupportedRuleset,
+        ReducerError::InvalidState(error) => ExecuteError::InvalidState(error),
+        ReducerError::InvalidRandom(error) => ExecuteError::InvalidRandom(error),
+        ReducerError::Violation(_) => {
+            unreachable!("violations are converted to preparation outcomes")
+        }
+    }
+}
+
+/// Apply a prepared command to the state that produced it.
+///
+/// Only combat consumes tokens from `random`. Deterministic actions report
+/// zero `random_consumed`. Do not reconcile these actions against tape offsets.
+pub fn execute_prepared(
+    prepared: PreparedCommand<'_>,
+    random: &[RandomToken],
+) -> Result<Execution, ExecuteError> {
+    execute_prepared_with(prepared, &mut RandomTape::new(random))
+}
+
+/// Apply a prepared command and ask `entropy` for values when it needs them.
+///
+/// Only combat asks `entropy` for values. Deterministic actions report zero
+/// `random_consumed`. Do not reconcile these actions against tape offsets. Attack
+/// preparation delays its combat draws until this application step.
+pub fn execute_prepared_with(
+    prepared: PreparedCommand<'_>,
+    entropy: &mut impl Entropy,
+) -> Result<Execution, ExecuteError> {
+    match prepared.command {
+        PreparedCommandKind::Wait(prepared) => Ok(movement::execute_prepared_wait(prepared)),
+        PreparedCommandKind::Capture(prepared) => {
+            property::execute_prepared_capture(prepared).map_err(execute_error)
+        }
+        PreparedCommandKind::Supply(prepared) => Ok(transport::execute_prepared_supply(prepared)),
+        PreparedCommandKind::Concealment(prepared) => {
+            Ok(movement::execute_prepared_concealment(prepared))
+        }
+        PreparedCommandKind::Join(prepared) => {
+            transport::execute_prepared_join(prepared).map_err(execute_error)
+        }
+        PreparedCommandKind::Load(prepared) => Ok(transport::execute_prepared_load(prepared)),
+        PreparedCommandKind::Attack(prepared) => {
+            let mut draws = Draws::new(entropy);
+            attack::execute_prepared_attack(prepared, &mut draws).map_err(execute_error)
+        }
+        PreparedCommandKind::Repair(prepared) => {
+            transport::execute_prepared_repair(prepared).map_err(execute_error)
+        }
+        PreparedCommandKind::Launch(prepared) => {
+            special::execute_prepared_launch(prepared).map_err(execute_error)
+        }
+        PreparedCommandKind::Explode(prepared) => {
+            special::execute_prepared_explode(prepared).map_err(execute_error)
+        }
     }
 }
 
@@ -539,12 +840,21 @@ impl<'a> ActiveTurn<'a> {
     ///
     /// Forwards to [`movement::plan`], which is the only constructor of a
     /// [`MovedUnit`], so no reducer can act on an unvalidated path.
-    pub(crate) fn plan_move(
+    fn plan_move(&self, unit: UnitId, path: Vec<Pos>) -> Result<MovedUnit, ReducerError> {
+        movement::plan(self, unit, path)
+    }
+
+    /// Validate movement and bind it to this turn's state.
+    pub(crate) fn prepare_move(
         &self,
         unit: UnitId,
         path: Vec<Pos>,
-    ) -> Result<MovedUnit, ReducerError> {
-        movement::plan(self, unit, path)
+    ) -> Result<PreparedMovement<'a>, ReducerError> {
+        Ok(PreparedMovement {
+            state: self.state,
+            unit,
+            movement: self.plan_move(unit, path)?,
+        })
     }
 }
 

--- a/crates/awvm/src/transition/attack.rs
+++ b/crates/awvm/src/transition/attack.rs
@@ -18,6 +18,12 @@ use crate::violation::{Action, Violation};
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
+#[derive(Debug)]
+pub(super) struct Attack {
+    target: PreparedAttackTarget,
+    destination: Option<AvailableDestination>,
+}
+
 /// Commander combat predicates take a capability set per combatant. No path
 /// through this module supplies one, so every combatant shares this empty set
 /// instead of allocating one per strike.
@@ -496,11 +502,10 @@ fn validate_tile_attack(
             target: Some(position.into()),
         })
     })?;
-    if state
-        .units
-        .iter()
-        .any(|unit| board_position(unit) == Some(position))
-    {
+    if state.units.iter().any(|unit| {
+        board_position(unit) == Some(position)
+            && !(unit.id == attacker.id && board_position(attacker) != Some(origin))
+    }) {
         return Err(violation(Violation::InvalidTarget {
             target: Some(position.into()),
         }));
@@ -648,14 +653,23 @@ pub(crate) fn execute_move_attack(
     target: AttackTarget,
     draws: &mut Draws<'_>,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let player = turn.player();
-    let plan = turn.plan_move(unit_id, path)?;
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_attack(movement, target)?;
+    execute_prepared_attack(prepared, draws)
+}
+
+pub(super) fn prepare_attack(
+    movement: PreparedMovement<'_>,
+    target: AttackTarget,
+) -> Result<Prepared<'_, Attack>, ExecuteError> {
+    let state = movement.state();
+    let player = &state.turn.active_player;
+    let unit_id = movement.unit();
+    let plan = movement.plan();
     let ai = plan.unit_index();
     let attacker = &state.units[ai];
-    let origin = plan.origin();
 
-    if plan.path().len() > 1 {
+    let (prepared_target, available_destination) = if plan.path().len() > 1 {
         match ruleset::profile(attacker.kind).fire_mode {
             FireMode::Indirect => {
                 return Err(violation(Violation::ActionNotSupported {
@@ -670,30 +684,75 @@ pub(crate) fn execute_move_attack(
             FireMode::Direct => {}
         }
 
-        let prepared_target = match target {
-            AttackTarget::Unit { unit } => {
-                PreparedAttackTarget::Unit(disclose_unit_target(state, plan.actor_team(), unit)?)
-            }
-            AttackTarget::Tile { position } => PreparedAttackTarget::Tile(position),
-        };
-
+        let prepared_target = prepare_attack_target(state, plan.actor_team(), target)?;
         let destination = plan.destination();
-        let view = AwbwVisibility.view(state, plan.actor_team());
-        if state.units.iter().any(|other| {
-            other.id != unit_id
-                && board_position(other) == Some(destination)
-                && occupancy_is_disclosed(&view, other)
-        }) {
-            return Err(violation(Violation::DestinationOccupied {
-                position: destination,
-            }));
-        }
+        let available_destination = movement.available_destination()?;
 
-        let mut movement = execute_planned_movement(state, unit_id, &plan);
-        if movement.trapped {
+        if planned_movement_trap(state, unit_id, plan).is_none() {
+            validate_attack_target(state, player, ai, destination, prepared_target)?;
+        }
+        (prepared_target, Some(available_destination))
+    } else {
+        let prepared_target = prepare_attack_target(state, plan.actor_team(), target)?;
+        validate_attack_target(state, player, ai, plan.origin(), prepared_target)?;
+        (prepared_target, None)
+    };
+
+    Ok(Prepared {
+        movement,
+        action: Attack {
+            target: prepared_target,
+            destination: available_destination,
+        },
+    })
+}
+
+fn validate_attack_target(
+    state: &State,
+    player: &PlayerId,
+    attacker_index: usize,
+    origin: Pos,
+    target: PreparedAttackTarget,
+) -> Result<(), ExecuteError> {
+    let attacker = &state.units[attacker_index];
+    match target {
+        PreparedAttackTarget::Unit(disclosed) => {
+            Engagement::open(state, attacker_index, origin, disclosed)?;
+        }
+        PreparedAttackTarget::Tile(position) => {
+            validate_tile_attack(state, player, attacker, origin, position)?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn execute_prepared_attack(
+    prepared: Prepared<'_, Attack>,
+    draws: &mut Draws<'_>,
+) -> Result<Execution, ExecuteError> {
+    let Prepared {
+        movement,
+        action:
+            Attack {
+                target: prepared_target,
+                destination: _destination,
+            },
+    } = prepared;
+    let state = movement.state();
+    let player = &state.turn.active_player;
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let ai = plan.unit_index();
+    let origin = plan.origin();
+
+    if plan.path().len() > 1 {
+        let destination = plan.destination();
+
+        let mut outcome = execute_planned_movement(state, unit_id, plan);
+        if outcome.trapped {
             return Ok(Execution {
-                state: movement.state,
-                events: movement.events,
+                state: outcome.state,
+                events: outcome.events,
                 random_consumed: 0,
             });
         }
@@ -701,9 +760,9 @@ pub(crate) fn execute_move_attack(
         // Movement spends the unit for movement-only actions. Restore readiness
         // internally so the atomic follow-up can resolve and emit the single
         // attack action transition.
-        movement.state.units[plan.unit_index()].action = UnitAction::Ready;
+        outcome.state.units[plan.unit_index()].action = UnitAction::Ready;
         let mut combat = execute_stationary_attack(
-            &movement.state,
+            &outcome.state,
             player,
             unit_id,
             plan.unit_index(),
@@ -711,20 +770,10 @@ pub(crate) fn execute_move_attack(
             prepared_target,
             draws,
         )?;
-        movement.events.append(&mut combat.events);
-        combat.events = movement.events;
+        outcome.events.append(&mut combat.events);
+        combat.events = outcome.events;
         return Ok(combat);
     }
-    let actor_team = state
-        .find_player(player)
-        .map(|candidate| &candidate.team)
-        .ok_or_else(|| ExecuteError::InvalidState("active player is absent".into()))?;
-    let prepared_target = match target {
-        AttackTarget::Unit { unit } => {
-            PreparedAttackTarget::Unit(disclose_unit_target(state, actor_team, unit)?)
-        }
-        AttackTarget::Tile { position } => PreparedAttackTarget::Tile(position),
-    };
     execute_stationary_attack(state, player, unit_id, ai, origin, prepared_target, draws)
 }
 
@@ -733,12 +782,26 @@ pub(crate) fn execute_move_attack(
 /// Movement can change visibility. It cannot change which enemy identifier the
 /// player can submit. Carry this result into the movement state. Combat can
 /// then use the resolved destination without a second visibility decision.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct DisclosedUnitTarget(UnitId);
 
+#[derive(Clone, Copy, Debug)]
 enum PreparedAttackTarget {
     Unit(DisclosedUnitTarget),
     Tile(Pos),
+}
+
+fn prepare_attack_target(
+    state: &State,
+    actor_team: &crate::semantic::TeamId,
+    target: AttackTarget,
+) -> Result<PreparedAttackTarget, ExecuteError> {
+    match target {
+        AttackTarget::Unit { unit } => Ok(PreparedAttackTarget::Unit(disclose_unit_target(
+            state, actor_team, unit,
+        )?)),
+        AttackTarget::Tile { position } => Ok(PreparedAttackTarget::Tile(position)),
+    }
 }
 
 fn disclose_unit_target(

--- a/crates/awvm/src/transition/movement.rs
+++ b/crates/awvm/src/transition/movement.rs
@@ -15,6 +15,37 @@ use crate::semantic::{
 };
 use crate::violation::{Action, Violation};
 
+#[derive(Debug)]
+pub(super) struct Wait(AvailableDestination);
+
+#[derive(Debug)]
+pub(super) struct ConcealmentAction {
+    target: crate::semantic::Concealment,
+    destination: AvailableDestination,
+}
+
+/// Proof that no disclosed unit occupies a movement's destination.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct AvailableDestination;
+
+impl PreparedMovement<'_> {
+    /// Validate that no disclosed unit occupies the destination.
+    pub(super) fn available_destination(&self) -> Result<AvailableDestination, ExecuteError> {
+        let destination = self.plan().destination();
+        let view = AwbwVisibility.view(self.state(), self.plan().actor_team());
+        if self.state().units.iter().any(|other| {
+            other.id != self.unit()
+                && board_position(other) == Some(destination)
+                && occupancy_is_disclosed(&view, other)
+        }) {
+            return Err(violation(Violation::DestinationOccupied {
+                position: destination,
+            }));
+        }
+        Ok(AvailableDestination)
+    }
+}
+
 /// A movement that has been validated, and the numbers that validating it
 /// produced.
 ///
@@ -22,6 +53,7 @@ use crate::violation::{Action, Violation};
 /// so holding one is proof the path was checked. `execute_move_capture` and
 /// `execute_move_join` each carried a verbatim copy of that check; nothing
 /// stopped a tenth reducer from carrying a subtly different one.
+#[derive(Clone, Debug)]
 pub(crate) struct MovedUnit {
     unit_index: usize,
     origin: Pos,
@@ -217,24 +249,7 @@ pub(crate) fn execute_planned_movement(
     unit_id: UnitId,
     plan: &MovedUnit,
 ) -> MovementOutcome {
-    let view = AwbwVisibility.view(state, plan.actor_team());
-    let trap = plan
-        .path
-        .iter()
-        .copied()
-        .enumerate()
-        .skip(1)
-        .find_map(|(index, position)| {
-            state
-                .units
-                .iter()
-                .find(|other| {
-                    other.id != unit_id
-                        && board_position(other) == Some(position)
-                        && !occupancy_is_disclosed(&view, other)
-                })
-                .map(|blocker| (index, position, blocker.id))
-        });
+    let trap = planned_movement_trap(state, unit_id, plan);
     let mut actual_length = trap
         .as_ref()
         .map_or(plan.path().len(), |(index, _, _)| *index);
@@ -285,6 +300,31 @@ pub(crate) fn execute_planned_movement(
     }
 }
 
+/// Return the first hidden unit that will stop this movement.
+pub(crate) fn planned_movement_trap(
+    state: &State,
+    unit_id: UnitId,
+    plan: &MovedUnit,
+) -> Option<(usize, Pos, UnitId)> {
+    let view = AwbwVisibility.view(state, plan.actor_team());
+    plan.path
+        .iter()
+        .copied()
+        .enumerate()
+        .skip(1)
+        .find_map(|(index, position)| {
+            state
+                .units
+                .iter()
+                .find(|other| {
+                    other.id != unit_id
+                        && board_position(other) == Some(position)
+                        && !occupancy_is_disclosed(&view, other)
+                })
+                .map(|blocker| (index, position, blocker.id))
+        })
+}
+
 pub(crate) fn reset_capture_on_departure(
     state: &mut State,
     unit_id: UnitId,
@@ -316,8 +356,17 @@ pub(crate) fn execute_move_concealment(
     path: Vec<Pos>,
     hide: bool,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let plan = turn.plan_move(unit_id, path)?;
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_concealment(movement, hide)?;
+    Ok(execute_prepared_concealment(prepared))
+}
+
+pub(super) fn prepare_concealment(
+    movement: PreparedMovement<'_>,
+    hide: bool,
+) -> Result<Prepared<'_, ConcealmentAction>, ExecuteError> {
+    let state = movement.state();
+    let plan = movement.plan();
     let original = &state.units[plan.unit_index()];
     let supported = ruleset::profile(original.kind).concealment.is_some();
     let target = if hide {
@@ -334,26 +383,35 @@ pub(crate) fn execute_move_concealment(
             },
         }));
     }
+    let destination = movement.available_destination()?;
 
-    let destination = plan.destination();
-    let view = AwbwVisibility.view(state, plan.actor_team());
-    if state.units.iter().any(|other| {
-        other.id != unit_id
-            && board_position(other) == Some(destination)
-            && occupancy_is_disclosed(&view, other)
-    }) {
-        return Err(violation(Violation::DestinationOccupied {
-            position: destination,
-        }));
-    }
+    Ok(Prepared {
+        movement,
+        action: ConcealmentAction {
+            target,
+            destination,
+        },
+    })
+}
 
-    let mut outcome = execute_planned_movement(state, unit_id, &plan);
+pub(super) fn execute_prepared_concealment(prepared: Prepared<'_, ConcealmentAction>) -> Execution {
+    let Prepared {
+        movement,
+        action:
+            ConcealmentAction {
+                target,
+                destination: _destination,
+            },
+    } = prepared;
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let mut outcome = execute_planned_movement(movement.state(), unit_id, plan);
     if outcome.trapped {
-        return Ok(Execution {
+        return Execution {
             state: outcome.state,
             events: outcome.events,
             random_consumed: 0,
-        });
+        };
     }
     let unit = &mut outcome.state.units[plan.unit_index()];
     let from = unit.concealment;
@@ -363,11 +421,11 @@ pub(crate) fn execute_move_concealment(
         from,
         to: target,
     });
-    Ok(Execution {
+    Execution {
         state: outcome.state,
         events: outcome.events,
         random_consumed: 0,
-    })
+    }
 }
 
 pub(crate) fn execute_move_wait(
@@ -375,23 +433,30 @@ pub(crate) fn execute_move_wait(
     unit_id: UnitId,
     path: Vec<Pos>,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let plan = turn.plan_move(unit_id, path)?;
-    let destination = plan.destination();
-    let view = AwbwVisibility.view(state, plan.actor_team());
-    if state.units.iter().any(|other| {
-        other.id != unit_id
-            && board_position(other) == Some(destination)
-            && occupancy_is_disclosed(&view, other)
-    }) {
-        return Err(violation(Violation::DestinationOccupied {
-            position: destination,
-        }));
-    }
-    let outcome = execute_planned_movement(state, unit_id, &plan);
-    Ok(Execution {
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_wait(movement)?;
+    Ok(execute_prepared_wait(prepared))
+}
+
+pub(super) fn prepare_wait(
+    movement: PreparedMovement<'_>,
+) -> Result<Prepared<'_, Wait>, ExecuteError> {
+    let destination = movement.available_destination()?;
+    Ok(Prepared {
+        movement,
+        action: Wait(destination),
+    })
+}
+
+pub(super) fn execute_prepared_wait(prepared: Prepared<'_, Wait>) -> Execution {
+    let Prepared {
+        movement,
+        action: Wait(_destination),
+    } = prepared;
+    let outcome = execute_planned_movement(movement.state(), movement.unit(), movement.plan());
+    Execution {
         state: outcome.state,
         events: outcome.events,
         random_consumed: 0,
-    })
+    }
 }

--- a/crates/awvm/src/transition/property.rs
+++ b/crates/awvm/src/transition/property.rs
@@ -10,10 +10,16 @@ use crate::commander::{self};
 use crate::event::Event;
 use crate::ruleset::{self, TerrainTrait, UnitKind};
 use crate::semantic::{
-    AwbwVisibility, Concealment, KnownReason, Location, Outcome, PlayerId, Pos, State, TerrainId,
-    TileOwner, Unit, UnitAction, UnitId, VictoryReason, Visibility,
+    Concealment, KnownReason, Location, Outcome, PlayerId, Pos, State, TerrainId, TileOwner, Unit,
+    UnitAction, UnitId, VictoryReason,
 };
 use crate::violation::{Action, Violation};
+
+#[derive(Debug)]
+pub(super) struct Capture {
+    strength: u64,
+    destination: AvailableDestination,
+}
 
 pub(crate) fn execute_produce_unit(
     turn: &ActiveTurn<'_>,
@@ -132,24 +138,25 @@ pub(crate) fn execute_move_capture(
     unit_id: UnitId,
     path: Vec<Pos>,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let player = turn.player();
-    let plan = turn.plan_move(unit_id, path)?;
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_capture(movement)?;
+    execute_prepared_capture(prepared)
+}
+
+pub(super) fn prepare_capture(
+    movement: PreparedMovement<'_>,
+) -> Result<Prepared<'_, Capture>, ExecuteError> {
+    let state = movement.state();
+    let plan = movement.plan();
     let unit = &state.units[plan.unit_index()];
-    let origin = plan.origin();
-    let path = plan.path();
     let profile = ruleset::profile(unit.kind);
     let actor_team = plan.actor_team();
-    let unit_index = plan.unit_index();
-    let entry_costs = plan.entry_costs();
-    let view = AwbwVisibility.view(state, actor_team);
-
     if !profile.can_capture {
         return Err(violation(Violation::ActionNotSupported {
             action: Action::Capture,
         }));
     }
-    let destination = *path.last().expect("origin was checked");
+    let destination = plan.destination();
     let destination_tile = &state.board.tile(destination);
     let capturable = ruleset::terrain_has(destination_tile.terrain, TerrainTrait::Capturable);
     let owner = destination_tile.owner.player();
@@ -163,72 +170,48 @@ pub(crate) fn execute_move_capture(
             target: Some(destination.into()),
         }));
     }
-    if state.units.iter().any(|other| {
-        other.id != unit_id
-            && board_position(other) == Some(destination)
-            && occupancy_is_disclosed(&view, other)
-    }) {
-        return Err(violation(Violation::DestinationOccupied {
-            position: destination,
-        }));
-    }
+    let available_destination = movement.available_destination()?;
 
-    // An undisclosed enemy is not a validation fact. It truncates execution
-    // before the occupied tile and suppresses capture.
-    let trap = path
-        .iter()
-        .copied()
-        .enumerate()
-        .skip(1)
-        .find_map(|(index, position)| {
-            state
-                .units
-                .iter()
-                .find(|other| {
-                    other.id != unit_id
-                        && board_position(other) == Some(position)
-                        && !occupancy_is_disclosed(&view, other)
-                })
-                .map(|blocker| (index, position, blocker.id))
-        });
-    let actual_length = trap.as_ref().map_or(path.len(), |(index, _, _)| *index);
-    let actual_path = path[..actual_length].to_vec();
-    let actual_destination = *actual_path.last().expect("actual path includes origin");
-    let fuel_spent: u64 = entry_costs[..actual_length].iter().sum();
-    let mut next = state.clone();
-    let mut events = Vec::new();
-    reset_capture_on_departure(&mut next, unit_id, origin, &actual_path, &mut events);
-    next.units[unit_index].fuel -= fuel_spent;
-    next.units[unit_index].action = UnitAction::Spent;
-    next.units[unit_index].location = Location::Board {
-        position: actual_destination,
-    };
-    events.push(Event::UnitMoved {
-        unit: unit_id,
-        from: origin,
-        to: actual_destination,
-        path: actual_path,
-        fuel_spent,
-    });
-    if let Some((_, position, blocker)) = trap {
-        events.push(Event::MovementTrapped {
-            unit: unit_id,
-            blocker,
-            position,
-        });
+    let strength =
+        commander::effective_capture_points(state, unit, u64::from(unit.hp.div_ceil(10)));
+    Ok(Prepared {
+        movement,
+        action: Capture {
+            strength,
+            destination: available_destination,
+        },
+    })
+}
+
+pub(super) fn execute_prepared_capture(
+    prepared: Prepared<'_, Capture>,
+) -> Result<Execution, ExecuteError> {
+    let Prepared {
+        movement,
+        action:
+            Capture {
+                strength: capture_strength,
+                destination: _destination,
+            },
+    } = prepared;
+    let state = movement.state();
+    let player = &state.turn.active_player;
+    let destination = movement.plan().destination();
+    let mut outcome = execute_planned_movement(state, movement.unit(), movement.plan());
+    if outcome.trapped {
         return Ok(Execution {
-            state: next,
-            events,
+            state: outcome.state,
+            events: outcome.events,
             random_consumed: 0,
         });
     }
 
+    let next = &mut outcome.state;
+    let events = &mut outcome.events;
     let tile = &mut next.board.tile_mut(destination);
     let before = tile
         .capture_points
         .ok_or(ExecuteError::UnsupportedRuleset)?;
-    let capture_strength =
-        commander::effective_capture_points(state, unit, u64::from(unit.hp.div_ceil(10)));
     if u64::from(before) > capture_strength {
         let after = u8::try_from(u64::from(before) - capture_strength)
             .map_err(|_| ExecuteError::InvalidState("capture result overflow".into()))?;
@@ -265,23 +248,23 @@ pub(crate) fn execute_move_capture(
             && next
                 .settings
                 .capture_limit
-                .is_some_and(|limit| capture_limit_count(&next, player) >= limit)
+                .is_some_and(|limit| capture_limit_count(next, player) >= limit)
         {
             let winning_team = next
                 .find_player(player)
                 .map(|candidate| candidate.team.clone())
                 .ok_or_else(|| ExecuteError::InvalidState("capturing player is absent".into()))?;
             complete_match(
-                &mut next,
+                next,
                 Outcome::Victory {
                     winners: vec![winning_team],
                     reason: VictoryReason::CaptureLimit,
                 },
-                &mut events,
+                events,
             );
             return Ok(Execution {
-                state: next,
-                events,
+                state: outcome.state,
+                events: outcome.events,
                 random_consumed: 0,
             });
         }
@@ -309,18 +292,18 @@ pub(crate) fn execute_move_capture(
                 VictoryReason::LabCapture
             };
             eliminate_player(
-                &mut next,
+                next,
                 &previous_owner,
                 cause,
                 Some(player),
                 Some(destination),
-                &mut events,
+                events,
             )?;
         }
     }
     Ok(Execution {
-        state: next,
-        events,
+        state: outcome.state,
+        events: outcome.events,
         random_consumed: 0,
     })
 }

--- a/crates/awvm/src/transition/special.rs
+++ b/crates/awvm/src/transition/special.rs
@@ -10,10 +10,17 @@ use super::*;
 use crate::commander::AreaStrikePolicy;
 use crate::event::Event;
 use crate::ruleset::{MISSILE_SILO_STRIKE, UNIT_EXPLOSION, UnitKind};
-use crate::semantic::{
-    AwbwVisibility, KnownReason, Pos, Silo, UnitAction, UnitId, VictoryReason, Visibility,
-};
+use crate::semantic::{KnownReason, Pos, Silo, UnitAction, UnitId, VictoryReason};
 use crate::violation::{Action, Violation};
+
+#[derive(Debug)]
+pub(super) struct Launch {
+    target: Pos,
+    destination: AvailableDestination,
+}
+
+#[derive(Debug)]
+pub(super) struct Explode(AvailableDestination);
 
 pub(crate) fn execute_move_launch(
     turn: &ActiveTurn<'_>,
@@ -21,8 +28,17 @@ pub(crate) fn execute_move_launch(
     path: Vec<Pos>,
     target: Pos,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let plan = turn.plan_move(unit_id, path)?;
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_launch(movement, target)?;
+    execute_prepared_launch(prepared)
+}
+
+pub(super) fn prepare_launch(
+    movement: PreparedMovement<'_>,
+    target: Pos,
+) -> Result<Prepared<'_, Launch>, ExecuteError> {
+    let state = movement.state();
+    let plan = movement.plan();
     if target.x >= state.board.width() || target.y >= state.board.height() {
         return Err(violation(Violation::InvalidTarget {
             target: Some(target.into()),
@@ -42,18 +58,32 @@ pub(crate) fn execute_move_launch(
             target: Some(silo_position.into()),
         }));
     }
-    let view = AwbwVisibility.view(state, plan.actor_team());
-    if state.units.iter().any(|other| {
-        other.id != unit_id
-            && board_position(other) == Some(silo_position)
-            && occupancy_is_disclosed(&view, other)
-    }) {
-        return Err(violation(Violation::DestinationOccupied {
-            position: silo_position,
-        }));
-    }
+    let destination = movement.available_destination()?;
 
-    let mut outcome = execute_planned_movement(state, unit_id, &plan);
+    Ok(Prepared {
+        movement,
+        action: Launch {
+            target,
+            destination,
+        },
+    })
+}
+
+pub(super) fn execute_prepared_launch(
+    prepared: Prepared<'_, Launch>,
+) -> Result<Execution, ExecuteError> {
+    let Prepared {
+        movement,
+        action: Launch {
+            target,
+            destination: _destination,
+        },
+    } = prepared;
+    let state = movement.state();
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let silo_position = plan.destination();
+    let mut outcome = execute_planned_movement(state, unit_id, plan);
     if outcome.trapped {
         return Ok(Execution {
             state: outcome.state,
@@ -117,27 +147,42 @@ pub(crate) fn execute_move_explode(
     unit_id: UnitId,
     path: Vec<Pos>,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let plan = turn.plan_move(unit_id, path)?;
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_explode(movement)?;
+    execute_prepared_explode(prepared)
+}
+
+pub(super) fn prepare_explode(
+    movement: PreparedMovement<'_>,
+) -> Result<Prepared<'_, Explode>, ExecuteError> {
+    let state = movement.state();
+    let plan = movement.plan();
     let unit = &state.units[plan.unit_index()];
     if unit.kind != UnitKind::BlackBomb {
         return Err(violation(Violation::ActionNotSupported {
             action: Action::MoveExplode,
         }));
     }
-    let destination = plan.destination();
-    let view = AwbwVisibility.view(state, plan.actor_team());
-    if state.units.iter().any(|other| {
-        other.id != unit_id
-            && board_position(other) == Some(destination)
-            && occupancy_is_disclosed(&view, other)
-    }) {
-        return Err(violation(Violation::DestinationOccupied {
-            position: destination,
-        }));
-    }
+    let destination = movement.available_destination()?;
 
-    let mut outcome = execute_planned_movement(state, unit_id, &plan);
+    Ok(Prepared {
+        movement,
+        action: Explode(destination),
+    })
+}
+
+pub(super) fn execute_prepared_explode(
+    prepared: Prepared<'_, Explode>,
+) -> Result<Execution, ExecuteError> {
+    let Prepared {
+        movement,
+        action: Explode(_destination),
+    } = prepared;
+    let state = movement.state();
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let destination = plan.destination();
+    let mut outcome = execute_planned_movement(state, unit_id, plan);
     if outcome.trapped {
         return Ok(Execution {
             state: outcome.state,

--- a/crates/awvm/src/transition/transport.rs
+++ b/crates/awvm/src/transition/transport.rs
@@ -16,13 +16,55 @@ use crate::semantic::{
 };
 use crate::violation::{Action, Violation};
 
+#[derive(Debug)]
+pub(super) struct Supply {
+    targets: TargetSet,
+    destination: AvailableDestination,
+}
+
+#[derive(Debug)]
+pub(super) struct Repair {
+    target: UnitId,
+    capability: ruleset::RepairProfile,
+    target_index: usize,
+    heal_cost: u64,
+    max_fuel: u64,
+    max_ammo: u64,
+    destination: AvailableDestination,
+}
+
+#[derive(Debug)]
+pub(super) struct Load {
+    transport: UnitId,
+    slot: usize,
+}
+
+#[derive(Debug)]
+pub(super) struct Join {
+    target: PreparedJoinTarget,
+}
+
+#[derive(Debug)]
+struct PreparedJoinTarget {
+    id: UnitId,
+    index: usize,
+}
+
 pub(crate) fn execute_move_supply(
     turn: &ActiveTurn<'_>,
     unit_id: UnitId,
     path: Vec<Pos>,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let plan = turn.plan_move(unit_id, path)?;
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_supply(movement)?;
+    Ok(execute_prepared_supply(prepared))
+}
+
+pub(super) fn prepare_supply(
+    movement: PreparedMovement<'_>,
+) -> Result<Prepared<'_, Supply>, ExecuteError> {
+    let state = movement.state();
+    let plan = movement.plan();
     let unit = &state.units[plan.unit_index()];
     let supply = ruleset::profile(unit.kind).supply;
     let Some(supply) = supply.filter(|supply| supply.relation == Relation::Adjacent) else {
@@ -30,25 +72,36 @@ pub(crate) fn execute_move_supply(
             action: Action::MoveSupply,
         }));
     };
-    let destination = plan.destination();
-    let view = AwbwVisibility.view(state, plan.actor_team());
-    if state.units.iter().any(|other| {
-        other.id != unit_id
-            && board_position(other) == Some(destination)
-            && occupancy_is_disclosed(&view, other)
-    }) {
-        return Err(violation(Violation::DestinationOccupied {
-            position: destination,
-        }));
-    }
+    let destination = movement.available_destination()?;
 
-    let mut outcome = execute_planned_movement(state, unit_id, &plan);
+    Ok(Prepared {
+        movement,
+        action: Supply {
+            targets: supply.targets,
+            destination,
+        },
+    })
+}
+
+pub(super) fn execute_prepared_supply(prepared: Prepared<'_, Supply>) -> Execution {
+    let Prepared {
+        movement,
+        action: Supply {
+            targets,
+            destination: _destination,
+        },
+    } = prepared;
+    let state = movement.state();
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let unit = &state.units[plan.unit_index()];
+    let mut outcome = execute_planned_movement(state, unit_id, plan);
     if outcome.trapped {
-        return Ok(Execution {
+        return Execution {
             state: outcome.state,
             events: outcome.events,
             random_consumed: 0,
-        });
+        };
     }
     let actual_destination =
         board_position(&outcome.state.units[plan.unit_index()]).expect("mover remains on board");
@@ -62,7 +115,7 @@ pub(crate) fn execute_move_supply(
                     &unit.owner,
                     plan.actor_team(),
                     &target.owner,
-                    supply.targets,
+                    targets,
                 )
                 && board_position(target).is_some_and(|position| {
                     position.x.abs_diff(actual_destination.x)
@@ -97,11 +150,11 @@ pub(crate) fn execute_move_supply(
             });
         }
     }
-    Ok(Execution {
+    Execution {
         state: outcome.state,
         events: outcome.events,
         random_consumed: 0,
-    })
+    }
 }
 
 pub(crate) fn supply_target_eligible(
@@ -125,9 +178,18 @@ pub(crate) fn execute_move_repair(
     path: Vec<Pos>,
     target_id: UnitId,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let player = turn.player();
-    let plan = turn.plan_move(unit_id, path)?;
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_repair(movement, target_id)?;
+    execute_prepared_repair(prepared)
+}
+
+pub(super) fn prepare_repair(
+    movement: PreparedMovement<'_>,
+    target_id: UnitId,
+) -> Result<Prepared<'_, Repair>, ExecuteError> {
+    let state = movement.state();
+    let unit_id = movement.unit();
+    let plan = movement.plan();
     let unit = &state.units[plan.unit_index()];
     let repair = ruleset::profile(unit.kind).repair;
     let Some(repair) = repair.filter(|repair| repair.relation == Relation::Adjacent) else {
@@ -135,48 +197,75 @@ pub(crate) fn execute_move_repair(
             action: Action::MoveRepair,
         }));
     };
-    let target_index = state.units.index_of(target_id);
-    let target = target_index.and_then(|index| state.units.at(index));
-    let target_team =
-        target.and_then(|target| state.find_player(&target.owner).map(|owner| &owner.team));
-    let target_position = target.and_then(board_position);
-    if !target.is_some_and(|target| {
-        target.id != unit_id && target_team == Some(plan.actor_team()) && target_position.is_some()
-    }) {
+    let Some(target_index) = state.units.index_of(target_id) else {
+        return Err(violation(Violation::InvalidTarget {
+            target: Some(target_id.into()),
+        }));
+    };
+    let target = &state.units[target_index];
+    let target_team = state.find_player(&target.owner).map(|owner| &owner.team);
+    let Some(target_position) = board_position(target) else {
+        return Err(violation(Violation::InvalidTarget {
+            target: Some(target_id.into()),
+        }));
+    };
+    if target.id == unit_id || target_team != Some(plan.actor_team()) {
         return Err(violation(Violation::InvalidTarget {
             target: Some(target_id.into()),
         }));
     }
     let destination = plan.destination();
-    let target_position = target_position.expect("target validity established its position");
     if target_position.x.abs_diff(destination.x) + target_position.y.abs_diff(destination.y) != 1 {
         return Err(violation(Violation::TargetOutOfRange {
             target: Some(target_id.into()),
         }));
     }
-    let view = AwbwVisibility.view(state, plan.actor_team());
-    if state.units.iter().any(|other| {
-        other.id != unit_id
-            && board_position(other) == Some(destination)
-            && occupancy_is_disclosed(&view, other)
-    }) {
-        return Err(violation(Violation::DestinationOccupied {
-            position: destination,
-        }));
-    }
+    let destination = movement.available_destination()?;
 
-    let target_index = target_index.expect("target validity established its index");
-    let exact_hp = repair.exact_hp;
-    let target_profile = ruleset::profile(target.expect("target exists").kind);
-    let max_fuel = target_profile.max_fuel;
-    let max_ammo = target_profile.max_ammo;
+    let target_profile = ruleset::profile(target.kind);
     let heal_cost = target_profile
         .cost
         .checked_mul(repair.cost_percent)
         .and_then(|cost| cost.checked_div(100))
         .ok_or(ExecuteError::UnsupportedRuleset)?;
 
-    let mut outcome = execute_planned_movement(state, unit_id, &plan);
+    Ok(Prepared {
+        movement,
+        action: Repair {
+            target: target_id,
+            capability: repair,
+            target_index,
+            heal_cost,
+            max_fuel: target_profile.max_fuel,
+            max_ammo: target_profile.max_ammo,
+            destination,
+        },
+    })
+}
+
+pub(super) fn execute_prepared_repair(
+    prepared: Prepared<'_, Repair>,
+) -> Result<Execution, ExecuteError> {
+    let Prepared {
+        movement,
+        action:
+            Repair {
+                target: target_id,
+                capability,
+                target_index,
+                heal_cost,
+                max_fuel,
+                max_ammo,
+                destination: _destination,
+            },
+    } = prepared;
+    let state = movement.state();
+    let player = &state.turn.active_player;
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let exact_hp = capability.exact_hp;
+
+    let mut outcome = execute_planned_movement(state, unit_id, plan);
     if outcome.trapped {
         return Ok(Execution {
             state: outcome.state,
@@ -237,9 +326,19 @@ pub(crate) fn execute_move_load(
     path: Vec<Pos>,
     transport_id: UnitId,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let player = turn.player();
-    let plan = turn.plan_move(unit_id, path)?;
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_load(movement, transport_id)?;
+    Ok(execute_prepared_load(prepared))
+}
+
+pub(super) fn prepare_load(
+    movement: PreparedMovement<'_>,
+    transport_id: UnitId,
+) -> Result<Prepared<'_, Load>, ExecuteError> {
+    let state = movement.state();
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let player = &state.turn.active_player;
     let mover = &state.units[plan.unit_index()];
     let transport_index = state.units.index_of(transport_id);
     let transport = transport_index.and_then(|index| state.units.at(index));
@@ -284,13 +383,33 @@ pub(crate) fn execute_move_load(
             ExecuteError::InvalidState(format!("transport {transport_id} is full").into())
         })?;
 
-    let mut outcome = execute_planned_movement(state, unit_id, &plan);
+    Ok(Prepared {
+        movement,
+        action: Load {
+            transport: transport_id,
+            slot,
+        },
+    })
+}
+
+pub(super) fn execute_prepared_load(prepared: Prepared<'_, Load>) -> Execution {
+    let Prepared {
+        movement,
+        action: Load {
+            transport: transport_id,
+            slot,
+        },
+    } = prepared;
+    let state = movement.state();
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let mut outcome = execute_planned_movement(state, unit_id, plan);
     if outcome.trapped {
-        return Ok(Execution {
+        return Execution {
             state: outcome.state,
             events: outcome.events,
             random_consumed: 0,
-        });
+        };
     }
     outcome.state.units[plan.unit_index()].location = Location::Cargo {
         transport: transport_id,
@@ -301,11 +420,11 @@ pub(crate) fn execute_move_load(
         transport: transport_id,
         slot,
     });
-    Ok(Execution {
+    Execution {
         state: outcome.state,
         events: outcome.events,
         random_consumed: 0,
-    })
+    }
 }
 
 pub(crate) fn execute_unload(
@@ -408,38 +527,40 @@ pub(crate) fn execute_move_join(
     path: Vec<Pos>,
     target_id: UnitId,
 ) -> Result<Execution, ExecuteError> {
-    let state = turn.state();
-    let player = turn.player();
-    let plan = turn.plan_move(unit_id, path)?;
-    let unit = &state.units[plan.unit_index()];
-    let origin = plan.origin();
-    let path = plan.path();
-    let profile = ruleset::profile(unit.kind);
-    let actor_team = plan.actor_team();
-    let unit_index = plan.unit_index();
-    let entry_costs = plan.entry_costs();
-    let view = AwbwVisibility.view(state, actor_team);
+    let movement = turn.prepare_move(unit_id, path)?;
+    let prepared = prepare_join(movement, target_id)?;
+    execute_prepared_join(prepared)
+}
 
-    let target_index = state.units.index_of(target_id);
-    let target = target_index.and_then(|index| state.units.at(index));
-    let target_owner_team =
-        target.and_then(|target| state.find_player(&target.owner).map(|owner| &owner.team));
-    let target_position = target.and_then(board_position);
-    let target_valid = target.is_some_and(|target| {
-        target.id != unit.id
-            && target.kind == unit.kind
-            && target_owner_team == Some(actor_team)
-            && target_position.is_some()
-    });
-    if !target_valid {
+pub(super) fn prepare_join(
+    movement: PreparedMovement<'_>,
+    target_id: UnitId,
+) -> Result<Prepared<'_, Join>, ExecuteError> {
+    let state = movement.state();
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let unit = &state.units[plan.unit_index()];
+    let actor_team = plan.actor_team();
+
+    let Some(target_index) = state.units.index_of(target_id) else {
+        return Err(violation(Violation::InvalidTarget {
+            target: Some(target_id.into()),
+        }));
+    };
+    let target = &state.units[target_index];
+    let target_owner_team = state.find_player(&target.owner).map(|owner| &owner.team);
+    let Some(target_position) = board_position(target) else {
+        return Err(violation(Violation::InvalidTarget {
+            target: Some(target_id.into()),
+        }));
+    };
+    if target.id == unit.id || target.kind != unit.kind || target_owner_team != Some(actor_team) {
         return Err(violation(Violation::InvalidTarget {
             target: Some(target_id.into()),
         }));
     }
-    let target = target.expect("target validity established the unit");
-    let target_index = target_index.expect("target validity established the index");
-    let destination = *path.last().expect("origin was checked");
-    if target_position != Some(destination) {
+    let destination = plan.destination();
+    if target_position != destination {
         return Err(violation(Violation::InvalidTarget {
             target: Some(destination.into()),
         }));
@@ -465,6 +586,45 @@ pub(crate) fn execute_move_join(
             target: Some(unit_id.into()),
         }));
     }
+
+    Ok(Prepared {
+        movement,
+        action: Join {
+            target: PreparedJoinTarget {
+                id: target_id,
+                index: target_index,
+            },
+        },
+    })
+}
+
+pub(super) fn execute_prepared_join(
+    prepared: Prepared<'_, Join>,
+) -> Result<Execution, ExecuteError> {
+    let Prepared {
+        movement,
+        action:
+            Join {
+                target:
+                    PreparedJoinTarget {
+                        id: target_id,
+                        index: target_index,
+                    },
+            },
+    } = prepared;
+    let state = movement.state();
+    let player = &state.turn.active_player;
+    let unit_id = movement.unit();
+    let plan = movement.plan();
+    let unit = &state.units[plan.unit_index()];
+    let origin = plan.origin();
+    let path = plan.path();
+    let profile = ruleset::profile(unit.kind);
+    let actor_team = plan.actor_team();
+    let unit_index = plan.unit_index();
+    let entry_costs = plan.entry_costs();
+    let view = AwbwVisibility.view(state, actor_team);
+    let target = &state.units[target_index];
 
     // Only an undisclosed intermediate enemy can trap a well-formed join: the
     // allied destination target is always disclosed and explicitly licensed.

--- a/crates/awvm/tests/prepared.rs
+++ b/crates/awvm/tests/prepared.rs
@@ -1,0 +1,257 @@
+//! Equivalence checks for commands that separate preparation from application.
+//!
+//! The ordinary reducer remains the oracle while the prepared API is small.
+//! Every prepared fixture command must produce the same rejection, state,
+//! events, and random count through both paths.
+
+use std::path::PathBuf;
+
+use awvm::conformance::collect_json;
+use awvm::prelude::*;
+use awvm::semantic::{Location, TileOwner};
+use serde_json::Value;
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../spec/fixtures")
+}
+
+#[test]
+fn every_supported_fixture_matches_prepared_execution() {
+    let root = fixture_root();
+    let mut files = Vec::new();
+    collect_json(&root, &mut files).expect("walk fixture root");
+    files.sort();
+
+    let mut waits = 0;
+    let mut captures = 0;
+    let mut supplies = 0;
+    let mut hides = 0;
+    let mut reveals = 0;
+    let mut explodes = 0;
+    let mut joins = 0;
+    let mut loads = 0;
+    let mut attacks = 0;
+    let mut repairs = 0;
+    let mut launches = 0;
+    for path in files {
+        let source = std::fs::read_to_string(&path).expect("read fixture");
+        let case: Value = serde_json::from_str(&source).expect("parse fixture");
+        let Ok(mut state) = serde_json::from_value::<State>(case["initial_state"].clone()) else {
+            continue;
+        };
+
+        for step in case["steps"].as_array().into_iter().flatten() {
+            let Ok(command) = serde_json::from_value::<Command>(step["command"].clone()) else {
+                continue;
+            };
+            let random: Vec<RandomToken> =
+                serde_json::from_value(step["random"].clone()).unwrap_or_default();
+            let ordinary = execute(&state, command.clone(), &random);
+
+            let counter = match &command {
+                Command::MoveWait { .. } => Some(&mut waits),
+                Command::MoveCapture { .. } => Some(&mut captures),
+                Command::MoveSupply { .. } => Some(&mut supplies),
+                Command::MoveHide { .. } => Some(&mut hides),
+                Command::MoveReveal { .. } => Some(&mut reveals),
+                Command::MoveExplode { .. } => Some(&mut explodes),
+                Command::MoveJoin { .. } => Some(&mut joins),
+                Command::MoveLoad { .. } => Some(&mut loads),
+                Command::MoveAttack { .. } => Some(&mut attacks),
+                Command::MoveRepair { .. } => Some(&mut repairs),
+                Command::MoveLaunch { .. } => Some(&mut launches),
+                _ => None,
+            };
+            if let Some(counter) = counter {
+                *counter += 1;
+                let prepared = prepare_command(&state, command);
+                match (&ordinary, prepared) {
+                    (
+                        Ok(ExecuteOutcome::Accepted(expected)),
+                        Ok(PrepareOutcome::Prepared(prepared)),
+                    ) => assert_eq!(
+                        execute_prepared(prepared, &random),
+                        Ok(expected.clone()),
+                        "{} disagreed at {}",
+                        path.display(),
+                        step["id"]
+                    ),
+                    (
+                        Ok(ExecuteOutcome::Rejected(expected)),
+                        Ok(PrepareOutcome::Rejected(actual)),
+                    ) => assert_eq!(
+                        actual,
+                        *expected,
+                        "{} disagreed at {}",
+                        path.display(),
+                        step["id"]
+                    ),
+                    (Err(expected), Err(actual)) => assert_eq!(
+                        actual,
+                        *expected,
+                        "{} disagreed at {}",
+                        path.display(),
+                        step["id"]
+                    ),
+                    (expected, actual) => panic!(
+                        "{} disagreed at {}: ordinary {expected:?}, prepared {actual:?}",
+                        path.display(),
+                        step["id"]
+                    ),
+                }
+            }
+
+            if let Ok(ExecuteOutcome::Accepted(execution)) = ordinary {
+                state = execution.state;
+            }
+        }
+    }
+
+    assert!(
+        waits >= 47,
+        "expected the full move-wait corpus, saw {waits}"
+    );
+    assert!(
+        captures >= 14,
+        "expected the full move-capture corpus, saw {captures}"
+    );
+    assert!(
+        supplies >= 5,
+        "expected the full move-supply corpus, saw {supplies}"
+    );
+    assert!(
+        hides >= 6,
+        "expected the full move-hide corpus, saw {hides}"
+    );
+    assert!(
+        reveals >= 2,
+        "expected the full move-reveal corpus, saw {reveals}"
+    );
+    assert!(
+        explodes >= 3,
+        "expected the full move-explode corpus, saw {explodes}"
+    );
+    assert!(
+        joins >= 6,
+        "expected the full move-join corpus, saw {joins}"
+    );
+    assert!(
+        loads >= 6,
+        "expected the full move-load corpus, saw {loads}"
+    );
+    assert!(
+        attacks >= 128,
+        "expected the full move-attack corpus, saw {attacks}"
+    );
+    assert!(
+        repairs >= 4,
+        "expected the full move-repair corpus, saw {repairs}"
+    );
+    assert!(
+        launches >= 4,
+        "expected the full move-launch corpus, saw {launches}"
+    );
+}
+
+#[test]
+fn one_movement_can_prepare_wait_and_capture() {
+    let source = include_str!("../../../spec/fixtures/capture/capture-city-partial.json");
+    let case: Value = serde_json::from_str(source).expect("parse fixture");
+    let state: State = serde_json::from_value(case["initial_state"].clone()).expect("decode state");
+    let command: Command =
+        serde_json::from_value(case["steps"][0]["command"].clone()).expect("decode command");
+    let Command::MoveCapture { player, unit, path } = command else {
+        panic!("fixture starts with capture")
+    };
+    let movement = match prepare_movement(&state, &player, unit, path.clone()).expect("prepare") {
+        PrepareMovementOutcome::Prepared(movement) => movement,
+        PrepareMovementOutcome::Rejected(violation) => panic!("movement rejected: {violation:?}"),
+    };
+    let wait = match movement.clone().prepare_wait().expect("prepare wait") {
+        PrepareOutcome::Prepared(wait) => wait,
+        PrepareOutcome::Rejected(violation) => panic!("wait rejected: {violation:?}"),
+    };
+    let capture = match movement.prepare_capture().expect("prepare capture") {
+        PrepareOutcome::Prepared(capture) => capture,
+        PrepareOutcome::Rejected(violation) => panic!("capture rejected: {violation:?}"),
+    };
+
+    let ordinary_wait = execute(
+        &state,
+        Command::MoveWait {
+            player: player.clone(),
+            unit,
+            path: path.clone(),
+        },
+        &[],
+    );
+    let ordinary_capture = execute(&state, Command::MoveCapture { player, unit, path }, &[]);
+
+    assert_eq!(
+        execute_prepared(wait, &[]).map(ExecuteOutcome::Accepted),
+        ordinary_wait
+    );
+    assert_eq!(
+        execute_prepared(capture, &[]).map(ExecuteOutcome::Accepted),
+        ordinary_capture
+    );
+}
+
+#[test]
+fn a_hidden_trap_suppresses_prepared_capture() {
+    let source = include_str!("../../../spec/fixtures/movement/teleporter-hidden-trap.json");
+    let case: Value = serde_json::from_str(source).expect("parse fixture");
+    let mut state: State =
+        serde_json::from_value(case["initial_state"].clone()).expect("decode state");
+    let destination = Pos::new(4, 0);
+    let tile = state.board.tile_mut(destination);
+    tile.terrain = awvm::ruleset::Terrain::City;
+    tile.owner = TileOwner::Neutral;
+    tile.capture_points = Some(20);
+    let wait: Command =
+        serde_json::from_value(case["steps"][0]["command"].clone()).expect("decode command");
+    let Command::MoveWait { player, unit, path } = wait else {
+        panic!("fixture starts with move-wait")
+    };
+    let command = Command::MoveCapture { player, unit, path };
+
+    let prepared = match prepare_command(&state, command).expect("prepare capture") {
+        PrepareOutcome::Prepared(prepared) => prepared,
+        PrepareOutcome::Rejected(violation) => panic!("capture rejected: {violation:?}"),
+    };
+    let execution = execute_prepared(prepared, &[]).expect("execute capture");
+
+    assert!(
+        execution
+            .events
+            .iter()
+            .any(|event| matches!(event, Event::MovementTrapped { .. }))
+    );
+    assert!(
+        !execution
+            .events
+            .iter()
+            .any(|event| matches!(event, Event::CaptureChanged { .. }))
+    );
+    assert_eq!(
+        execution.state.units.get(unit).map(|unit| &unit.location),
+        Some(&Location::Board {
+            position: Pos::new(0, 0)
+        })
+    );
+}
+
+#[test]
+fn preparation_refuses_commands_outside_the_movement_surface() {
+    let source = include_str!("../../../spec/fixtures/movement/infantry-plain-move.json");
+    let case: Value = serde_json::from_str(source).expect("parse fixture");
+    let state: State = serde_json::from_value(case["initial_state"].clone()).expect("decode state");
+    let command = Command::EndTurn {
+        player: state.turn.active_player.clone(),
+    };
+
+    assert_eq!(
+        prepare_command(&state, command).unwrap_err(),
+        ExecuteError::UnsupportedCommand
+    );
+}

--- a/crates/awvm/tests/query.rs
+++ b/crates/awvm/tests/query.rs
@@ -1,9 +1,10 @@
 //! `query` against `execute`, over the whole corpus.
 //!
-//! `actions_at` and `attack_targets` run the reducer, so they cannot disagree
-//! with it by construction. `reachable` does not — it is a search written
-//! beside the rules, which is exactly the arrangement this module exists to
-//! spare consumers — so it is the one thing that needs holding to account.
+//! `actions_at` uses reducer preparation or execution, and `attack_targets`
+//! runs the reducer. They cannot disagree with it by construction. `reachable`
+//! does not. It is a search written beside the rules, which is exactly the
+//! arrangement this module exists to spare consumers. It therefore needs
+//! separate equivalence coverage.
 //!
 //! The ground truth here is `execute` itself. Fixture boards are at most 21
 //! tiles, so every simple path a unit could submit can be enumerated and put to
@@ -18,7 +19,7 @@ use awvm::combat::DamageRange;
 use awvm::conformance::collect_json;
 use awvm::prelude::*;
 use awvm::query::{self, can_act};
-use awvm::semantic::{KnownReason, Location, Reason, UnitAction};
+use awvm::semantic::{KnownReason, Location, Reason, RulesetRevision, UnitAction};
 use serde_json::Value;
 
 fn corpus() -> Vec<(String, Value)> {
@@ -296,6 +297,189 @@ fn every_accepted_fixture_command_was_offered() {
     }
 }
 
+/// Prepared movement gives the same action verdicts as execution.
+#[test]
+fn prepared_action_queries_agree_with_execution() {
+    let mut checked = 0;
+    for (relative, case) in corpus() {
+        for state in states(&case) {
+            for subject in state.units.iter() {
+                if subject.owner != state.turn.active_player
+                    || can_act(&state, subject.id) != Ok(Ok(()))
+                {
+                    continue;
+                }
+                let field = query::reachable(&state, subject.id).expect("an on-board unit");
+                for (destination, _) in field.reach() {
+                    let path = field
+                        .path_to(destination)
+                        .expect("a reachable tile has a path");
+                    let actions = query::actions_at(&state, subject.id, destination)
+                        .unwrap_or_else(|error| panic!("{relative}: {error}"));
+                    let from_path = query::actions_for_path(&state, subject.id, path.clone())
+                        .unwrap_or_else(|error| panic!("{relative}: {error}"));
+                    assert_eq!(
+                        from_path, actions,
+                        "{relative}: unit {} path query disagreed at {destination}",
+                        subject.id
+                    );
+                    let accepts = |command| {
+                        matches!(
+                            execute(&state, command, &[]),
+                            Ok(ExecuteOutcome::Accepted(_))
+                        )
+                    };
+                    let occupant = state.units.iter().find_map(|unit| match unit.location {
+                        Location::Board { position } if position == destination => Some(unit.id),
+                        _ => None,
+                    });
+
+                    assert_eq!(
+                        actions.wait,
+                        accepts(Command::MoveWait {
+                            player: subject.owner.clone(),
+                            unit: subject.id,
+                            path: path.clone(),
+                        }),
+                        "{relative}: unit {} Wait disagreed at {destination}",
+                        subject.id
+                    );
+                    assert_eq!(
+                        actions.capture,
+                        accepts(Command::MoveCapture {
+                            player: subject.owner.clone(),
+                            unit: subject.id,
+                            path: path.clone(),
+                        }),
+                        "{relative}: unit {} Capture disagreed at {destination}",
+                        subject.id
+                    );
+                    assert_eq!(
+                        actions.supply,
+                        accepts(Command::MoveSupply {
+                            player: subject.owner.clone(),
+                            unit: subject.id,
+                            path: path.clone(),
+                        }),
+                        "{relative}: unit {} Supply disagreed at {destination}",
+                        subject.id
+                    );
+                    assert_eq!(
+                        actions.hide,
+                        accepts(Command::MoveHide {
+                            player: subject.owner.clone(),
+                            unit: subject.id,
+                            path: path.clone(),
+                        }),
+                        "{relative}: unit {} Hide disagreed at {destination}",
+                        subject.id
+                    );
+                    assert_eq!(
+                        actions.reveal,
+                        accepts(Command::MoveReveal {
+                            player: subject.owner.clone(),
+                            unit: subject.id,
+                            path: path.clone(),
+                        }),
+                        "{relative}: unit {} Reveal disagreed at {destination}",
+                        subject.id
+                    );
+                    assert_eq!(
+                        actions.join,
+                        occupant.is_some_and(|target| accepts(Command::MoveJoin {
+                            player: subject.owner.clone(),
+                            unit: subject.id,
+                            path: path.clone(),
+                            target,
+                        })),
+                        "{relative}: unit {} Join disagreed at {destination}",
+                        subject.id
+                    );
+                    assert_eq!(
+                        actions.load,
+                        occupant.is_some_and(|transport| accepts(Command::MoveLoad {
+                            player: subject.owner.clone(),
+                            unit: subject.id,
+                            path: path.clone(),
+                            transport,
+                        })),
+                        "{relative}: unit {} Load disagreed at {destination}",
+                        subject.id
+                    );
+                    assert_eq!(
+                        actions.explode,
+                        accepts(Command::MoveExplode {
+                            player: subject.owner.clone(),
+                            unit: subject.id,
+                            path,
+                        }),
+                        "{relative}: unit {} Explode disagreed at {destination}",
+                        subject.id
+                    );
+                    checked += 1;
+                }
+            }
+        }
+    }
+
+    assert!(
+        checked >= 704,
+        "expected the full movement corpus, saw {checked} destinations"
+    );
+}
+
+#[test]
+fn a_path_from_a_stale_field_is_validated_again() {
+    let source = include_str!("../../../spec/fixtures/movement/infantry-plain-move.json");
+    let case: Value = serde_json::from_str(source).expect("parse fixture");
+    let mut state: State =
+        serde_json::from_value(case["initial_state"].clone()).expect("decode state");
+    let unit = state.units[0].id;
+    let field = query::reachable(&state, unit).expect("compute field");
+    let path = field.path_to(Pos::new(1, 0)).expect("destination has path");
+    state.units.get_mut(unit).expect("unit exists").action = UnitAction::Spent;
+
+    assert_eq!(
+        query::actions_for_path(&state, unit, path),
+        Ok(query::ActionSet::default())
+    );
+}
+
+#[test]
+fn prepared_action_queries_propagate_movement_faults() {
+    let source = include_str!("../../../spec/fixtures/movement/infantry-plain-move.json");
+    let case: Value = serde_json::from_str(source).expect("parse fixture");
+    let state: State = serde_json::from_value(case["initial_state"].clone()).expect("decode state");
+    let unit = state.units[0].id;
+    let Location::Board { position } = state.units[0].location else {
+        panic!("fixture unit is on the board");
+    };
+    let path = vec![position];
+
+    let mut unsupported = state.clone();
+    unsupported.ruleset.revision = RulesetRevision::from("unsupported");
+    assert_eq!(
+        query::actions_for_path(&unsupported, unit, path.clone()),
+        Err(QueryError::Transition(ExecuteError::UnsupportedRuleset))
+    );
+    assert_eq!(
+        query::attack_targets(&unsupported, unit, position),
+        Err(QueryError::Transition(ExecuteError::UnsupportedRuleset))
+    );
+
+    let mut invalid = state;
+    invalid.turn.active_player = PlayerId::from("unknown");
+    invalid.units[0].owner = PlayerId::from("unknown");
+    assert!(matches!(
+        query::actions_for_path(&invalid, unit, path.clone()),
+        Err(QueryError::Transition(ExecuteError::InvalidState(_)))
+    ));
+    assert!(matches!(
+        query::attack_targets(&invalid, unit, position),
+        Err(QueryError::Transition(ExecuteError::InvalidState(_)))
+    ));
+}
+
 #[test]
 fn observed_production_options_include_hachi_scop_city_metadata() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -551,6 +735,8 @@ fn observed_actions_agree_with_authoritative_actions_without_fog() {
                 continue;
             };
             let reified = query::reify(&observation).expect("fog-free observation must reify");
+            let observed_query =
+                query::ObservedQuery::new(&observation).expect("build observed query");
 
             for subject in state.units.iter() {
                 if subject.owner != recipient || can_act(&state, subject.id) != Ok(Ok(())) {
@@ -561,14 +747,21 @@ fn observed_actions_agree_with_authoritative_actions_without_fog() {
                 };
 
                 for (destination, _) in field.destinations() {
+                    let path = field.path_to(destination).expect("destination has path");
                     let authoritative = query::actions_at(&state, subject.id, destination)
                         .map(|actions| query::by_position(&state, actions));
                     let observed = query::actions_at(&reified, subject.id, destination)
                         .map(|actions| query::by_position(&reified, actions));
+                    let observed_from_path = observed_query.actions_for_path(subject.id, path);
                     assert_eq!(
                         observed, authoritative,
                         "{relative}: unit {} at {destination:?} disagrees between the \
                          projection and the state it came from",
+                        subject.id
+                    );
+                    assert_eq!(
+                        observed_from_path, authoritative,
+                        "{relative}: unit {} path query disagrees at {destination:?}",
                         subject.id
                     );
                     checked += 1;


### PR DESCRIPTION
- Add typed preparation for all movement actions and delay state changes and random draws until execution.
- Reuse prepared movement, observations, and Dial-based reachability during action enumeration.
- Preserve fog, hidden trap, combat, and target semantics through shared validators and applicators.
- Verify prepared and ordinary execution against the fixture corpus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added prepared command workflows for validating and executing movement, combat, transport, repair, concealment, launch, and special actions.
  - Added reusable observed queries for reachability and available actions at destinations or along paths.
  - Improved movement reachability for bounded costs and zero-cost teleportation.
- **Bug Fixes**
  - Improved trap, occupancy, visibility, and destination validation.
  - Ensured query results consistently reflect authoritative command execution and report invalid states clearly.
- **Tests**
  - Added broad equivalence coverage between prepared and standard command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->