### PR TITLE
Match results

### DIFF
--- a/web/drizzle/global/0000_initial.sql
+++ b/web/drizzle/global/0000_initial.sql
@@ -32,6 +32,36 @@ CREATE TABLE `match_participants` (
 --> statement-breakpoint
 CREATE INDEX `match_participants_match_idx` ON `match_participants` (`matchId`);--> statement-breakpoint
 CREATE INDEX `match_participants_match_user_idx` ON `match_participants` (`matchId`,`userId`);--> statement-breakpoint
+CREATE TABLE `match_results` (
+	`matchId` text NOT NULL,
+	`slotIndex` integer NOT NULL,
+	`userId` text NOT NULL,
+	`teamId` text,
+	`outcome` text NOT NULL,
+	`placement` integer NOT NULL,
+	`reason` text,
+	`pool` text,
+	`recordedAt` integer NOT NULL DEFAULT (unixepoch()),
+	PRIMARY KEY(`matchId`, `slotIndex`),
+	FOREIGN KEY (`matchId`) REFERENCES `matches`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "match_results_placement_matches_outcome" CHECK(typeof("match_results"."placement") = 'integer' and "match_results"."placement" >= 1 and ("match_results"."placement" = 1) = ("match_results"."outcome" in ('win', 'draw'))),
+	CONSTRAINT "match_results_outcome_vocabulary" CHECK("match_results"."outcome" in ('win', 'loss', 'draw')),
+	CONSTRAINT "match_results_reason_null_only_for_standing_win" CHECK("match_results"."reason" is not null or "match_results"."outcome" = 'win')
+);
+--> statement-breakpoint
+CREATE INDEX `match_results_user_idx` ON `match_results` (`userId`,`recordedAt`);--> statement-breakpoint
+CREATE INDEX `match_results_pool_idx` ON `match_results` (`pool`,`recordedAt`) WHERE "match_results"."pool" is not null;--> statement-breakpoint
+CREATE TABLE `match_voids` (
+	`matchId` text PRIMARY KEY NOT NULL,
+	`voidedByUserId` text NOT NULL,
+	`reason` text NOT NULL,
+	`voidedAt` integer NOT NULL DEFAULT (unixepoch()),
+	FOREIGN KEY (`matchId`) REFERENCES `matches`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`voidedByUserId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE INDEX `match_voids_voidedAt_idx` ON `match_voids` (`voidedAt`);--> statement-breakpoint
 CREATE TABLE `matches` (
 	`id` text PRIMARY KEY NOT NULL,
 	`name` text NOT NULL,

--- a/web/drizzle/global/meta/0000_snapshot.json
+++ b/web/drizzle/global/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "f718c8a5-7d92-4dda-932d-c75d7736b28d",
+  "id": "b1de914a-c1c0-4eab-8374-6af6c11ecf46",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "account": {
@@ -89,7 +89,8 @@
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "autoincrement": false
+          "autoincrement": false,
+          "default": "(unixepoch())"
         },
         "updatedAt": {
           "name": "updatedAt",
@@ -222,6 +223,193 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "match_results": {
+      "name": "match_results",
+      "columns": {
+        "matchId": {
+          "name": "matchId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slotIndex": {
+          "name": "slotIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pool": {
+          "name": "pool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "match_results_user_idx": {
+          "name": "match_results_user_idx",
+          "columns": ["userId", "recordedAt"],
+          "isUnique": false
+        },
+        "match_results_pool_idx": {
+          "name": "match_results_pool_idx",
+          "columns": ["pool", "recordedAt"],
+          "isUnique": false,
+          "where": "\"match_results\".\"pool\" is not null"
+        }
+      },
+      "foreignKeys": {
+        "match_results_matchId_matches_id_fk": {
+          "name": "match_results_matchId_matches_id_fk",
+          "tableFrom": "match_results",
+          "tableTo": "matches",
+          "columnsFrom": ["matchId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_results_userId_user_id_fk": {
+          "name": "match_results_userId_user_id_fk",
+          "tableFrom": "match_results",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "match_results_matchId_slotIndex_pk": {
+          "columns": ["matchId", "slotIndex"],
+          "name": "match_results_matchId_slotIndex_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "match_results_placement_matches_outcome": {
+          "name": "match_results_placement_matches_outcome",
+          "value": "typeof(\"match_results\".\"placement\") = 'integer' and \"match_results\".\"placement\" >= 1 and (\"match_results\".\"placement\" = 1) = (\"match_results\".\"outcome\" in ('win', 'draw'))"
+        },
+        "match_results_outcome_vocabulary": {
+          "name": "match_results_outcome_vocabulary",
+          "value": "\"match_results\".\"outcome\" in ('win', 'loss', 'draw')"
+        },
+        "match_results_reason_null_only_for_standing_win": {
+          "name": "match_results_reason_null_only_for_standing_win",
+          "value": "\"match_results\".\"reason\" is not null or \"match_results\".\"outcome\" = 'win'"
+        }
+      }
+    },
+    "match_voids": {
+      "name": "match_voids",
+      "columns": {
+        "matchId": {
+          "name": "matchId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voidedByUserId": {
+          "name": "voidedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voidedAt": {
+          "name": "voidedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "match_voids_voidedAt_idx": {
+          "name": "match_voids_voidedAt_idx",
+          "columns": ["voidedAt"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "match_voids_matchId_matches_id_fk": {
+          "name": "match_voids_matchId_matches_id_fk",
+          "tableFrom": "match_voids",
+          "tableTo": "matches",
+          "columnsFrom": ["matchId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_voids_voidedByUserId_user_id_fk": {
+          "name": "match_voids_voidedByUserId_user_id_fk",
+          "tableFrom": "match_voids",
+          "tableTo": "user",
+          "columnsFrom": ["voidedByUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "matches": {
       "name": "matches",
       "columns": {
@@ -293,7 +481,8 @@
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "autoincrement": false
+          "autoincrement": false,
+          "default": "(unixepoch())"
         },
         "updatedAt": {
           "name": "updatedAt",
@@ -378,7 +567,8 @@
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "autoincrement": false
+          "autoincrement": false,
+          "default": "(unixepoch())"
         },
         "updatedAt": {
           "name": "updatedAt",
@@ -479,7 +669,8 @@
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "autoincrement": false
+          "autoincrement": false,
+          "default": "(unixepoch())"
         },
         "updatedAt": {
           "name": "updatedAt",
@@ -537,7 +728,8 @@
           "type": "integer",
           "primaryKey": false,
           "notNull": false,
-          "autoincrement": false
+          "autoincrement": false,
+          "default": "(unixepoch())"
         },
         "updatedAt": {
           "name": "updatedAt",

--- a/web/src/db/global.ts
+++ b/web/src/db/global.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
+  check,
   index,
   integer,
   primaryKey,
@@ -7,7 +8,16 @@ import {
   text,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
-import type { MatchPhase, MatchSettings } from "#/matches/schemas.ts";
+import { matchOutcomes } from "#/matches/schemas.ts";
+import type {
+  MatchOutcome,
+  MatchPhase,
+  MatchSettings,
+  RankedPool,
+  SeatResultReason,
+} from "#/matches/schemas.ts";
+
+const sqlLiterals = (values: readonly string[]) => sql.raw(values.map((v) => `'${v}'`).join(", "));
 
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -126,4 +136,66 @@ export const matchParticipants = sqliteTable(
     index("match_participants_match_idx").on(t.matchId),
     index("match_participants_match_user_idx").on(t.matchId, t.userId),
   ],
+);
+
+/**
+ * One authoritative result row per seat. `reason` stores an elimination cause
+ * or match ending. A null reason means a standing winner. `outcome` is the
+ * team result, `placement` is the final rank, and `pool` marks ranked play.
+ */
+export const matchResults = sqliteTable(
+  "match_results",
+  {
+    matchId: text("matchId")
+      .notNull()
+      .references(() => matches.id, { onDelete: "cascade" }),
+    slotIndex: integer("slotIndex").notNull(),
+    userId: text("userId")
+      .notNull()
+      .references(() => user.id, { onDelete: "restrict" }),
+    teamId: text("teamId"),
+    outcome: text("outcome").notNull().$type<MatchOutcome>(),
+    placement: integer("placement").notNull(),
+    reason: text("reason").$type<SeatResultReason>(),
+    pool: text("pool").$type<RankedPool>(),
+    recordedAt: integer("recordedAt", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (t) => [
+    primaryKey({ columns: [t.matchId, t.slotIndex] }),
+    index("match_results_user_idx").on(t.userId, t.recordedAt),
+    index("match_results_pool_idx")
+      .on(t.pool, t.recordedAt)
+      .where(sql`${t.pool} is not null`),
+    check(
+      "match_results_placement_matches_outcome",
+      // SQLite stores fractional values as REAL. Reject them before checking rank.
+      sql`typeof(${t.placement}) = 'integer' and ${t.placement} >= 1 and (${t.placement} = 1) = (${t.outcome} in ('win', 'draw'))`,
+    ),
+    check("match_results_outcome_vocabulary", sql`${t.outcome} in (${sqlLiterals(matchOutcomes)})`),
+    check(
+      "match_results_reason_null_only_for_standing_win",
+      sql`${t.reason} is not null or ${t.outcome} = 'win'`,
+    ),
+  ],
+);
+
+/** Records a voided match without changing its result. */
+export const matchVoids = sqliteTable(
+  "match_voids",
+  {
+    matchId: text("matchId")
+      .primaryKey()
+      .references(() => matches.id, { onDelete: "cascade" }),
+    voidedByUserId: text("voidedByUserId")
+      .notNull()
+      .references(() => user.id, { onDelete: "restrict" }),
+    /** Free text for abuse records in the first release. */
+    reason: text("reason").notNull(),
+    voidedAt: integer("voidedAt", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (t) => [index("match_voids_voidedAt_idx").on(t.voidedAt)],
 );

--- a/web/src/matches/match_results.test.ts
+++ b/web/src/matches/match_results.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+  isRatedResult,
+  placementMatchesOutcome,
+  reasonMatchesOutcome,
+  glickoScore,
+  seatStatus,
+  wonAfterLeaving,
+} from "./match_results.ts";
+import {
+  matchOutcomeSchema,
+  rankedPoolSchema,
+  seatResultReasonSchema,
+  type SeatResultReason,
+} from "./schemas.ts";
+
+const decisiveReasons = [
+  "rout",
+  "hq-capture",
+  "lab-capture",
+  "capture-limit",
+  "day-limit",
+  "resignation",
+  "timeout",
+] as const satisfies readonly SeatResultReason[];
+
+describe("match results", () => {
+  it("rates every real result in a pool, draws included", () => {
+    expect(decisiveReasons.length).toBe(7);
+    for (const outcome of ["win", "loss", "draw"] as const) {
+      expect(isRatedResult({ outcome, pool: "fog_async", voided: false })).toBe(true);
+    }
+  });
+
+  it("scores a draw at a half point for Glicko-2", () => {
+    expect(glickoScore("win")).toBe(1);
+    expect(glickoScore("draw")).toBe(0.5);
+    expect(glickoScore("loss")).toBe(0);
+  });
+
+  it("stops a voided match counting without rewriting what happened", () => {
+    const win = { outcome: "win", pool: "async" } as const;
+    expect(isRatedResult({ ...win, voided: false })).toBe(true);
+    expect(isRatedResult({ ...win, voided: true })).toBe(false);
+    // Voiding does not change the stored outcome.
+    expect(glickoScore(win.outcome)).toBe(1);
+  });
+
+  it("leaves poolless matches unrated", () => {
+    expect(isRatedResult({ outcome: "win", pool: null, voided: false })).toBe(false);
+  });
+
+  it("derives a seat's status from its reason", () => {
+    expect(seatStatus(null)).toBe("active");
+    expect(seatStatus("resignation")).toBe("resigned");
+    expect(seatStatus("timeout")).toBe("timed-out");
+    expect(seatStatus("rout")).toBe("eliminated");
+    expect(seatStatus("hq-capture")).toBe("eliminated");
+    expect(seatStatus("lab-capture")).toBe("eliminated");
+    // These endings leave the seat active.
+    expect(seatStatus("capture-limit")).toBe("active");
+    expect(seatStatus("day-limit")).toBe("active");
+    expect(seatStatus("agreement")).toBe("active");
+  });
+
+  it("leaves the loser of a capture limit standing but names why it lost", () => {
+    // The limit ends the match without eliminating the loser.
+    const loser = { outcome: "loss", reason: "capture-limit", placement: 2 } as const;
+    expect(seatStatus(loser.reason)).toBe("active");
+    expect(isRatedResult({ ...loser, pool: "async", voided: false })).toBe(true);
+  });
+
+  it("recovers a 1v1 ending from the loser's reason alone", () => {
+    // The non-null reason identifies the 1v1 ending.
+    const endings = [
+      { end: "rout", seats: [null, "rout"] },
+      { end: "hq-capture", seats: [null, "hq-capture"] },
+      { end: "capture-limit", seats: [null, "capture-limit"] },
+      { end: "day-limit", seats: [null, "day-limit"] },
+      { end: "agreement", seats: ["agreement", "agreement"] },
+    ] as const;
+    for (const { end, seats } of endings) {
+      expect(seats.find((reason) => reason !== null)).toBe(end);
+    }
+  });
+
+  it("wins a team match for a member eliminated before their allies finished", () => {
+    // Red wins after red-2 is eliminated.
+    const redTwo = { outcome: "win", reason: "rout", placement: 1 } as const;
+    const redOne = { outcome: "win", reason: null, placement: 1 } as const;
+
+    expect(wonAfterLeaving(redTwo)).toBe(true);
+    expect(seatStatus(redTwo.reason)).toBe("eliminated");
+    expect(wonAfterLeaving(redOne)).toBe(false);
+    expect(seatStatus(redOne.reason)).toBe("active");
+    for (const seat of [redOne, redTwo]) {
+      expect(placementMatchesOutcome(seat.outcome, seat.placement)).toBe(true);
+    }
+  });
+
+  it("places wins and draws first, and ranks everyone else", () => {
+    expect(placementMatchesOutcome("win", 1)).toBe(true);
+    expect(placementMatchesOutcome("draw", 1)).toBe(true);
+    expect(placementMatchesOutcome("loss", 2)).toBe(true);
+    expect(placementMatchesOutcome("loss", 4)).toBe(true);
+    expect(placementMatchesOutcome("win", 2)).toBe(false);
+    expect(placementMatchesOutcome("loss", 1)).toBe(false);
+    expect(placementMatchesOutcome("draw", 2)).toBe(false);
+  });
+
+  it("rejects a placement below first, as the check constraint does", () => {
+    expect(placementMatchesOutcome("loss", 0)).toBe(false);
+    expect(placementMatchesOutcome("loss", -3)).toBe(false);
+    expect(placementMatchesOutcome("win", 0)).toBe(false);
+  });
+
+  it("rejects a placement that is not a whole rank", () => {
+    // Reject fractional and non-finite ranks.
+    for (const outcome of ["win", "loss", "draw"] as const) {
+      for (const placement of [1.5, 2.5, NaN, Infinity, -Infinity]) {
+        expect(placementMatchesOutcome(outcome, placement)).toBe(false);
+      }
+    }
+    // Whole-number ranks pass.
+    expect(placementMatchesOutcome("loss", 2.0)).toBe(true);
+  });
+
+  it("lets only a standing winner leave its reason null", () => {
+    expect(reasonMatchesOutcome("win", null)).toBe(true);
+    expect(reasonMatchesOutcome("loss", null)).toBe(false);
+    // A draw must record the ending.
+    expect(reasonMatchesOutcome("draw", null)).toBe(false);
+    expect(reasonMatchesOutcome("draw", "day-limit")).toBe(true);
+    expect(reasonMatchesOutcome("draw", "agreement")).toBe(true);
+    // An early winner carries its cause.
+    expect(reasonMatchesOutcome("win", "rout")).toBe(true);
+    for (const reason of decisiveReasons) {
+      expect(reasonMatchesOutcome("loss", reason)).toBe(true);
+    }
+  });
+
+  it("records a free-for-all where seats left for different reasons", () => {
+    const ffa = [
+      { outcome: "win", reason: null, placement: 1 },
+      { outcome: "loss", reason: "rout", placement: 2 },
+      { outcome: "loss", reason: "hq-capture", placement: 3 },
+      { outcome: "loss", reason: "resignation", placement: 4 },
+    ] as const;
+    expect(ffa.map((seat) => seatStatus(seat.reason))).toEqual([
+      "active",
+      "eliminated",
+      "eliminated",
+      "resigned",
+    ]);
+    for (const seat of ffa) {
+      expect(placementMatchesOutcome(seat.outcome, seat.placement)).toBe(true);
+      expect(reasonMatchesOutcome(seat.outcome, seat.reason)).toBe(true);
+    }
+  });
+
+  it("speaks the engine's vocabulary", () => {
+    expect(seatResultReasonSchema.safeParse("lab-capture").success).toBe(true);
+    expect(seatResultReasonSchema.safeParse("hq_capture").success).toBe(false);
+    expect(seatResultReasonSchema.safeParse("surrender").success).toBe(false);
+    expect(matchOutcomeSchema.safeParse("draw").success).toBe(true);
+    expect(rankedPoolSchema.safeParse("fog_live").success).toBe(true);
+    expect(rankedPoolSchema.safeParse("blitz").success).toBe(false);
+  });
+
+  it("keeps void out of the result vocabulary entirely", () => {
+    // Voiding is separate from the result.
+    expect(seatResultReasonSchema.safeParse("void").success).toBe(false);
+    expect(matchOutcomeSchema.safeParse("void").success).toBe(false);
+  });
+});

--- a/web/src/matches/match_results.ts
+++ b/web/src/matches/match_results.ts
@@ -1,0 +1,82 @@
+import type { DrawReason, PlayerStatus, VictoryReason } from "#/wasm/awbrn_server.js";
+import type { MatchOutcome, MatchSeatStatus, RankedPool, SeatResultReason } from "./schemas.ts";
+
+/** Keep result reasons and statuses in sync with the engine vocabulary. */
+type AssertNever<T extends never> = T;
+export type EngineReasonsAreCovered = AssertNever<
+  Exclude<VictoryReason | DrawReason, SeatResultReason>
+>;
+export type SeatReasonsAreEngineReasons = AssertNever<
+  Exclude<SeatResultReason, VictoryReason | DrawReason>
+>;
+export type EngineStatusesAreCovered = AssertNever<Exclude<PlayerStatus, MatchSeatStatus>>;
+export type SeatStatusesAreEngineStatuses = AssertNever<Exclude<MatchSeatStatus, PlayerStatus>>;
+
+/** First place, held by every winning seat and by every seat of a draw. */
+export const PLACEMENT_FIRST = 1;
+
+/** Map a result reason to its terminal seat status. */
+export function seatStatus(reason: SeatResultReason | null): MatchSeatStatus {
+  switch (reason) {
+    case null:
+      return "active";
+    case "resignation":
+      return "resigned";
+    case "timeout":
+      return "timed-out";
+    case "rout":
+    case "hq-capture":
+    case "lab-capture":
+      return "eliminated";
+    case "capture-limit":
+    case "day-limit":
+    case "agreement":
+      return "active";
+  }
+}
+
+export interface MatchResultOutcome {
+  outcome: MatchOutcome;
+  pool: RankedPool | null;
+  /** True when a `match_voids` row exists for this seat's match. */
+  voided: boolean;
+}
+
+/** Whether a pooled, non-voided result counts for ratings. */
+export function isRatedResult(result: MatchResultOutcome): boolean {
+  return result.pool !== null && !result.voided;
+}
+
+/** The Glicko-2 score for a seat: 1 for a win, 0.5 for a draw, 0 for a loss. */
+export function glickoScore(outcome: MatchOutcome): number {
+  switch (outcome) {
+    case "win":
+      return 1;
+    case "draw":
+      return 0.5;
+    case "loss":
+      return 0;
+  }
+}
+
+/** Whether a winning seat left before its team won. */
+export function wonAfterLeaving(result: {
+  outcome: MatchOutcome;
+  reason: SeatResultReason | null;
+}): boolean {
+  return result.outcome === "win" && seatStatus(result.reason) !== "active";
+}
+
+/** Whether a positive integer placement agrees with the outcome. */
+export function placementMatchesOutcome(outcome: MatchOutcome, placement: number): boolean {
+  if (!Number.isInteger(placement) || placement < PLACEMENT_FIRST) return false;
+  return (placement === PLACEMENT_FIRST) === (outcome === "win" || outcome === "draw");
+}
+
+/** Whether the result reason is valid for the seat outcome. */
+export function reasonMatchesOutcome(
+  outcome: MatchOutcome,
+  reason: SeatResultReason | null,
+): boolean {
+  return reason !== null || outcome === "win";
+}

--- a/web/src/matches/schemas.ts
+++ b/web/src/matches/schemas.ts
@@ -40,6 +40,40 @@ export const matchMutationRequestSchema = z.discriminatedUnion("action", [
 ]);
 
 export type MatchPhase = "draft" | "lobby" | "starting" | "active" | "completed" | "cancelled";
+
+/** Engine reasons for a seat elimination or match ending. */
+export const seatResultReasons = [
+  "rout",
+  "hq-capture",
+  "lab-capture",
+  "capture-limit",
+  "day-limit",
+  "resignation",
+  "timeout",
+  "agreement",
+] as const;
+
+export const seatResultReasonSchema = z.enum(seatResultReasons);
+
+/** Result for one seat. Team members share the team outcome. */
+export const matchOutcomes = ["win", "loss", "draw"] as const;
+
+export const matchOutcomeSchema = z.enum(matchOutcomes);
+
+/** Terminal seat status derived from its result reason. */
+export const matchSeatStatuses = ["active", "resigned", "timed-out", "eliminated"] as const;
+
+export const matchSeatStatusSchema = z.enum(matchSeatStatuses);
+
+/** Ranked pools, one per `{ fog, pace }` pair. Live pools open after async ones. */
+export const rankedPools = ["async", "fog_async", "live", "fog_live"] as const;
+
+export const rankedPoolSchema = z.enum(rankedPools);
+
+export type SeatResultReason = (typeof seatResultReasons)[number];
+export type MatchOutcome = (typeof matchOutcomes)[number];
+export type MatchSeatStatus = (typeof matchSeatStatuses)[number];
+export type RankedPool = (typeof rankedPools)[number];
 export type MatchSettings = z.infer<typeof matchSettingsSchema>;
 export type MatchCreateRequest = z.infer<typeof matchCreateRequestSchema>;
 export type MatchBrowseRequest = z.infer<typeof matchBrowseRequestSchema>;


### PR DESCRIPTION
Add match_results and match_voids tables

Build order step 1 of ranked play (#246), schema only. Nothing
transitions a match to completed yet, so there is no write site.

match_results holds one row per seat, for every match size. Ranked play
is 1v1, but that lives in the pool column rather than the table's shape,
so free-for-all and team matches are recorded with a null pool. Keyed on
(matchId, slotIndex) rather than user, because hotseat lets one account
hold several seats.

A result is three independent axes, mirroring awvm:

  - reason     why this seat's run ended - its own elimination cause, or
             the match ending for a seat that was never eliminated.
             Null means it won while standing.
  - outcome    how its team fared, since Outcome::Victory names teams and
             a team survives while any member is active.
  - placement  1 for a win or draw, else the finishing rank.

Keeping them separate is what lets a routed player still be a winner
when their allies finish the job, and what distinguishes that seat from
a survivor of the same victory. PlayerStatus is derived from reason
rather than stored, as semantics/elimination.md defines it that way.

Reason values are awvm's exact wire strings, so a stored value is what
the engine emitted. Type-level assertions tie the vocabulary to the
generated VictoryReason, DrawReason, and PlayerStatus in both
directions, so a ruleset regen breaks the build rather than writing a
value the table cannot hold.

match_voids records annulment separately - who, when, and why - instead
of overwriting the result. Sparse, so the rating path is an anti-join
rather than a flag kept in step across a match's seats, and unvoiding is
deleting the row.

Four assumptions in #246 turned out to disagree with the engine and are
not implemented as written: a day limit is decided on property count and
is normally a win, not a draw; the reason vocabulary is awvm's, which
adds lab-capture, capture-limit and day-limit and renames surrender and
draw_agreed; void is an audit record rather than a reason; and draws now
count toward ratings at 0.5, which reverses §3 and is the one change
that is a judgement call rather than a correction. Details in comment.md
for the issue thread.

Folded into the initial migration rather than adding a second one, since
the app is not in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recording match results, player placements, outcomes, ranked pools, and result reasons.
  * Added handling for voided matches with administrative reasons and timestamps.
  * Added consistent seat-status tracking for resignations, timeouts, and eliminations.
  * Added rating eligibility and Glicko score calculation for supported match outcomes.
* **Bug Fixes**
  * Added validation to prevent inconsistent placements and outcomes.
  * Clarified that voided matches do not create player outcomes or rating results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->