### PR TITLE
Reject allied units as attack targets

### DIFF
--- a/crates/awvm/src/transition/attack.rs
+++ b/crates/awvm/src/transition/attack.rs
@@ -671,12 +671,9 @@ pub(crate) fn execute_move_attack(
         }
 
         let prepared_target = match target {
-            AttackTarget::Unit { unit } => PreparedAttackTarget::Unit(disclose_unit_target(
-                state,
-                player,
-                plan.actor_team(),
-                unit,
-            )?),
+            AttackTarget::Unit { unit } => {
+                PreparedAttackTarget::Unit(disclose_unit_target(state, plan.actor_team(), unit)?)
+            }
             AttackTarget::Tile { position } => PreparedAttackTarget::Tile(position),
         };
 
@@ -724,7 +721,7 @@ pub(crate) fn execute_move_attack(
         .ok_or_else(|| ExecuteError::InvalidState("active player is absent".into()))?;
     let prepared_target = match target {
         AttackTarget::Unit { unit } => {
-            PreparedAttackTarget::Unit(disclose_unit_target(state, player, actor_team, unit)?)
+            PreparedAttackTarget::Unit(disclose_unit_target(state, actor_team, unit)?)
         }
         AttackTarget::Tile { position } => PreparedAttackTarget::Tile(position),
     };
@@ -746,7 +743,6 @@ enum PreparedAttackTarget {
 
 fn disclose_unit_target(
     state: &State,
-    player: &PlayerId,
     actor_team: &crate::semantic::TeamId,
     target_id: UnitId,
 ) -> Result<DisclosedUnitTarget, ExecuteError> {
@@ -756,7 +752,11 @@ fn disclose_unit_target(
         })
     };
     let defender = state.units.get(target_id).ok_or_else(invalid)?;
-    if defender.owner == *player
+    let defender_team = state
+        .find_player(&defender.owner)
+        .map(|candidate| &candidate.team)
+        .ok_or_else(|| ExecuteError::InvalidState("target owner is absent".into()))?;
+    if defender_team == actor_team
         || !matches!(defender.location, Location::Board { .. })
         || !AwbwVisibility.view(state, actor_team).unit(defender)
     {
@@ -996,7 +996,7 @@ pub(crate) fn forecast_unit_attack(
         .find_player(player)
         .map(|candidate| &candidate.team)
         .ok_or_else(|| ExecuteError::InvalidState("active player is absent".into()))?;
-    let disclosed = disclose_unit_target(state, player, actor_team, target_id)?;
+    let disclosed = disclose_unit_target(state, actor_team, target_id)?;
     let engagement = Engagement::open(state, attacker_index, origin, disclosed)?;
     let attacker = engagement.attacker.unit;
     let defender = engagement.defender.unit;

--- a/crates/awvm/tests/goldens/observations.txt
+++ b/crates/awvm/tests/goldens/observations.txt
@@ -10,6 +10,7 @@ cbb7dcc2f8b4bf3c  obs=2 ev=2  capture/capture-city-partial.json
 d17abb0f2b37014d  obs=4 ev=8  capture/lab-ignored-with-hq.json
 f19ea69f3ed887da  obs=6 ev=22  capture/lab-last-owned-lab.json
 1bbb626dcd8e533d  obs=4 ev=8  combat/air-units-ignore-terrain-stars.json
+cdc2af0355b95356  obs=9 ev=0  combat/allied-unit-targets-rejected.json
 89a799f793990228  obs=4 ev=13  combat/carrier-loss-no-cargo-charge.json
 e2cc132dd92412a6  obs=4 ev=8  combat/lethal-capture-reset.json
 1696656096f514ab  obs=4 ev=12  combat/movement-direct-visible-capture.json

--- a/crates/awvm/tests/query.rs
+++ b/crates/awvm/tests/query.rs
@@ -339,6 +339,43 @@ fn observed_production_options_include_hachi_scop_city_metadata() {
     );
 }
 
+#[test]
+fn allied_units_are_not_attack_targets_or_forecasts() {
+    let case: Value = serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../spec/fixtures/combat/allied-unit-targets-rejected.json"
+    )))
+    .unwrap();
+    let state: State = serde_json::from_value(case["initial_state"].clone()).unwrap();
+
+    for (attacker, from, ally, ally_position) in [
+        (
+            UnitId::new(0),
+            Pos::new(0, 0),
+            UnitId::new(1),
+            Pos::new(1, 0),
+        ),
+        (
+            UnitId::new(2),
+            Pos::new(1, 1),
+            UnitId::new(3),
+            Pos::new(2, 1),
+        ),
+    ] {
+        assert!(
+            !query::attack_targets(&state, attacker, from)
+                .unwrap()
+                .contains(&AttackTarget::Unit { unit: ally })
+        );
+
+        let observation = observe(&AwbwVisibility, &state, &PlayerId::from("red")).unwrap();
+        assert_eq!(
+            query::observed_forecasts(&observation, attacker, from, &[ally_position]).unwrap(),
+            vec![None]
+        );
+    }
+}
+
 /// Assert that `command`, which the reducer accepted, is one `query` offers.
 ///
 /// Returns the family checked, or `None` for the commands that are not tied to

--- a/spec/fixtures/combat/allied-unit-targets-rejected.json
+++ b/spec/fixtures/combat/allied-unit-targets-rejected.json
@@ -1,0 +1,178 @@
+{
+  "id": "combat-allied-unit-targets-rejected",
+  "spec_version": "0.1.0",
+  "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+  "feature": "combat-neutral-v1",
+  "evidence": {
+    "confidence": "corroborated-implementation",
+    "note": "WarsWorld excludes same-team units from attack targets and rejects them in its attack handler."
+  },
+  "initial_state": {
+    "ruleset": { "id": "awbw", "revision": "2026-07-10" },
+    "settings": {
+      "fog": false,
+      "income_per_property": 1000,
+      "starting_funds": 0,
+      "powers": "disabled",
+      "tags": false,
+      "weather": "clear",
+      "lab_units": [],
+      "unit_bans": [],
+      "commander_bans": { "lead": [], "backup": [] },
+      "capture_limit": null,
+      "day_limit": null,
+      "unit_limit": null
+    },
+    "board": {
+      "width": 4,
+      "height": 2,
+      "tiles": [
+        [
+          { "terrain": "plain" },
+          { "terrain": "plain" },
+          { "terrain": "plain" },
+          { "terrain": "plain" }
+        ],
+        [
+          { "terrain": "plain" },
+          { "terrain": "plain" },
+          { "terrain": "plain" },
+          { "terrain": "plain" }
+        ]
+      ]
+    },
+    "teams": [
+      { "id": "red-team", "status": "active" },
+      { "id": "blue-team", "status": "active" }
+    ],
+    "players": [
+      {
+        "id": "red",
+        "team": "red-team",
+        "funds": 0,
+        "status": "active",
+        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "power_state": { "type": "none" }
+      },
+      {
+        "id": "green",
+        "team": "red-team",
+        "funds": 0,
+        "status": "active",
+        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "power_state": { "type": "none" }
+      },
+      {
+        "id": "blue",
+        "team": "blue-team",
+        "funds": 0,
+        "status": "active",
+        "commanders": [{ "id": "neutral", "active": true, "power_charge": 0, "power_uses": 0 }],
+        "power_state": { "type": "none" }
+      }
+    ],
+    "turn": {
+      "day": 1,
+      "active_player": "red",
+      "phase": "unit-action",
+      "order": ["red", "green", "blue"],
+      "position": 0
+    },
+    "weather": { "kind": "clear", "remaining_turns": 0 },
+    "units": [
+      {
+        "id": 0,
+        "kind": "infantry",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [0, 0] }
+      },
+      {
+        "id": 1,
+        "kind": "infantry",
+        "owner": "green",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [1, 0] }
+      },
+      {
+        "id": 2,
+        "kind": "infantry",
+        "owner": "red",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [0, 1] }
+      },
+      {
+        "id": 3,
+        "kind": "infantry",
+        "owner": "green",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [2, 1] }
+      },
+      {
+        "id": 4,
+        "kind": "infantry",
+        "owner": "blue",
+        "hp": 100,
+        "fuel": 99,
+        "ammo": 0,
+        "action": "ready",
+        "concealment": "exposed",
+        "location": { "type": "board", "position": [3, 0] }
+      }
+    ],
+    "match": { "status": "active", "draw_offers": [] }
+  },
+  "steps": [
+    {
+      "id": "reject-allied-stationary-attack",
+      "command": {
+        "type": "move-attack",
+        "player": "red",
+        "unit": 0,
+        "path": [[0, 0]],
+        "target": { "type": "unit", "unit": 1 }
+      },
+      "random": [],
+      "expect": {
+        "status": "rejected",
+        "violation": { "code": "INVALID_TARGET", "target": 1 },
+        "random_consumed": 0
+      }
+    },
+    {
+      "id": "reject-allied-move-attack",
+      "command": {
+        "type": "move-attack",
+        "player": "red",
+        "unit": 2,
+        "path": [
+          [0, 1],
+          [1, 1]
+        ],
+        "target": { "type": "unit", "unit": 3 }
+      },
+      "random": [],
+      "expect": {
+        "status": "rejected",
+        "violation": { "code": "INVALID_TARGET", "target": 3 },
+        "random_consumed": 0
+      }
+    }
+  ]
+}

--- a/spec/semantics/combat.md
+++ b/spec/semantics/combat.md
@@ -7,6 +7,11 @@ projection, and elimination remain outside this feature.
 
 ## Weapon and command eligibility
 
+The target of a unit attack MUST be an enemy unit: its owner's team MUST differ
+from the acting player's team. An own or allied unit target is rejected as
+`INVALID_TARGET`. This check applies before weapon selection or combat
+randomness and is shared by stationary and moving attacks.
+
 Resolve Manhattan distance after movement. A direct weapon has range 1. An
 indirect weapon uses the unit's minimum and maximum range and the attacker MUST
 not have moved in the command. Selection tries the ammo matrix when ammo is
@@ -201,6 +206,14 @@ These authoritative facts and exact charge are global information under
 `model/observation.md`.
 
 ## Evidence
+
+Enemy-only unit targeting is `corroborated-implementation` from WarsWorld. Its
+target-list path includes a unit only when the target and attacker teams differ,
+and its authoritative attack handler independently rejects a defender on the
+acting player's team. AWBW Replay Player consumes completed replay actions and
+does not expose command eligibility, so it supplies no independent evidence for
+this rule. A controlled AWBW experiment is still required for a higher evidence
+rank.
 
 The weapon selection and base damage are backed by `weapons.json`. The formula,
 visual HP use, counter post-damage HP, and demand-driven counter are


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unit attacks now reject allied and own units as invalid targets.
  * Invalid allied-target attacks no longer consume randomness.
  * Target validation is consistent for stationary and movement-based attacks.

* **Tests**
  * Added regression coverage confirming allied units are excluded from attack targets and forecasts.
  * Added combat scenarios and observation records for rejected allied-unit attacks.

* **Documentation**
  * Updated combat rules to clarify that attacks require opposing-team targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->