### PR TITLE
Add benchmarks for clientless play

### DIFF
--- a/crates/bench/src/benchmarks.rs
+++ b/crates/bench/src/benchmarks.rs
@@ -1,3 +1,4 @@
+pub mod ai;
 pub mod awvm;
 pub mod replay;
 pub mod server;

--- a/crates/bench/src/benchmarks/ai.rs
+++ b/crates/bench/src/benchmarks/ai.rs
@@ -1,0 +1,679 @@
+//! AWVM command and turn-enumeration costs at the scale of a real match.
+//!
+//! Small specification fixtures hide the state clone that each accepted
+//! command creates. The command cases use 20x20 boards with a full deployment
+//! so the clone has the size that an opponent search pays for each node.
+//!
+//! Turn enumeration is separate because a policy asks for every legal action
+//! before it chooses one. Movement actions use read-only preparation. The
+//! authoritative and observed cases show the remaining cost of enumerating a
+//! complete turn and the extra work that a fog-safe policy needs.
+//!
+//! The cycle cases keep execute, observation, reification, and action
+//! enumeration separate. This identifies the stage that controls the cost of
+//! one search node. Fog-on and fog-off cases use the same board and command.
+
+use ::awvm::query;
+use ::awvm::ruleset::UnitKind;
+use ::awvm::semantic::{
+    AwbwVisibility, Location, Observation, ObservedUnitRef, Pos, State, UnitAction, UnitId, observe,
+};
+use ::awvm::transition::{
+    ActiveTurn, Command, ExecuteOutcome, PreparedMovement, execute, prepare_command,
+    prepare_movement,
+};
+
+use super::{awvm, server};
+
+const WIDTH: u8 = 20;
+const HEIGHT: u8 = 20;
+const UNITS: usize = 30;
+
+/// One accepted command and its input state.
+pub struct CommandCase {
+    pub state: State,
+    pub command: Command,
+}
+
+pub fn projected_move() -> CommandCase {
+    let source = awvm::CASES[0].1;
+    let projected = awvm::project(source, WIDTH, HEIGHT, UNITS);
+    let case = awvm::load(source);
+    CommandCase {
+        state: projected.state,
+        command: serde_json::from_value(case.command).expect("decode command"),
+    }
+}
+
+pub fn server_move() -> CommandCase {
+    let state = server::state(server::DUEL, false);
+    CommandCase {
+        command: Command::MoveWait {
+            player: state.turn.active_player.clone(),
+            unit: UnitId::new(1),
+            path: vec![Pos::new(0, 3), Pos::new(0, 4), Pos::new(0, 5)],
+        },
+        state,
+    }
+}
+
+pub fn server_produce() -> CommandCase {
+    let state = server::state(server::DUEL, false);
+    CommandCase {
+        command: Command::ProduceUnit {
+            player: state.turn.active_player.clone(),
+            position: Pos::new(2, 0),
+            kind: UnitKind::Infantry,
+        },
+        state,
+    }
+}
+
+pub fn server_capture() -> CommandCase {
+    let mut state = server::state(server::DUEL, false);
+    let unit = state.units.get_mut(UnitId::new(1)).expect("mover exists");
+    let profile = ::awvm::ruleset::profile(UnitKind::Infantry);
+    unit.kind = UnitKind::Infantry;
+    unit.fuel = profile.max_fuel;
+    unit.ammo = profile.max_ammo;
+    unit.location = Location::Board {
+        position: Pos::new(3, 9),
+    };
+    CommandCase {
+        command: Command::MoveCapture {
+            player: state.turn.active_player.clone(),
+            unit: UnitId::new(1),
+            path: vec![Pos::new(3, 9), Pos::new(3, 10)],
+        },
+        state,
+    }
+}
+
+pub fn run_command(case: &CommandCase) -> usize {
+    match execute(&case.state, case.command.clone(), &[]) {
+        Ok(ExecuteOutcome::Accepted(execution)) => execution.events.len(),
+        Ok(ExecuteOutcome::Rejected(violation)) => {
+            panic!("benchmark command was rejected: {violation:?}")
+        }
+        Err(error) => panic!("benchmark command did not execute: {error:?}"),
+    }
+}
+
+fn execute_state(case: &CommandCase) -> State {
+    match execute(&case.state, case.command.clone(), &[]) {
+        Ok(ExecuteOutcome::Accepted(execution)) => execution.state,
+        Ok(ExecuteOutcome::Rejected(violation)) => {
+            panic!("benchmark command was rejected: {violation:?}")
+        }
+        Err(error) => panic!("benchmark command did not execute: {error:?}"),
+    }
+}
+
+pub fn run_prepare(case: &CommandCase) -> usize {
+    match prepare_command(&case.state, case.command.clone()) {
+        Ok(Ok(prepared)) => {
+            std::hint::black_box(prepared);
+            1
+        }
+        Ok(Err(violation)) => panic!("benchmark command was rejected: {violation:?}"),
+        Err(error) => panic!("benchmark command was not prepared: {error:?}"),
+    }
+}
+
+pub fn prepared_movement(case: &CommandCase) -> PreparedMovement<'_> {
+    let (player, unit, path) = match &case.command {
+        Command::MoveWait { player, unit, path } | Command::MoveCapture { player, unit, path } => {
+            (player, *unit, path.clone())
+        }
+        command => panic!("benchmark command has no prepared movement: {command:?}"),
+    };
+    match prepare_movement(&case.state, player, unit, path) {
+        Ok(Ok(movement)) => movement,
+        Ok(Err(violation)) => panic!("benchmark movement was rejected: {violation:?}"),
+        Err(error) => panic!("benchmark movement was not prepared: {error:?}"),
+    }
+}
+
+pub fn run_prepare_movement(case: &CommandCase) -> usize {
+    std::hint::black_box(prepared_movement(case));
+    1
+}
+
+/// A stable result from one complete pass through a turn's action space.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Enumeration {
+    pub destinations: usize,
+    pub actions: usize,
+}
+
+fn count_actions(actions: &query::ActionSet) -> usize {
+    [
+        actions.wait,
+        actions.capture,
+        actions.join,
+        actions.load,
+        actions.supply,
+        actions.hide,
+        actions.reveal,
+        actions.explode,
+    ]
+    .into_iter()
+    .filter(|available| *available)
+    .count()
+        + actions.attack.len()
+        + actions.repair.len()
+        + actions.launch.len()
+}
+
+fn count_observed_actions(actions: &query::ObservedActionSet) -> usize {
+    [
+        actions.wait,
+        actions.capture,
+        actions.join,
+        actions.load,
+        actions.supply,
+        actions.hide,
+        actions.reveal,
+        actions.explode,
+    ]
+    .into_iter()
+    .filter(|available| *available)
+    .count()
+        + actions.attack.len()
+        + actions.repair.len()
+        + actions.launch.len()
+}
+
+fn production_sites() -> [Pos; 3] {
+    [Pos::new(2, 0), Pos::new(7, 0), Pos::new(12, 0)]
+}
+
+pub fn enumerate_state(state: &State) -> Enumeration {
+    let player = &state.turn.active_player;
+    let seat = state.player_index(player);
+    let mut result = Enumeration {
+        destinations: 0,
+        actions: 0,
+    };
+    let turn = ActiveTurn::open(state, player)
+        .expect("benchmark state can open a turn")
+        .unwrap_or_else(|violation| panic!("benchmark turn was rejected: {violation:?}"));
+    for unit in state
+        .units
+        .iter()
+        .filter(|unit| Some(unit.owner) == seat && unit.action == UnitAction::Ready)
+    {
+        let field = turn
+            .move_field(unit.id)
+            .expect("benchmark unit can be checked")
+            .expect("benchmark unit has a prepared movement field");
+        for (destination, _) in field.reach() {
+            result.destinations += 1;
+            result.actions += count_actions(
+                &field
+                    .actions_at(destination)
+                    .expect("benchmark destination can be queried"),
+            );
+        }
+    }
+    result.actions += production_sites()
+        .into_iter()
+        .map(|position| query::production_options(state, player, position).len())
+        .sum::<usize>();
+    result
+}
+
+pub fn enumerate_reachable(state: &State) -> usize {
+    let seat = state.player_index(&state.turn.active_player);
+    state
+        .units
+        .iter()
+        .filter(|unit| Some(unit.owner) == seat && unit.action == UnitAction::Ready)
+        .map(|unit| {
+            query::reachable(state, unit.id)
+                .expect("benchmark unit is on the board")
+                .reach()
+                .count()
+        })
+        .sum()
+}
+
+pub fn enumerate_production(state: &State) -> usize {
+    let player = &state.turn.active_player;
+    production_sites()
+        .into_iter()
+        .map(|position| query::production_options(state, player, position).len())
+        .sum()
+}
+
+pub fn observation(state: &State) -> Observation {
+    observe(&AwbwVisibility, state, &state.turn.active_player).expect("observe benchmark state")
+}
+
+/// Inputs and intermediate values for one execute-to-enumeration cycle.
+pub struct CycleCase {
+    command: CommandCase,
+    post_state: State,
+    observation: Observation,
+    query: query::ObservedQuery,
+}
+
+pub fn cycle_case(fog: bool) -> CycleCase {
+    let state = server::state(server::DUEL, fog);
+    let command = CommandCase {
+        command: Command::MoveWait {
+            player: state.turn.active_player.clone(),
+            unit: UnitId::new(1),
+            path: vec![Pos::new(0, 3), Pos::new(0, 4), Pos::new(0, 5)],
+        },
+        state,
+    };
+    let post_state = execute_state(&command);
+    let observation = observation(&post_state);
+    let query = query::ObservedQuery::new(&observation).expect("reify benchmark observation");
+    CycleCase {
+        command,
+        post_state,
+        observation,
+        query,
+    }
+}
+
+pub fn run_observe(state: &State) -> usize {
+    observation(state).units.len()
+}
+
+pub fn run_reify(observation: &Observation) -> usize {
+    query::reify(observation)
+        .expect("reify benchmark observation")
+        .units
+        .len()
+}
+
+pub fn run_cycle(case: &CycleCase) -> Enumeration {
+    let state = execute_state(&case.command);
+    let observation = observation(&state);
+    enumerate_observation(&observation)
+}
+
+pub fn enumerate_observation(observation: &Observation) -> Enumeration {
+    let query = query::ObservedQuery::new(observation).expect("reify benchmark observation");
+    enumerate_observed_query(observation, &query)
+}
+
+fn enumerate_observed_query(
+    observation: &Observation,
+    query: &query::ObservedQuery,
+) -> Enumeration {
+    let mut result = Enumeration {
+        destinations: 0,
+        actions: 0,
+    };
+    let turn = query
+        .turn()
+        .expect("observed benchmark state can open a turn")
+        .expect("observed benchmark recipient may command");
+    for unit in observation.units.iter().filter_map(|unit| {
+        if unit.owner == observation.recipient && unit.action == UnitAction::Ready {
+            match unit.reference {
+                ObservedUnitRef::Friendly { unit } => Some(unit),
+                ObservedUnitRef::Enemy { .. } => None,
+            }
+        } else {
+            None
+        }
+    }) {
+        let field = turn
+            .move_field(unit)
+            .expect("observed benchmark unit can be queried")
+            .expect("observed benchmark unit can act");
+        for (destination, _) in field.reach() {
+            result.destinations += 1;
+            result.actions += count_observed_actions(
+                &field
+                    .observed_actions_at(destination)
+                    .expect("observed benchmark destination can be queried"),
+            );
+        }
+    }
+    result.actions += production_sites()
+        .into_iter()
+        .map(|position| {
+            query::observed_production_options(observation, position)
+                .into_iter()
+                .filter(|option| option.affordable)
+                .count()
+        })
+        .sum::<usize>();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_cases_are_accepted() {
+        for case in [
+            projected_move(),
+            server_move(),
+            server_capture(),
+            server_produce(),
+        ] {
+            assert!(run_command(&case) > 0, "command produced no events");
+        }
+    }
+
+    #[test]
+    fn move_wait_case_can_be_prepared() {
+        assert_eq!(run_prepare(&server_move()), 1);
+        assert_eq!(run_prepare_movement(&server_move()), 1);
+    }
+
+    #[test]
+    fn move_capture_case_can_be_prepared() {
+        assert_eq!(run_prepare(&server_capture()), 1);
+        assert_eq!(run_prepare_movement(&server_capture()), 1);
+    }
+
+    #[test]
+    fn production_case_can_be_prepared() {
+        assert_eq!(run_prepare(&server_produce()), 1);
+    }
+
+    #[test]
+    fn both_query_families_find_actions() {
+        let state = server::state(server::DUEL, false);
+        let authoritative = enumerate_state(&state);
+        let observed = enumerate_observation(&observation(&state));
+        assert!(authoritative.destinations > 0);
+        assert!(authoritative.actions > 0);
+        assert_eq!(observed, authoritative);
+    }
+
+    #[test]
+    fn complete_cycles_match_the_isolated_enumeration() {
+        for fog in [false, true] {
+            let case = cycle_case(fog);
+            let isolated = enumerate_observed_query(&case.observation, &case.query);
+            assert!(isolated.actions > 0);
+            assert_eq!(run_cycle(&case), isolated);
+        }
+    }
+}
+
+pub mod criterion_benches {
+    use super::*;
+    use criterion::{BatchSize, BenchmarkId, Criterion};
+    use std::hint::black_box;
+
+    fn commands(c: &mut Criterion) {
+        let mut group = c.benchmark_group("ai-execute");
+        for (name, case) in [
+            ("move-projected-20x20-30units", projected_move()),
+            ("move-server-20x20-40units", server_move()),
+            ("produce-server-20x20-40units", server_produce()),
+        ] {
+            group.bench_function(BenchmarkId::from_parameter(name), |b| {
+                b.iter(|| black_box(run_command(&case)));
+            });
+        }
+        group.finish();
+    }
+
+    fn enumerate(c: &mut Criterion) {
+        let state = server::state(server::DUEL, false);
+        let view = observation(&state);
+        let mut group = c.benchmark_group("ai-enumerate-turn");
+        group.bench_function("state-server-20x20-40units", |b| {
+            b.iter(|| black_box(enumerate_state(&state)));
+        });
+        group.bench_function("observed-server-20x20-40units", |b| {
+            b.iter(|| black_box(enumerate_observation(&view)));
+        });
+        group.finish();
+
+        let mut group = c.benchmark_group("ai-reachable-turn");
+        group.bench_function("state-server-20x20-40units", |b| {
+            b.iter(|| black_box(enumerate_reachable(&state)));
+        });
+        group.finish();
+    }
+
+    fn prepare(c: &mut Criterion) {
+        let wait = server_move();
+        let capture = server_capture();
+        let produce = server_produce();
+        let mut group = c.benchmark_group("ai-prepare");
+        group.bench_function("movement-wait-server-20x20-40units", |b| {
+            b.iter(|| black_box(run_prepare_movement(&wait)));
+        });
+        group.bench_function("command-wait-server-20x20-40units", |b| {
+            b.iter(|| black_box(run_prepare(&wait)));
+        });
+        group.bench_function("movement-capture-server-20x20-40units", |b| {
+            b.iter(|| black_box(run_prepare_movement(&capture)));
+        });
+        group.bench_function("command-capture-server-20x20-40units", |b| {
+            b.iter(|| black_box(run_prepare(&capture)));
+        });
+        group.bench_function("command-produce-server-20x20-40units", |b| {
+            b.iter(|| black_box(run_prepare(&produce)));
+        });
+        group.finish();
+
+        let state = server::state(server::DUEL, false);
+        let mut group = c.benchmark_group("ai-enumerate-production");
+        group.bench_function("state-server-20x20-40units", |b| {
+            b.iter(|| black_box(enumerate_production(&state)));
+        });
+        group.finish();
+
+        let wait_movement = prepared_movement(&wait);
+        let capture_movement = prepared_movement(&capture);
+        let mut group = c.benchmark_group("ai-prepare-action");
+        group.bench_function("wait-from-movement", |b| {
+            b.iter_batched(
+                || wait_movement.clone(),
+                |movement| black_box(movement.prepare_wait().expect("prepare wait")),
+                BatchSize::SmallInput,
+            );
+        });
+        group.bench_function("capture-from-movement", |b| {
+            b.iter_batched(
+                || capture_movement.clone(),
+                |movement| black_box(movement.prepare_capture().expect("prepare capture")),
+                BatchSize::SmallInput,
+            );
+        });
+        group.finish();
+    }
+
+    fn cycle(c: &mut Criterion) {
+        let cases = [("fog-off", cycle_case(false)), ("fog-on", cycle_case(true))];
+
+        let mut group = c.benchmark_group("ai-cycle-execute");
+        for (name, case) in &cases {
+            group.bench_function(*name, |b| {
+                b.iter(|| black_box(run_command(&case.command)));
+            });
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group("ai-cycle-observe");
+        for (name, case) in &cases {
+            group.bench_function(*name, |b| {
+                b.iter(|| black_box(run_observe(&case.post_state)));
+            });
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group("ai-cycle-reify");
+        for (name, case) in &cases {
+            group.bench_function(*name, |b| {
+                b.iter(|| black_box(run_reify(&case.observation)));
+            });
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group("ai-cycle-enumerate");
+        for (name, case) in &cases {
+            group.bench_function(*name, |b| {
+                b.iter(|| black_box(enumerate_observed_query(&case.observation, &case.query)));
+            });
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group("ai-cycle-complete");
+        for (name, case) in &cases {
+            group.bench_function(*name, |b| {
+                b.iter(|| black_box(run_cycle(case)));
+            });
+        }
+        group.finish();
+    }
+
+    criterion::criterion_group!(ai_benches, commands, enumerate, prepare, cycle);
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub mod gungraun_benches {
+    use super::*;
+    use gungraun::{library_benchmark, library_benchmark_group};
+
+    #[derive(Clone, Copy)]
+    enum CommandFixture {
+        ProjectedMove,
+        ServerMove,
+        ServerCapture,
+        ServerProduce,
+    }
+
+    fn command_case(fixture: CommandFixture) -> CommandCase {
+        match fixture {
+            CommandFixture::ProjectedMove => projected_move(),
+            CommandFixture::ServerMove => server_move(),
+            CommandFixture::ServerCapture => server_capture(),
+            CommandFixture::ServerProduce => server_produce(),
+        }
+    }
+
+    #[library_benchmark(setup = command_case)]
+    #[bench::move_projected(CommandFixture::ProjectedMove)]
+    #[bench::move_server(CommandFixture::ServerMove)]
+    #[bench::produce_server(CommandFixture::ServerProduce)]
+    fn command(case: CommandCase) -> usize {
+        let case = std::mem::ManuallyDrop::new(case);
+        run_command(&case)
+    }
+
+    #[library_benchmark(setup = command_case)]
+    #[bench::wait(CommandFixture::ServerMove)]
+    #[bench::capture(CommandFixture::ServerCapture)]
+    #[bench::produce(CommandFixture::ServerProduce)]
+    fn prepare(case: CommandCase) -> usize {
+        // Gungraun counts drops in the benchmark function. Keep the fixture
+        // alive so this case measures preparation instead of State teardown.
+        let case = std::mem::ManuallyDrop::new(case);
+        run_prepare(&case)
+    }
+
+    #[library_benchmark(setup = command_case)]
+    #[bench::wait(CommandFixture::ServerMove)]
+    #[bench::capture(CommandFixture::ServerCapture)]
+    fn prepare_movement(case: CommandCase) -> usize {
+        let case = std::mem::ManuallyDrop::new(case);
+        run_prepare_movement(&case)
+    }
+
+    fn authoritative_state() -> State {
+        server::state(server::DUEL, false)
+    }
+
+    #[library_benchmark(setup = authoritative_state)]
+    #[bench::state()]
+    fn enumerate_authoritative(state: State) -> Enumeration {
+        enumerate_state(&state)
+    }
+
+    fn observed_state() -> Observation {
+        observation(&server::state(server::DUEL, false))
+    }
+
+    fn profiled_cycle_case(fog: bool) -> CycleCase {
+        let case = cycle_case(fog);
+        // Initialize lazy ruleset tables outside the measured region. Criterion
+        // does this during warm-up; Callgrind runs the benchmark only once.
+        std::hint::black_box(enumerate_observed_query(&case.observation, &case.query));
+        case
+    }
+
+    #[library_benchmark(setup = observed_state)]
+    #[bench::observed()]
+    fn enumerate_observed(observation: Observation) -> Enumeration {
+        enumerate_observation(&observation)
+    }
+
+    #[library_benchmark(setup = authoritative_state)]
+    #[bench::production()]
+    fn enumerate_authoritative_production(state: State) -> usize {
+        enumerate_production(&state)
+    }
+
+    #[library_benchmark(setup = cycle_case)]
+    #[bench::fog_off(false)]
+    #[bench::fog_on(true)]
+    fn cycle_execute(case: CycleCase) -> usize {
+        let case = std::mem::ManuallyDrop::new(case);
+        run_command(&case.command)
+    }
+
+    #[library_benchmark(setup = cycle_case)]
+    #[bench::fog_off(false)]
+    #[bench::fog_on(true)]
+    fn cycle_observe(case: CycleCase) -> usize {
+        let case = std::mem::ManuallyDrop::new(case);
+        run_observe(&case.post_state)
+    }
+
+    #[library_benchmark(setup = cycle_case)]
+    #[bench::fog_off(false)]
+    #[bench::fog_on(true)]
+    fn cycle_reify(case: CycleCase) -> usize {
+        let case = std::mem::ManuallyDrop::new(case);
+        run_reify(&case.observation)
+    }
+
+    #[library_benchmark(setup = profiled_cycle_case)]
+    #[bench::fog_off(false)]
+    #[bench::fog_on(true)]
+    fn cycle_enumerate(case: CycleCase) -> Enumeration {
+        let case = std::mem::ManuallyDrop::new(case);
+        enumerate_observed_query(&case.observation, &case.query)
+    }
+
+    #[library_benchmark(setup = cycle_case)]
+    #[bench::fog_off(false)]
+    #[bench::fog_on(true)]
+    fn complete_cycle(case: CycleCase) -> Enumeration {
+        let case = std::mem::ManuallyDrop::new(case);
+        run_cycle(&case)
+    }
+
+    library_benchmark_group!(
+        name = ai_benches,
+        benchmarks = [
+            command,
+            prepare,
+            prepare_movement,
+            enumerate_authoritative,
+            enumerate_observed,
+            enumerate_authoritative_production,
+            cycle_execute,
+            cycle_observe,
+            cycle_reify,
+            cycle_enumerate,
+            complete_cycle,
+        ]
+    );
+}

--- a/crates/bench/src/benchmarks/server.rs
+++ b/crates/bench/src/benchmarks/server.rs
@@ -26,8 +26,12 @@
 //! from the measurement.
 
 use awbrn_map::{AwbrnMap, AwbwMap, Position};
-use awbrn_server::{GameCommand, GameServer, GameSetup, PlayerId, PlayerSetup, PostMoveAction};
-use awbrn_types::{AwbwTerrain, Co, Faction, PlayerFaction, Property, Unit};
+use awbrn_server::{
+    GameCommand, GameServer, GameSetup, PlayerId, PlayerSetup, PostMoveAction, state_from_setup,
+};
+use awbrn_types::{AwbwTerrain, Co, Faction, PlayerFaction, Property, Unit as ServerUnit};
+use awvm::ruleset::{UnitKind, profile};
+use awvm::semantic::{Concealment, Location, Pos, State, Unit as AwvmUnit, UnitAction, UnitId};
 
 /// The board every case runs on. AWBW's own maps cluster around this size.
 const WIDTH: usize = 20;
@@ -116,12 +120,12 @@ fn map(players: usize) -> AwbrnMap {
 
 /// A mix wide enough that the damage tables are actually consulted rather than
 /// one row of them being reused.
-const ROSTER: [Unit; 5] = [
-    Unit::Infantry,
-    Unit::Mech,
-    Unit::Tank,
-    Unit::Artillery,
-    Unit::Apc,
+const ROSTER: [ServerUnit; 5] = [
+    ServerUnit::Infantry,
+    ServerUnit::Mech,
+    ServerUnit::Tank,
+    ServerUnit::Artillery,
+    ServerUnit::Apc,
 ];
 
 /// The tile the mover starts on, and the two it walks to. Kept clear of every
@@ -134,7 +138,7 @@ const ATTACK_TARGET: (usize, usize) = (1, 5);
 
 /// Where the rest of the roster stands: rows 6 upward, clear of both edges'
 /// properties and of the mover's lane.
-fn deployment(players: usize) -> impl Iterator<Item = (Position, Unit, PlayerFaction)> {
+fn deployment(players: usize) -> impl Iterator<Item = (Position, ServerUnit, PlayerFaction)> {
     (0..UNITS - 1).map(move |i| {
         let position = Position::new(i % WIDTH, 6 + i / WIDTH);
         // Round-robin so every seat owns units — a seat with none sees nothing
@@ -172,13 +176,73 @@ pub fn server(players: usize, fog: bool) -> GameServer {
     // The mover goes first so it is always unit 1, whatever the roster does.
     server.spawn_unit(
         Position::new(MOVER_START.0, MOVER_START.1),
-        Unit::Tank,
+        ServerUnit::Tank,
         FACTIONS[0],
     );
     for (position, unit, faction) in deployment(players) {
         server.spawn_unit(position, unit, faction);
     }
     server
+}
+
+/// An AWVM state with the same deployment as [`server`].
+///
+/// `state_from_setup` converts the terrain and roster only. Applying the
+/// deployment here prevents AI benchmarks from measuring an empty unit store.
+pub fn state(players: usize, fog: bool) -> State {
+    let mut state = state_from_setup(&setup(players, fog)).expect("game setup is valid");
+    let units = std::iter::once((
+        Position::new(MOVER_START.0, MOVER_START.1),
+        ServerUnit::Tank,
+        FACTIONS[0],
+    ))
+    .chain(deployment(players));
+
+    for (index, (position, kind, faction)) in units.enumerate() {
+        let kind = awvm_kind(kind);
+        let unit_profile = profile(kind);
+        let owner_index = FACTIONS
+            .iter()
+            .position(|candidate| *candidate == faction)
+            .expect("a deployment faction is in the roster");
+        // The roster keeps the seating order of `setup`, which is the order of
+        // `FACTIONS`, so the faction's position in it is the seat to read.
+        let owner = state
+            .players
+            .seats()
+            .map(|(seat, _)| seat)
+            .nth(owner_index)
+            .expect("a deployment faction has a seat");
+        state.units.push(AwvmUnit {
+            id: UnitId::new(u32::try_from(index + 1).expect("unit identifier fits in u32")),
+            kind,
+            owner,
+            hp: 100,
+            fuel: unit_profile.max_fuel,
+            ammo: unit_profile.max_ammo,
+            action: UnitAction::Ready,
+            concealment: Concealment::Exposed,
+            location: Location::Board {
+                position: Pos::new(
+                    u8::try_from(position.x).expect("map position fits in u8"),
+                    u8::try_from(position.y).expect("map position fits in u8"),
+                ),
+            },
+        });
+    }
+    state.next_unit_id = Some(u32::try_from(UNITS + 1).expect("unit identifier fits in u32"));
+    state
+}
+
+fn awvm_kind(kind: ServerUnit) -> UnitKind {
+    match kind {
+        ServerUnit::Infantry => UnitKind::Infantry,
+        ServerUnit::Mech => UnitKind::Mech,
+        ServerUnit::Tank => UnitKind::Tank,
+        ServerUnit::Artillery => UnitKind::Artillery,
+        ServerUnit::Apc => UnitKind::Apc,
+        _ => panic!("the benchmark roster contains an unsupported unit"),
+    }
 }
 
 /// A server and the command to submit against it.
@@ -216,7 +280,7 @@ pub fn submission(kind: Kind, players: usize, fog: bool) -> Submission {
         },
         Kind::Attack => {
             let target = Position::new(ATTACK_TARGET.0, ATTACK_TARGET.1);
-            server.spawn_unit(target, Unit::Infantry, FACTIONS[1]);
+            server.spawn_unit(target, ServerUnit::Infantry, FACTIONS[1]);
             GameCommand::MoveUnit {
                 unit_id: awbrn_server::ServerUnitId(1),
                 path,
@@ -286,6 +350,11 @@ mod tests {
                 run_spectator_view(&mut server),
                 UNITS,
                 "roster is not {UNITS} units at {players} players"
+            );
+            assert_eq!(
+                state(players, false).units.len(),
+                UNITS,
+                "AWVM roster is not {UNITS} units at {players} players"
             );
         }
     }

--- a/crates/bench/src/bin/throughput.rs
+++ b/crates/bench/src/bin/throughput.rs
@@ -1,0 +1,777 @@
+//! Measurement 4: what one core costs for each command with no client attached.
+//!
+//! Measurements 1 to 3 price the parts of one search node on a fixture that is
+//! held still. This binary is the only case that runs the parts together across
+//! a complete game, so it is the only one that shows whether they add up in a
+//! straight line. A difference between the modeled cost and the measured cost
+//! is the result, in whichever direction it goes. The first suspect is the unit
+//! count: units collect over a game, and the state clone, the projection and
+//! enumeration all grow with them, so the report gives the units a game ends
+//! with beside the rate.
+//!
+//! **Games for each second is a policy number, not an engine number.** The task
+//! that asked for this measurement wanted games for each second, on the
+//! reasoning that a random agent thinks as little as an agent can, so its rate
+//! bounds every other agent. The first half holds. The second does not: a
+//! random agent almost never captures a headquarters and almost never
+//! eliminates an army, so its games do not end, and its rate is a rate over
+//! abandoned games that falls as the turn cap rises. The report says so when
+//! every game reaches the cap.
+//!
+//! So the number to take from here is **commands for each second**, which is
+//! search nodes for each second. Multiply it by the commands a real policy
+//! needs for one game to price a tier. Commands for each game is reported too,
+//! and it belongs to the agent: this one produces units at every chance, so its
+//! games are much longer than a played game.
+//!
+//! This is a binary and not a Criterion case because Criterion measures a short
+//! operation many times. A game is one long operation, and the wanted number is
+//! its rate.
+//!
+//! The agent enumerates through the observed query family, and it plays the
+//! complete execute-observe-reify-enumerate cycle that measurement 3 prices.
+//! An agent that enumerated the authoritative state would skip the projection
+//! and the reification, and its cost could not be compared with the model.
+
+use std::time::Instant;
+
+use awvm::commander::Domain;
+use awvm::event::AttackTarget;
+use awvm::query;
+use awvm::random::{Entropy, Luck, RandomError};
+use awvm::ruleset::{UnitKind as UnitKindId, WeatherKind, terrain};
+use awvm::semantic::{
+    AwbwVisibility, Location, Match, Observation, ObservedTileOwner, ObservedUnitRef, PlayerId,
+    Pos, State, UnitAction, UnitId, observe,
+};
+use awvm::transition::{ActiveTurn, Command, ExecuteOutcome, execute_with};
+
+use bench::benchmarks::server;
+
+/// The complete cycle that `ai-cycle-complete` recorded, in microseconds.
+///
+/// The report divides the measured seconds by the commands played to get the
+/// same quantity from a whole game, and prints the two beside each other. That
+/// comparison is what this measurement exists to make. Update these when
+/// `ai.rs` records a new number.
+const MODELED_CYCLE_FOG_OFF_US: f64 = 350.0;
+const MODELED_CYCLE_FOG_ON_US: f64 = 368.0;
+
+/// How many player turns a game may take before this binary abandons it.
+///
+/// Random agents make games that never end, so a cap is necessary. Sixty player
+/// turns is about a thirty-day duel, which is the length of a played game.
+///
+/// The cap does more than stop the loop. This agent produces a unit at every
+/// chance and loses units slowly, so its armies grow without limit, and the
+/// cost of one command grows with them: at a cap of 200 a game ends with about
+/// 123 units, against the 40 the other measurements use. A high cap therefore
+/// measures armies larger than a game ever holds. The report gives the units a
+/// game ended with, so raise the cap when the question is how the cost grows,
+/// and keep it low when the question is what one command costs.
+const DEFAULT_TURN_CAP: u32 = 60;
+
+/// Refusals in a row that end the turn by force.
+///
+/// A refused offer changes nothing, so a loop that only ends a turn when there
+/// is no offer left has no guarantee it makes progress. This bounds it. The
+/// value is high enough that an ordinary fog refusal does not end a turn early:
+/// the report gives the refusal count so that this can be checked.
+const REJECTION_LIMIT: u32 = 64;
+
+fn main() {
+    let options = match Options::parse(std::env::args().skip(1)) {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{message}\n\n{USAGE}");
+            std::process::exit(2);
+        }
+    };
+
+    let mut outcomes = Vec::with_capacity(options.games);
+
+    let start = Instant::now();
+    for game in 0..options.games {
+        outcomes.push(play(&options, game as u64));
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+
+    report(&options, &outcomes, elapsed);
+}
+
+const USAGE: &str = "\
+usage: throughput [--seed N] [--games N] [--fog] [--turn-cap N]
+
+  --seed N       Seed for the agent and the reducer. The same seed gives the
+                 same result. Default 1.
+  --games N      Complete games to play. Default 200.
+  --fog          Play with fog of war on. Default off.
+  --turn-cap N   Abandon a game after this many player turns. Default 60.
+                 A high cap measures armies larger than a real game holds.";
+
+struct Options {
+    seed: u64,
+    games: usize,
+    fog: bool,
+    turn_cap: u32,
+}
+
+impl Options {
+    fn parse(arguments: impl Iterator<Item = String>) -> Result<Self, String> {
+        let mut options = Self {
+            seed: 1,
+            games: 200,
+            fog: false,
+            turn_cap: DEFAULT_TURN_CAP,
+        };
+        let mut arguments = arguments.peekable();
+        while let Some(argument) = arguments.next() {
+            let mut value = || {
+                arguments
+                    .next()
+                    .ok_or_else(|| format!("{argument} needs a value"))
+            };
+            match argument.as_str() {
+                "--seed" => options.seed = parse_number(&value()?)?,
+                "--games" => options.games = parse_number(&value()?)?,
+                "--turn-cap" => options.turn_cap = parse_number(&value()?)?,
+                "--fog" => options.fog = true,
+                "--help" | "-h" => {
+                    println!("{USAGE}");
+                    std::process::exit(0);
+                }
+                other => return Err(format!("unknown argument {other}")),
+            }
+        }
+        if options.games == 0 {
+            return Err("--games must be at least 1".to_owned());
+        }
+        if options.turn_cap == 0 {
+            return Err("--turn-cap must be at least 1".to_owned());
+        }
+        Ok(options)
+    }
+}
+
+fn parse_number<T: std::str::FromStr>(text: &str) -> Result<T, String> {
+    text.parse()
+        .map_err(|_| format!("{text} is not a number this argument accepts"))
+}
+
+/// A seeded generator, used for the agent's choices and for the reducer's luck.
+///
+/// This is the xorshift that `awbrn-server` seeds a match with. It is repeated
+/// here rather than exported from that crate: a benchmark is not a reason to
+/// widen a server interface, and this binary needs two independent streams so
+/// that an agent choice cannot move the combat draws.
+struct Rng {
+    state: u64,
+}
+
+impl Rng {
+    const fn from_seed(seed: u64) -> Self {
+        Self {
+            state: if seed == 0 {
+                0x9e37_79b9_7f4a_7c15
+            } else {
+                seed
+            },
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state ^= self.state << 13;
+        self.state ^= self.state >> 7;
+        self.state ^= self.state << 17;
+        self.state
+    }
+
+    /// A value in `0..range`, without the modulo bias that a bare remainder has.
+    fn below(&mut self, range: u64) -> u64 {
+        if range <= 1 {
+            return 0;
+        }
+        let limit = u64::MAX - (u64::MAX % range);
+        loop {
+            let sample = self.next_u64();
+            if sample < limit {
+                return sample % range;
+            }
+        }
+    }
+}
+
+impl Entropy for Rng {
+    fn luck(&mut self, _polarity: Luck, domain: Domain) -> Result<i64, RandomError> {
+        let width = u64::try_from(domain.maximum - domain.minimum)
+            .expect("commander luck domains are ordered");
+        Ok(domain.minimum + self.below(width + 1) as i64)
+    }
+
+    fn weather(&mut self) -> Result<WeatherKind, RandomError> {
+        // `state_from_setup` sets a clear weather setting, and the reducer draws
+        // weather only for the random setting, so this is unreachable today. It
+        // answers rather than panics so that a later fixture change does not
+        // stop the measurement.
+        Ok(match self.below(3) {
+            0 => WeatherKind::Clear,
+            1 => WeatherKind::Rain,
+            _ => WeatherKind::Snow,
+        })
+    }
+}
+
+/// A seed for one game, derived so that game `n` does not continue game `n-1`.
+///
+/// Deriving each game's seed from the run seed and the game index is what makes
+/// one game reproducible on its own, and what keeps `--games 10` and
+/// `--games 200` playing the same first ten games.
+const fn mix(value: u64) -> u64 {
+    let mut z = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+struct GameOutcome {
+    turns: u32,
+    commands: u64,
+    /// Offers the reducer refused. Each one costs a complete node and counts as
+    /// no command, so a large share makes the reported rate pessimistic.
+    rejected: u64,
+    /// Units on the board when the game stopped.
+    ///
+    /// The cost model assumes each command costs the same. Units collect over a
+    /// game, and the state clone, the projection and enumeration all grow with
+    /// them, so this is the first thing to look at when the measured rate and
+    /// the modeled rate disagree.
+    units: usize,
+    capped: bool,
+}
+
+fn play(options: &Options, game: u64) -> GameOutcome {
+    let mut state = server::state(server::DUEL, options.fog);
+    // Two streams from one seed, so that an agent choice cannot move a combat
+    // draw. Both are derived from the game index, which is what makes one game
+    // reproducible on its own.
+    let mut entropy = Rng::from_seed(mix(options.seed ^ (game << 32) ^ 0x1));
+    let mut choices = Rng::from_seed(mix(options.seed ^ (game << 32) ^ 0x2));
+
+    let mut turns = 0;
+    let mut commands = 0;
+    let mut rejected = 0;
+    let mut rejected_in_a_row = 0;
+
+    while matches!(state.match_state, Match::Active { .. }) {
+        if turns >= options.turn_cap {
+            return GameOutcome {
+                turns,
+                commands,
+                rejected,
+                units: state.units.iter().count(),
+                capped: true,
+            };
+        }
+
+        let observation = observe(&AwbwVisibility, &state, &state.turn.active_player)
+            .expect("the active player can observe the state they act on");
+
+        // An offer the reducer refuses leaves the state alone, so the next pass
+        // sees the same board and draws again. That escapes on its own while
+        // one offer is acceptable, but nothing in the loop guarantees it. Ending
+        // the turn by force after a run of refusals bounds the loop: `turns`
+        // then rises whatever the reducer says, so the turn cap always stops the
+        // game.
+        let command = if rejected_in_a_row >= REJECTION_LIMIT {
+            rejected_in_a_row = 0;
+            turns += 1;
+            Command::EndTurn {
+                player: state.turn.active_player.clone(),
+            }
+        } else {
+            match choose(&observation, &state, &mut choices) {
+                Some(command) => command,
+                None => {
+                    turns += 1;
+                    Command::EndTurn {
+                        player: state.turn.active_player.clone(),
+                    }
+                }
+            }
+        };
+
+        match execute_with(&state, command, &mut entropy) {
+            Ok(ExecuteOutcome::Accepted(execution)) => {
+                state = execution.state;
+                commands += 1;
+                rejected_in_a_row = 0;
+            }
+            // A rejection means the observed family offered a command the
+            // authoritative reducer refuses. With fog on that is expected, and
+            // it is the player's own risk: an attack on a unit that fog hid,
+            // for example. A rejection still costs a complete node, so the
+            // report gives the count: rejections make the rate pessimistic,
+            // because the work is done and no command is counted for it.
+            Ok(ExecuteOutcome::Rejected(_)) => {
+                rejected += 1;
+                rejected_in_a_row += 1;
+            }
+            Err(error) => panic!("the reducer failed on a generated command: {error:?}"),
+        }
+    }
+
+    GameOutcome {
+        turns,
+        commands,
+        rejected,
+        units: state.units.iter().count(),
+        capped: false,
+    }
+}
+
+/// One offer the agent may take, named without building its command.
+///
+/// A ceiling measures the engine, so the agent must not add work of its own. A
+/// turn offers about a thousand commands, and each one holds a path, so a list
+/// of commands would put a thousand allocations for each node into a number
+/// whose subject is the reducer. This names an offer in bytes instead, and only
+/// the taken offer becomes a [`Command`].
+///
+/// This shape is not free: rebuilding the taken offer asks the movement field
+/// for its path a second time. That is one reachability search for each node
+/// against the nineteen the enumeration already ran.
+#[derive(Clone, Copy)]
+enum Choice {
+    Move {
+        unit: UnitId,
+        destination: Pos,
+        action: MoveAction,
+    },
+    Produce {
+        position: Pos,
+        kind: UnitKindId,
+    },
+    Unload {
+        transport: UnitId,
+        cargo: UnitId,
+        destination: Pos,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum MoveAction {
+    Wait,
+    Capture,
+    Supply,
+    Hide,
+    Reveal,
+    Explode,
+    Join,
+    Load,
+    Repair(Pos),
+    Launch(Pos),
+    Attack(Pos),
+}
+
+/// A uniform draw over a sequence whose length is not known in advance.
+///
+/// Offer each candidate once. Candidate `n` replaces the held one with
+/// probability `1/n`, which leaves each candidate equally likely. This is what
+/// lets the agent choose uniformly without a list to choose from.
+#[derive(Default)]
+struct Reservoir {
+    seen: u64,
+    chosen: Option<Choice>,
+}
+
+impl Reservoir {
+    fn offer(&mut self, rng: &mut Rng, choice: Choice) {
+        self.seen += 1;
+        if rng.below(self.seen) == 0 {
+            self.chosen = Some(choice);
+        }
+    }
+}
+
+/// Draw one legal command uniformly, as the observed family reports the offers.
+///
+/// The offers are the eleven movement actions, production, and unload. There is
+/// no `ActivatePower` and no `Tag`, because `query` has no enumerator for them,
+/// so a random agent cannot find them the way it finds a unit action. A power
+/// changes what a turn costs, so this rate is a lower bound for a game in which
+/// powers are used. There is no `DeleteUnit` and no `Resign`: both end a game
+/// earlier for a reason no policy would choose, and both would make the turn
+/// count a property of the agent's readiness to give up.
+///
+/// `None` means the player has no command left, which is how a turn ends.
+fn choose(observation: &Observation, truth: &State, rng: &mut Rng) -> Option<Command> {
+    let player = observation.recipient.clone();
+    let query = query::ObservedQuery::new(observation).expect("an observation reifies");
+    let turn = query.turn().expect("the recipient's turn can be checked")?;
+
+    let mut reservoir = Reservoir::default();
+
+    for unit in ready_friendly_units(observation) {
+        let Some(field) = turn
+            .move_field(unit)
+            .expect("a friendly unit can be checked")
+        else {
+            continue;
+        };
+        for (destination, _) in field.reach() {
+            let actions = field
+                .observed_actions_at(destination)
+                .expect("a destination from this field can be queried");
+            offer_destination(
+                &mut reservoir,
+                rng,
+                observation,
+                unit,
+                destination,
+                &actions,
+            );
+        }
+    }
+    offer_unloads(&mut reservoir, rng, observation);
+    offer_production(&mut reservoir, rng, observation, &player);
+
+    let choice = reservoir.chosen?;
+    Some(build(&turn, observation, truth, player, choice))
+}
+
+fn ready_friendly_units(observation: &Observation) -> impl Iterator<Item = UnitId> + '_ {
+    observation.units.iter().filter_map(|unit| {
+        match (&unit.reference, unit.owner == observation.recipient) {
+            (ObservedUnitRef::Friendly { unit: id }, true) if unit.action == UnitAction::Ready => {
+                Some(*id)
+            }
+            _ => None,
+        }
+    })
+}
+
+fn offer_destination(
+    reservoir: &mut Reservoir,
+    rng: &mut Rng,
+    observation: &Observation,
+    unit: UnitId,
+    destination: Pos,
+    actions: &query::ObservedActionSet,
+) {
+    let mut offer = |action| {
+        reservoir.offer(
+            rng,
+            Choice::Move {
+                unit,
+                destination,
+                action,
+            },
+        );
+    };
+    for (present, action) in [
+        (actions.wait, MoveAction::Wait),
+        (actions.capture, MoveAction::Capture),
+        (actions.supply, MoveAction::Supply),
+        (actions.hide, MoveAction::Hide),
+        (actions.reveal, MoveAction::Reveal),
+        (actions.explode, MoveAction::Explode),
+    ] {
+        if present {
+            offer(action);
+        }
+    }
+
+    // Join and load name the unit already standing at the destination, and a
+    // projection carries the id of a friendly unit, so both resolve inside the
+    // observation.
+    let occupied = friendly_at(observation, destination).is_some();
+    if actions.join && occupied {
+        offer(MoveAction::Join);
+    }
+    if actions.load && occupied {
+        offer(MoveAction::Load);
+    }
+
+    for position in &actions.repair {
+        if friendly_at(observation, *position).is_some() {
+            offer(MoveAction::Repair(*position));
+        }
+    }
+    for target in &actions.launch {
+        offer(MoveAction::Launch(*target));
+    }
+    for position in &actions.attack {
+        offer(MoveAction::Attack(*position));
+    }
+}
+
+fn offer_unloads(reservoir: &mut Reservoir, rng: &mut Rng, observation: &Observation) {
+    let mut transports: Vec<UnitId> = observation
+        .units
+        .iter()
+        .filter_map(|unit| match unit.location {
+            Location::Cargo { transport, .. } => Some(transport),
+            Location::Board { .. } => None,
+        })
+        .collect();
+    transports.sort_unstable();
+    transports.dedup();
+
+    for transport in transports {
+        for unload in query::observed_unloads(observation, transport).unwrap_or_default() {
+            reservoir.offer(
+                rng,
+                Choice::Unload {
+                    transport,
+                    cargo: unload.cargo,
+                    destination: unload.destination,
+                },
+            );
+        }
+    }
+}
+
+/// Production, at every facility the recipient holds.
+///
+/// The facility positions come from walking the projected board, not from
+/// naming the fixture's three bases. A game captures property, so at turn
+/// thirty the facilities are not the ones the setup gave, and a fixed list
+/// would report a production cost that falls as the game goes on.
+fn offer_production(
+    reservoir: &mut Reservoir,
+    rng: &mut Rng,
+    observation: &Observation,
+    player: &PlayerId,
+) {
+    for (position, tile) in observation.board.iter() {
+        if !matches!(&tile.owner, ObservedTileOwner::Owned(owner) if owner == player) {
+            continue;
+        }
+        if !terrain(tile.terrain).produces_any() {
+            continue;
+        }
+        for option in query::observed_production_options(observation, position) {
+            if option.affordable {
+                reservoir.offer(
+                    rng,
+                    Choice::Produce {
+                        position,
+                        kind: option.kind,
+                    },
+                );
+            }
+        }
+    }
+}
+
+fn build(
+    turn: &ActiveTurn<'_>,
+    observation: &Observation,
+    truth: &State,
+    player: PlayerId,
+    choice: Choice,
+) -> Command {
+    match choice {
+        Choice::Produce { position, kind } => Command::ProduceUnit {
+            player,
+            position,
+            kind,
+        },
+        Choice::Unload {
+            transport,
+            cargo,
+            destination,
+        } => Command::Unload {
+            player,
+            transport,
+            cargo,
+            destination,
+        },
+        Choice::Move {
+            unit,
+            destination,
+            action,
+        } => {
+            let path = turn
+                .move_field(unit)
+                .expect("the chosen unit can be checked")
+                .expect("the chosen unit had a movement field when it was offered")
+                .path_to(destination)
+                .expect("the chosen destination came from that field");
+            build_movement(observation, truth, player, unit, path, destination, action)
+        }
+    }
+}
+
+fn build_movement(
+    observation: &Observation,
+    truth: &State,
+    player: PlayerId,
+    unit: UnitId,
+    path: Vec<Pos>,
+    destination: Pos,
+    action: MoveAction,
+) -> Command {
+    let occupant =
+        || friendly_at(observation, destination).expect("the destination held a unit when offered");
+    let friendly = |position| {
+        friendly_at(observation, position).expect("the target was friendly when offered")
+    };
+    match action {
+        MoveAction::Wait => Command::MoveWait { player, unit, path },
+        MoveAction::Capture => Command::MoveCapture { player, unit, path },
+        MoveAction::Supply => Command::MoveSupply { player, unit, path },
+        MoveAction::Hide => Command::MoveHide { player, unit, path },
+        MoveAction::Reveal => Command::MoveReveal { player, unit, path },
+        MoveAction::Explode => Command::MoveExplode { player, unit, path },
+        MoveAction::Join => Command::MoveJoin {
+            player,
+            unit,
+            path,
+            target: occupant(),
+        },
+        MoveAction::Load => Command::MoveLoad {
+            player,
+            unit,
+            path,
+            transport: occupant(),
+        },
+        MoveAction::Repair(position) => Command::MoveRepair {
+            player,
+            unit,
+            path,
+            target: friendly(position),
+        },
+        MoveAction::Launch(target) => Command::MoveLaunch {
+            player,
+            unit,
+            path,
+            target,
+        },
+        MoveAction::Attack(position) => Command::MoveAttack {
+            player,
+            unit,
+            path,
+            target: attack_target(truth, position),
+        },
+    }
+}
+
+/// Name what stands at `position`, reading the authoritative state.
+///
+/// This is the one place the agent looks past its own projection, and it is a
+/// benchmark shortcut rather than fog-safe play. A projection reports an attack
+/// target as a position, because it carries no id for an enemy, and an id taken
+/// from a reification is an invention that means nothing to a reducer. A real
+/// client resolves this at the server. This binary owns the authoritative
+/// state, so it resolves the position directly.
+fn attack_target(truth: &State, position: Pos) -> AttackTarget {
+    truth
+        .units
+        .iter()
+        .find(|unit| unit.location == Location::Board { position })
+        .map_or(AttackTarget::Tile { position }, |unit| AttackTarget::Unit {
+            unit: unit.id,
+        })
+}
+
+fn friendly_at(observation: &Observation, position: Pos) -> Option<UnitId> {
+    observation
+        .units
+        .iter()
+        .find_map(|unit| match (&unit.reference, unit.location) {
+            (ObservedUnitRef::Friendly { unit: id }, Location::Board { position: at })
+                if at == position =>
+            {
+                Some(*id)
+            }
+            _ => None,
+        })
+}
+
+fn report(options: &Options, outcomes: &[GameOutcome], elapsed: f64) {
+    let games = outcomes.len();
+    let commands: u64 = outcomes.iter().map(|outcome| outcome.commands).sum();
+    let rejected: u64 = outcomes.iter().map(|outcome| outcome.rejected).sum();
+    let capped = outcomes.iter().filter(|outcome| outcome.capped).count();
+    let capped_share = capped as f64 / games as f64 * 100.0;
+
+    let median_turns = median(&sorted(outcomes, |outcome| outcome.turns as u64));
+    let median_commands = median(&sorted(outcomes, |outcome| outcome.commands));
+    let median_units = median(&sorted(outcomes, |outcome| outcome.units as u64));
+
+    let commands_a_second = commands as f64 / elapsed;
+    let games_a_second = games as f64 / elapsed;
+    let node_us = 1.0e6 / commands_a_second;
+
+    let modeled_node_us = if options.fog {
+        MODELED_CYCLE_FOG_ON_US
+    } else {
+        MODELED_CYCLE_FOG_OFF_US
+    };
+
+    println!(
+        "seed {}  games {}  fog {}",
+        options.seed, games, options.fog
+    );
+    println!("turn cap {}", options.turn_cap);
+    println!();
+
+    // The engine number. This is what measurement 4 can actually establish,
+    // and it is the one that prices a tier.
+    println!("elapsed                  {elapsed:.3} s");
+    println!("commands each second     {commands_a_second:.1}");
+    println!("one command              {node_us:.3} us measured");
+    println!("                         {modeled_node_us:.3} us modeled, from ai-cycle-complete");
+    println!("measured / modeled       {:.2}x", node_us / modeled_node_us);
+    println!(
+        "refused offers           {rejected} ({:.2}% of nodes)",
+        rejected as f64 / (commands + rejected) as f64 * 100.0
+    );
+    println!();
+
+    // The policy numbers. A game's length belongs to the agent, not the engine,
+    // so these describe the random agent and not the workspace.
+    println!("median turns each game   {median_turns}");
+    println!("median commands each game {median_commands}");
+    println!("median units at the end  {median_units}");
+    println!("reached the turn cap     {capped} of {games} ({capped_share:.1}%)");
+    println!();
+
+    if capped == games {
+        println!(
+            "Every game reached the cap, so no game ended. Games for each second is\n\
+             not measured: {games_a_second:.3} is a rate over abandoned games, and it\n\
+             falls as the cap rises. A random agent almost never wins, so this is a\n\
+             property of the agent. Use commands each second above, and divide by\n\
+             the commands a real policy needs."
+        );
+    } else {
+        println!("games for each second    {games_a_second:.3}");
+        if capped_share > 10.0 {
+            println!(
+                "warning: more than 10% of games reached the cap, so the median is a\n\
+                 property of --turn-cap and not of the game. Raise the cap and run again."
+            );
+        }
+    }
+}
+
+fn sorted(outcomes: &[GameOutcome], read: impl Fn(&GameOutcome) -> u64) -> Vec<u64> {
+    let mut values: Vec<u64> = outcomes.iter().map(read).collect();
+    values.sort_unstable();
+    values
+}
+
+/// The middle game, which the report uses in place of the mean.
+///
+/// A random agent makes some games that run to the cap, and a mean that a few
+/// capped games pull is a number about the cap.
+fn median(sorted: &[u64]) -> u64 {
+    let middle = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        (sorted[middle - 1] + sorted[middle]) / 2
+    } else {
+        sorted[middle]
+    }
+}

--- a/crates/bench/src/criterion_main.rs
+++ b/crates/bench/src/criterion_main.rs
@@ -1,7 +1,8 @@
-use bench::benchmarks::{awvm, replay, server};
+use bench::benchmarks::{ai, awvm, replay, server};
 use criterion::criterion_main;
 
 criterion_main!(
+    ai::criterion_benches::ai_benches,
     awvm::criterion_benches::awvm_benches,
     replay::criterion_benches::replay_benches,
     server::criterion_benches::server_benches

--- a/crates/bench/src/gungraun_main.rs
+++ b/crates/bench/src/gungraun_main.rs
@@ -1,13 +1,13 @@
 use bench::benchmarks::{
-    awvm::gungraun_benches::awvm_benches, replay::gungraun_benches::replay_benches,
-    server::gungraun_benches::server_benches,
+    ai::gungraun_benches::ai_benches, awvm::gungraun_benches::awvm_benches,
+    replay::gungraun_benches::replay_benches, server::gungraun_benches::server_benches,
 };
 
 mod instrumented {
-    use super::{awvm_benches, replay_benches, server_benches};
+    use super::{ai_benches, awvm_benches, replay_benches, server_benches};
     use gungraun::main;
 
-    main!(library_benchmark_groups = [awvm_benches, replay_benches, server_benches]);
+    main!(library_benchmark_groups = [ai_benches, awvm_benches, replay_benches, server_benches]);
 
     pub fn run() {
         main();
@@ -38,7 +38,7 @@ fn run_once() {
         };
     }
 
-    run_once!(awvm_benches, replay_benches, server_benches,);
+    run_once!(ai_benches, awvm_benches, replay_benches, server_benches,);
 }
 
 fn main() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AI-focused benchmark coverage for command execution, movement, production, visibility, and state enumeration.
  - Added configurable throughput benchmarking for seeded games with optional fog of war and turn limits.
  - Integrated AI benchmarks into the Criterion and Gungraun benchmark suites.

- **Tests**
  - Added validation for command acceptance, preparation, query consistency, and fog-of-war cycle behavior.
  - Expanded server benchmark state coverage and roster validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->