### PR TITLE
Require pre-command visibility for move attacks

### DIFF
--- a/crates/awvm/src/transition.rs
+++ b/crates/awvm/src/transition.rs
@@ -1417,6 +1417,7 @@ mod tests {
     #[test]
     fn direct_unit_moves_then_attacks_from_resolved_destination() {
         let mut state = direct_combat_state(3);
+        state.settings.fog = true;
         state.board.tile_mut(Pos::new(0, 0)).capture_points = Some(10);
         let mut defender = state.units[0].clone();
         defender.id = UnitId::new(1);
@@ -1476,7 +1477,7 @@ mod tests {
     }
 
     #[test]
-    fn movement_can_reveal_attack_target_under_fog() {
+    fn movement_cannot_make_an_undisclosed_unit_an_attack_target() {
         let mut state = direct_combat_state(3);
         state.settings.fog = true;
         state.board.tile_mut(Pos::new(2, 0)).terrain = TerrainId::Wood;
@@ -1498,23 +1499,71 @@ mod tests {
             "target":{"type":"unit","unit":1}
         }))
         .unwrap();
-        let random = vec![
-            RandomToken::CombatGoodLuck(0),
-            RandomToken::CombatBadLuck(0),
-            RandomToken::CombatGoodLuck(0),
-            RandomToken::CombatBadLuck(0),
-        ];
+        assert!(
+            !crate::query::attack_targets(&state, UnitId::new(0), Pos::new(1, 0))
+                .unwrap()
+                .contains(&AttackTarget::Unit {
+                    unit: UnitId::new(1)
+                })
+        );
+        let observation = crate::semantic::observe(&AwbwVisibility, &state, &"red".into()).unwrap();
+        assert_eq!(
+            crate::query::observed_forecasts(
+                &observation,
+                UnitId::new(0),
+                Pos::new(1, 0),
+                &[Pos::new(2, 0)]
+            )
+            .unwrap(),
+            vec![None]
+        );
+        assert_eq!(
+            execute(&state, command, &[]),
+            Err(violation(Violation::InvalidTarget {
+                target: Some(UnitId::new(1).into())
+            }))
+        );
+    }
 
-        let result = execute(&state, command, &random).unwrap();
+    #[test]
+    fn capture_does_not_require_precommand_property_visibility() {
+        let mut state = direct_combat_state(4);
+        state.settings.fog = true;
+        let destination = Pos::new(3, 0);
+        let property = state.board.tile_mut(destination);
+        property.terrain = TerrainId::City;
+        property.owner = TileOwner::Neutral;
+        property.capture_points = Some(20);
+        assert!(
+            !AwbwVisibility
+                .view(&state, &crate::semantic::TeamId::from("red-team"))
+                .position(destination)
+        );
+        let command: Command = serde_json::from_value(json!({
+            "type":"move-capture", "player":"red", "unit":0,
+            "path":[
+                Pos::new(0, 0), Pos::new(1, 0), Pos::new(2, 0), destination
+            ]
+        }))
+        .unwrap();
 
-        assert_eq!(result.events[0].kind(), EventKind::UnitMoved);
-        assert_eq!(result.events[1].kind(), EventKind::AttackResolved);
+        let result = execute(&state, command, &[]).unwrap();
+
+        assert_eq!(board_position(&result.state.units[0]), Some(destination));
+        assert_eq!(
+            result.state.board.tile(destination).capture_points,
+            Some(10)
+        );
     }
 
     #[test]
     fn hidden_blocker_truncates_combat_movement_and_suppresses_attack() {
         let mut state = direct_combat_state(5);
         state.settings.fog = true;
+        let target_tile = state.board.tile_mut(Pos::new(4, 0));
+        target_tile.terrain = TerrainId::City;
+        target_tile.owner = TileOwner::Owned("red".into());
+        target_tile.capture_points = Some(20);
         let mut blocker = state.units[0].clone();
         blocker.id = UnitId::new(1);
         blocker.kind = UnitKindId::Tank;

--- a/crates/awvm/src/transition/attack.rs
+++ b/crates/awvm/src/transition/attack.rs
@@ -670,6 +670,16 @@ pub(crate) fn execute_move_attack(
             FireMode::Direct => {}
         }
 
+        let prepared_target = match target {
+            AttackTarget::Unit { unit } => PreparedAttackTarget::Unit(disclose_unit_target(
+                state,
+                player,
+                plan.actor_team(),
+                unit,
+            )?),
+            AttackTarget::Tile { position } => PreparedAttackTarget::Tile(position),
+        };
+
         let destination = plan.destination();
         let view = AwbwVisibility.view(state, plan.actor_team());
         if state.units.iter().any(|other| {
@@ -701,14 +711,58 @@ pub(crate) fn execute_move_attack(
             unit_id,
             plan.unit_index(),
             destination,
-            target,
+            prepared_target,
             draws,
         )?;
         movement.events.append(&mut combat.events);
         combat.events = movement.events;
         return Ok(combat);
     }
-    execute_stationary_attack(state, player, unit_id, ai, origin, target, draws)
+    let actor_team = state
+        .find_player(player)
+        .map(|candidate| &candidate.team)
+        .ok_or_else(|| ExecuteError::InvalidState("active player is absent".into()))?;
+    let prepared_target = match target {
+        AttackTarget::Unit { unit } => {
+            PreparedAttackTarget::Unit(disclose_unit_target(state, player, actor_team, unit)?)
+        }
+        AttackTarget::Tile { position } => PreparedAttackTarget::Tile(position),
+    };
+    execute_stationary_attack(state, player, unit_id, ai, origin, prepared_target, draws)
+}
+
+/// A unit target that is visible to the acting team in the command input state.
+///
+/// Movement can change visibility. It cannot change which enemy identifier the
+/// player can submit. Carry this result into the movement state. Combat can
+/// then use the resolved destination without a second visibility decision.
+#[derive(Clone, Copy)]
+struct DisclosedUnitTarget(UnitId);
+
+enum PreparedAttackTarget {
+    Unit(DisclosedUnitTarget),
+    Tile(Pos),
+}
+
+fn disclose_unit_target(
+    state: &State,
+    player: &PlayerId,
+    actor_team: &crate::semantic::TeamId,
+    target_id: UnitId,
+) -> Result<DisclosedUnitTarget, ExecuteError> {
+    let invalid = || {
+        violation(Violation::InvalidTarget {
+            target: Some(target_id.into()),
+        })
+    };
+    let defender = state.units.get(target_id).ok_or_else(invalid)?;
+    if defender.owner == *player
+        || !matches!(defender.location, Location::Board { .. })
+        || !AwbwVisibility.view(state, actor_team).unit(defender)
+    {
+        return Err(invalid());
+    }
+    Ok(DisclosedUnitTarget(target_id))
 }
 
 /// Resolve an attack after movement validation has established the attacker.
@@ -722,17 +776,17 @@ fn execute_stationary_attack(
     unit_id: UnitId,
     ai: usize,
     origin: Pos,
-    target: AttackTarget,
+    target: PreparedAttackTarget,
     draws: &mut Draws<'_>,
 ) -> Result<Execution, ExecuteError> {
     let attacker = &state.units[ai];
-    let target_id = match target {
-        AttackTarget::Unit { unit } => unit,
-        AttackTarget::Tile { position } => {
+    let disclosed = match target {
+        PreparedAttackTarget::Unit(disclosed) => disclosed,
+        PreparedAttackTarget::Tile(position) => {
             return execute_tile_attack(state, player, unit_id, ai, attacker, origin, position);
         }
     };
-    let engagement = Engagement::open(state, player, ai, origin, target_id)?;
+    let engagement = Engagement::open(state, ai, origin, disclosed)?;
     if engagement.counter_comes_first() {
         resolve_counter_first(&engagement, draws)
     } else {
@@ -763,11 +817,11 @@ impl<'a> Engagement<'a> {
     /// Check the target and score the initiating strike.
     fn open(
         state: &'a State,
-        player: &PlayerId,
         attacker_index: usize,
         origin: Pos,
-        target_id: UnitId,
+        disclosed: DisclosedUnitTarget,
     ) -> Result<Self, ExecuteError> {
+        let target_id = disclosed.0;
         let invalid = || {
             violation(Violation::InvalidTarget {
                 target: Some(target_id.into()),
@@ -782,16 +836,6 @@ impl<'a> Engagement<'a> {
         else {
             return Err(invalid());
         };
-        if defender.owner == player {
-            return Err(invalid());
-        }
-        let actor_team = state
-            .find_player(player)
-            .map(|candidate| &candidate.team)
-            .ok_or_else(|| ExecuteError::InvalidState("active player is absent".into()))?;
-        if !AwbwVisibility.view(state, actor_team).unit(defender) {
-            return Err(invalid());
-        }
         let concealed_target_compatible = match (defender.concealment, defender.kind, attacker.kind)
         {
             (Concealment::Hidden, UnitKindId::Sub, UnitKindId::Sub | UnitKindId::Cruiser)
@@ -948,7 +992,12 @@ pub(crate) fn forecast_unit_attack(
     origin: Pos,
     target_id: UnitId,
 ) -> Result<Forecast, ExecuteError> {
-    let engagement = Engagement::open(state, player, attacker_index, origin, target_id)?;
+    let actor_team = state
+        .find_player(player)
+        .map(|candidate| &candidate.team)
+        .ok_or_else(|| ExecuteError::InvalidState("active player is absent".into()))?;
+    let disclosed = disclose_unit_target(state, player, actor_team, target_id)?;
+    let engagement = Engagement::open(state, attacker_index, origin, disclosed)?;
     let attacker = engagement.attacker.unit;
     let defender = engagement.defender.unit;
     let initial = &engagement.initial;

--- a/crates/awvm/tests/entropy.rs
+++ b/crates/awvm/tests/entropy.rs
@@ -165,30 +165,26 @@ fn an_out_of_domain_roll_is_rejected_like_a_malformed_tape() {
     }
 
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../spec/fixtures/combat/movement-direct-fog-capture.json");
+        .join("../../spec/fixtures/combat/neutral-infantry-counter.json");
     let case: Value =
         serde_json::from_str(&std::fs::read_to_string(root).expect("read fixture")).unwrap();
     let state: State = serde_json::from_value(case["initial_state"].clone()).unwrap();
 
-    let attack = case["steps"]
+    let (attack, honest) = case["steps"]
         .as_array()
         .unwrap()
         .iter()
         .find_map(|step| {
             let command: Command = serde_json::from_value(step["command"].clone()).ok()?;
-            matches!(command, Command::MoveAttack { .. }).then_some(command)
+            let random: Vec<RandomToken> = serde_json::from_value(step["random"].clone()).ok()?;
+            (matches!(command, Command::MoveAttack { .. }) && !random.is_empty())
+                .then_some((command, random))
         })
-        .expect("the fixture attacks");
+        .expect("the fixture has a random attack");
 
     // The same command against the fixture's own tape is accepted, so the only
     // difference is where the number came from. The fixture draws four luck
     // values, so `Cheat` is reached.
-    let honest: Vec<RandomToken> = case["steps"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .find_map(|step| serde_json::from_value(step["random"].clone()).ok())
-        .unwrap_or_default();
     assert!(matches!(
         execute(&state, attack.clone(), &honest),
         Ok(ExecuteOutcome::Accepted(_))

--- a/crates/awvm/tests/goldens/observations.txt
+++ b/crates/awvm/tests/goldens/observations.txt
@@ -12,8 +12,9 @@ f19ea69f3ed887da  obs=6 ev=22  capture/lab-last-owned-lab.json
 1bbb626dcd8e533d  obs=4 ev=8  combat/air-units-ignore-terrain-stars.json
 89a799f793990228  obs=4 ev=13  combat/carrier-loss-no-cargo-charge.json
 e2cc132dd92412a6  obs=4 ev=8  combat/lethal-capture-reset.json
-26fd763d8e637bec  obs=4 ev=12  combat/movement-direct-fog-capture.json
-5435e277f6bbe2c9  obs=4 ev=3  combat/movement-hidden-blocker.json
+1696656096f514ab  obs=4 ev=12  combat/movement-direct-visible-capture.json
+f48f42c9a1decade  obs=4 ev=3  combat/movement-hidden-blocker.json
+0564d5d05f3738ce  obs=4 ev=0  combat/movement-target-revealed-by-movement.json
 54b1692f890447d7  obs=4 ev=8  combat/movement-tile-target.json
 11300ff82b325cbf  obs=10 ev=0  combat/movement-validation.json
 5a06192cc516df2e  obs=8 ev=8  combat/neutral-infantry-counter.json

--- a/spec/fixtures/combat/movement-direct-visible-capture.json
+++ b/spec/fixtures/combat/movement-direct-visible-capture.json
@@ -1,9 +1,12 @@
 {
-  "id": "combat-movement-direct-fog-capture",
+  "id": "combat-movement-direct-visible-capture",
   "spec_version": "0.1.0",
   "ruleset": { "id": "awbw", "revision": "2026-07-10" },
   "feature": "combat-movement-v1",
-  "evidence": { "confidence": "documentation-only" },
+  "evidence": {
+    "confidence": "documentation-only",
+    "note": "The target on plain is present in the acting player's pre-command observation."
+  },
   "initial_state": {
     "ruleset": { "id": "awbw", "revision": "2026-07-10" },
     "settings": {
@@ -27,7 +30,7 @@
         [
           { "terrain": "city", "owner": "blue", "capture_points": 10 },
           { "terrain": "plain" },
-          { "terrain": "wood" }
+          { "terrain": "plain" }
         ]
       ]
     },
@@ -89,7 +92,7 @@
   },
   "steps": [
     {
-      "id": "move-reveal-and-attack",
+      "id": "attack-from-resolved-destination",
       "command": {
         "type": "move-attack",
         "player": "red",
@@ -115,7 +118,7 @@
               [
                 { "capture_points": 20, "owner": "blue", "terrain": "city" },
                 { "terrain": "plain" },
-                { "terrain": "wood" }
+                { "terrain": "plain" }
               ]
             ],
             "width": 3
@@ -175,7 +178,7 @@
               "ammo": 0,
               "concealment": "exposed",
               "fuel": 98,
-              "hp": 73,
+              "hp": 75,
               "id": 0,
               "kind": "infantry",
               "location": { "position": [1, 0], "type": "board" },
@@ -186,7 +189,7 @@
               "ammo": 0,
               "concealment": "exposed",
               "fuel": 99,
-              "hp": 56,
+              "hp": 51,
               "id": 1,
               "kind": "infantry",
               "location": { "position": [2, 0], "type": "board" },
@@ -214,13 +217,7 @@
             "type": "attack-resolved",
             "weapon": "unlimited"
           },
-          {
-            "from_hp": 100,
-            "reason": "combat",
-            "to_hp": 56,
-            "type": "unit-damaged",
-            "unit": 1
-          },
+          { "from_hp": 100, "reason": "combat", "to_hp": 51, "type": "unit-damaged", "unit": 1 },
           {
             "attacker": 1,
             "target": { "type": "unit", "unit": 0 },
@@ -230,7 +227,7 @@
           {
             "from_hp": 100,
             "reason": "combat-counter",
-            "to_hp": 73,
+            "to_hp": 75,
             "type": "unit-damaged",
             "unit": 0
           },

--- a/spec/fixtures/combat/movement-hidden-blocker.json
+++ b/spec/fixtures/combat/movement-hidden-blocker.json
@@ -29,7 +29,7 @@
           { "terrain": "plain" },
           { "terrain": "plain" },
           { "terrain": "plain" },
-          { "terrain": "plain" }
+          { "terrain": "city", "owner": "red", "capture_points": 20 }
         ]
       ]
     },
@@ -127,7 +127,7 @@
                 { "terrain": "plain" },
                 { "terrain": "plain" },
                 { "terrain": "plain" },
-                { "terrain": "plain" }
+                { "terrain": "city", "owner": "red", "capture_points": 20 }
               ]
             ],
             "width": 5

--- a/spec/fixtures/combat/movement-target-revealed-by-movement.json
+++ b/spec/fixtures/combat/movement-target-revealed-by-movement.json
@@ -1,0 +1,114 @@
+{
+  "id": "combat-movement-target-revealed-by-movement",
+  "spec_version": "0.1.0",
+  "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+  "feature": "combat-movement-v1",
+  "evidence": {
+    "confidence": "documentation-only",
+    "note": "The target in woods is absent from the acting player's pre-command observation."
+  },
+  "initial_state": {
+    "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+    "settings": {
+      "fog": true,
+      "income_per_property": 1000,
+      "starting_funds": 0,
+      "powers": "disabled",
+      "tags": false,
+      "weather": "clear",
+      "lab_units": [],
+      "unit_bans": [],
+      "commander_bans": { "lead": [], "backup": [] },
+      "capture_limit": null,
+      "day_limit": null,
+      "unit_limit": null
+    },
+    "board": {
+      "width": 3,
+      "height": 1,
+      "tiles": [
+        [
+          { "terrain": "city", "owner": "blue", "capture_points": 10 },
+          { "terrain": "plain" },
+          { "terrain": "wood" }
+        ]
+      ]
+    },
+    "teams": [
+      { "id": "red-team", "status": "active" },
+      { "id": "blue-team", "status": "active" }
+    ],
+    "players": [
+      {
+        "id": "red",
+        "team": "red-team",
+        "funds": 0,
+        "status": "active",
+        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "power_state": { "type": "none" }
+      },
+      {
+        "id": "blue",
+        "team": "blue-team",
+        "funds": 0,
+        "status": "active",
+        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "power_state": { "type": "none" }
+      }
+    ],
+    "turn": {
+      "day": 1,
+      "active_player": "red",
+      "phase": "unit-action",
+      "order": ["red", "blue"],
+      "position": 0
+    },
+    "weather": { "kind": "clear", "remaining_turns": 0 },
+    "units": [
+      {
+        "id": 0,
+        "kind": "infantry",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [0, 0] }
+      },
+      {
+        "id": 1,
+        "kind": "infantry",
+        "owner": "blue",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [2, 0] }
+      }
+    ],
+    "match": { "status": "active", "draw_offers": [] }
+  },
+  "steps": [
+    {
+      "id": "reject-target-revealed-only-by-movement",
+      "command": {
+        "type": "move-attack",
+        "player": "red",
+        "unit": 0,
+        "path": [
+          [0, 0],
+          [1, 0]
+        ],
+        "target": { "type": "unit", "unit": 1 }
+      },
+      "random": [],
+      "expect": {
+        "status": "rejected",
+        "violation": { "code": "INVALID_TARGET", "target": 1 },
+        "random_consumed": 0
+      }
+    }
+  ]
+}

--- a/spec/model/commands.md
+++ b/spec/model/commands.md
@@ -42,6 +42,12 @@ destructible tile state such as an AWBW pipe seam. The attack specification must
 also require any positional relationship needed at validation/execution time.
 Cargo units cannot be targeted merely because their IDs exist.
 
+The numeric enemy `UnitId` is an internal canonical reference. Recipient
+observations do not expose it. A client-facing adapter resolves a visible
+position-scoped enemy reference before it constructs the command. For an atomic
+`move-attack`, that resolution uses the pre-command observation. Movement in the
+command cannot supply a new enemy reference for the same command.
+
 `move-load.transport` and `move-join.target` are stable numeric `UnitId`s. Their final
 path position is validated against the referenced unit's board position.
 

--- a/spec/semantics/capture.md
+++ b/spec/semantics/capture.md
@@ -90,6 +90,9 @@ DESTINATION_OCCUPIED
   `capturable` property, or when its `owner` is the acting player or any player
   on the acting player's team. A friendly or already-owned property cannot be
   captured.
+- Capture eligibility does not require `visible-position` at the destination.
+  Terrain is map data, and `move-capture` names no enemy unit identifier. A unit
+  can move onto and capture a property that was fogged before the command.
 - `DESTINATION_OCCUPIED` is still evaluated last, because a capturable
   destination may be blocked by another unit; capture does not license an
   occupied destination.

--- a/spec/semantics/combat.md
+++ b/spec/semantics/combat.md
@@ -97,12 +97,17 @@ nothing, and the existing fixtures leave fog disabled.
 ## Fog-sensitive unit targeting
 
 Feature `combat-visibility-v1` validates a unit target against the acting
-player's team and the authoritative state before combat randomness is consumed.
-The target MUST satisfy `visible-unit(R,S,team(player),target)` from
-`semantics/fog.md`. With map fog disabled this admits every exposed on-board
-unit, while a submerged Sub or hidden Stealth still requires concealment
-detection. An unseen target is rejected as `INVALID_TARGET`, using the same
-violation class as an absent or otherwise invalid unit target.
+player's team and the command's authoritative input state `S` before combat
+randomness is consumed. The target MUST satisfy
+`visible-unit(R,S,team(player),target)` from `semantics/fog.md`. This is a
+pre-command knowledge check. Movement in the same `move-attack` command MUST
+NOT make an undisclosed enemy unit eligible as that command's target. An unseen
+target is rejected as `INVALID_TARGET`, using the same violation class as an
+absent or otherwise invalid unit target.
+
+With map fog disabled, the rule admits every exposed on-board unit. A submerged
+Sub or hidden Stealth still requires concealment detection. A one-position
+attack uses the same rule; its input state and attack state are identical.
 
 Visibility and attack compatibility are distinct. Any adjacent friendly unit
 can detect a voluntarily concealed unit, but a detected submerged Sub can be
@@ -110,10 +115,18 @@ attacked only by a Sub or Cruiser, and a detected hidden Stealth can be attacked
 only by a Fighter or Stealth. These compatibility restrictions continue to
 apply to a unit whose `concealment` is `hidden` when fog is disabled.
 
-The current reducer supports only the stationary path `[origin]`, so
-pre-command and post-movement visibility are identical. A future combat-movement
-increment MUST evaluate the target after resolving the movement path and hidden
-occupancy, without allowing a target identifier to reveal an unseen unit.
+For a moving direct attack, preparation records that the target passed this
+check in `S`. Execution then resolves the shared movement prefix. A hidden
+blocker can truncate movement and suppress the attack. If movement reaches its
+intended destination, attack range, weapon selection, commander effects,
+terrain defense, and counter geometry use the resolved destination and the
+resulting movement state. Execution MUST carry the preparation result into
+that state and MUST NOT repeat target visibility there.
+
+Attack-target queries and forecasts MUST apply the same pre-command disclosure
+rule. They MUST NOT offer or forecast a unit that the proposed movement would
+reveal. This rule applies to unit identifiers only. Tile-target visibility is
+the separate rule in the next section.
 
 ## Destructible tile targets
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Move-attack commands now safely handle enemy units hidden by fog of war.
  - Hidden enemy units cannot be selected unless they were visible before the command.
  - Units can capture properties concealed by fog when movement reaches them.
  - Attack targets remain consistent through movement, including cases where hidden blockers interrupt movement.
- **Bug Fixes**
  - Target queries and combat forecasts no longer reveal or select units exposed only by planned movement.
  - Invalid hidden-target attacks are rejected before combat randomness is consumed.
- **Documentation**
  - Clarified fog-of-war targeting and hidden-property capture behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->