### PR TITLE
pnpm install before dev:web

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -93,6 +93,7 @@ depends = ["test:rust", "test:web"]
 
 [tasks."dev:web"]
 description = "Run the web server"
+depends = ["pnpm-install"]
 dir = "web"
 run = [
     "node ../scripts/setup-dev.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The web development task now automatically installs required packages before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->