### PR TITLE
Specify elimination causes and drop no-contest

### DIFF
--- a/crates/awvm-awbw/src/recorded.rs
+++ b/crates/awvm-awbw/src/recorded.rs
@@ -1325,6 +1325,7 @@ fn diff_events(prior: &State, post: &State, action: &Action) -> Vec<Event> {
                 player: before.id().clone(),
                 from: before.status,
                 to: after.status,
+                reason: reason(),
             });
         }
         for (slot, (old, new)) in before.commanders.iter().zip(&after.commanders).enumerate() {
@@ -1392,6 +1393,21 @@ fn diff_events(prior: &State, post: &State, action: &Action) -> Vec<Event> {
                 }
             }
             _ => {}
+        }
+    }
+    // `retire_player` eliminates a team directly, so the status changes with no
+    // event of its own. `semantics/elimination.md` pairs that change with
+    // `TeamEliminated`, after the player status that caused it, as a played
+    // match emits the two.
+    for before in &prior.teams {
+        let Some(after) = post.teams.iter().find(|team| team.id == before.id) else {
+            continue;
+        };
+        if before.status != TeamStatus::Eliminated && after.status == TeamStatus::Eliminated {
+            events.push(Event::TeamEliminated {
+                team: before.id.clone(),
+                reason: reason(),
+            });
         }
     }
     if prior.turn.day != post.turn.day {

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1362397.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1362397.zip.snap
@@ -103,8 +103,8 @@ input_file: assets/replays/1362397.zip
 01735 d=20 p=3192682 End        s=1a4e3cb6b711b61f o=ea7554700a040dec
 01743 d=20 p=3189356 End        s=258db602fa7ba47b o=05535c9bb0355992
 01791 d=21 p=3189394 End        s=4dd3034647aaf95a o=695fd6b0c72af2f6
-01792 d=21 p=3189812 Resign     s=e27e9639793a675a o=90e2f6cf8d1c3f87
-01793 d=21 p=3189442 Resign     s=1e5ae35ed000e4e8 o=16f3cff8856e71d4
-01794 d=21 p=3192682 Resign     s=4097b11621f59e31 o=39050a6aab0a500a
-01795 d=21 p=3192682 Resign     s=4aed860063aece8d o=0c904b74f67cbebd
+01792 d=21 p=3189812 Resign     s=e27e9639793a675a o=6fbfa31e831bc1aa
+01793 d=21 p=3189442 Resign     s=1e5ae35ed000e4e8 o=e0bc66ad98d174de
+01794 d=21 p=3192682 Resign     s=4097b11621f59e31 o=b7b902eb4c6e8be6
+01795 d=21 p=3192682 Resign     s=4aed860063aece8d o=8135c617546b9e28
 final {"day":21,"match":{"outcome":{"reason":"resignation","type":"victory","winners":["player:3189356"]},"status":"finished"},"phase":"finished","players":[["3189394","resigned",11],["3189812","resigned",9],["3189442","resigned",10],["3192682","resigned",8],["3189356","active",40]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1391406.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1391406.zip.snap
@@ -44,5 +44,5 @@ input_file: assets/replays/1391406.zip
 00938 d=20 p=3252473 End        s=ee3f9e0b1bd467f6 o=2387e2130fd2963c
 00962 d=21 p=3252378 End        s=f38fe6088f2f7f28 o=444dc50ede3362da
 01000 d=21 p=3252473 End        s=cc6ef74600760e6d o=d29469f27f675059
-01006 d=21 p=3252473 Resign     s=daf4b723965ecb0e o=3f6b3a60331ed899
+01006 d=21 p=3252473 Resign     s=daf4b723965ecb0e o=86a0291859fb12d3
 final {"day":21,"match":{"outcome":{"reason":"resignation","type":"victory","winners":["player:3252378"]},"status":"finished"},"phase":"finished","players":[["3252378","active",27],["3252473","resigned",26]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1403019.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1403019.zip.snap
@@ -100,7 +100,7 @@ input_file: assets/replays/1403019.zip
 02286 d=20 p=3277095 End        s=48492dbc76f883f4 o=d51e9d3879a5deac
 02313 d=20 p=3276843 End        s=eb1a506cb1b20b99 o=2bddef3902703622
 02361 d=21 p=3276855 End        s=d5efc56eb175c857 o=c2f28f2c6f8902be
-02363 d=21 p=3277011 Resign     s=0eaf5529cd8a605f o=0b04ae422e713b49
+02363 d=21 p=3277011 Resign     s=0eaf5529cd8a605f o=9208c84555ef6e13
 02410 d=21 p=3279740 End        s=6c83662b228c099d o=09b22d490f60b10f
 02432 d=21 p=3277095 End        s=ffcb0adfa7e23039 o=cac5f927f4b16085
 02452 d=21 p=3276843 End        s=5c223f582b1c1309 o=72c8bc3e8aaa0060
@@ -125,5 +125,5 @@ input_file: assets/replays/1403019.zip
 03109 d=26 p=3277095 End        s=aaa6640628733f23 o=36ff7475193cda3c
 03110 d=26 p=3276843 Resign     s=8298519b6ee32875 o=e8e378430aa707f9
 03154 d=27 p=3277011 End        s=4048bd082b5dc5f1 o=ce1e6e49685945b9
-03158 d=27 p=3277011 Resign     s=da6ae1331d6bf3ac o=a97b2b8cb2f10880
+03158 d=27 p=3277011 Resign     s=da6ae1331d6bf3ac o=fcb71902ec3e8d01
 final {"day":27,"match":{"outcome":{"reason":"resignation","type":"victory","winners":["team:B"]},"status":"finished"},"phase":"finished","players":[["3276855","resigned",2],["3277011","resigned",41],["3279740","active",22],["3277095","resigned",12],["3276843","active",32]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1419680.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1419680.zip.snap
@@ -31,5 +31,5 @@ input_file: assets/replays/1419680.zip
 00523 d=14 p=3313081 End        s=62e1d160ba39d607 o=abb146a820e8f803
 00563 d=14 p=3313080 End        s=1d551544a87f00cc o=c48ea1510c802f8c
 00622 d=15 p=3313081 End        s=2a88f49f1e3579f3 o=d658b310ec027dff
-00630 d=15 p=3313081 Resign     s=040013fec3875451 o=a6faf9043f4fd3b7
+00630 d=15 p=3313081 Resign     s=040013fec3875451 o=f3cfdca19e6a7444
 final {"day":15,"match":{"outcome":{"reason":"resignation","type":"victory","winners":["player:3313080"]},"status":"finished"},"phase":"finished","players":[["3313081","resigned",20],["3313080","active",24]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1468032_landfall_2025-12-22.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1468032_landfall_2025-12-22.zip.snap
@@ -248,5 +248,5 @@ input_file: assets/replays/1468032_landfall_2025-12-22.zip
 04791 d=41 p=3422137 End        s=aecd52d74b142af1 o=30b522d3cac1e328
 04792 d=41 p=3418315 Resign     s=78ea1125601e2a26 o=de6a779eabbfed1d
 04793 d=41 p=3416925 End        s=78d167604ee688ae o=12bce0b7b82e8f22
-04794 d=41 p=3416925 Resign     s=727e897bcd1f065a o=ef87acd4bc474849
+04794 d=41 p=3416925 Resign     s=727e897bcd1f065a o=9cf32f457274244e
 final {"day":41,"match":{"outcome":{"reason":"resignation","type":"victory","winners":["team:A"]},"status":"finished"},"phase":"finished","players":[["3416848","active",21],["3417170","resigned",13],["3421988","active",17],["3422137","resigned",15],["3418315","active",18],["3416925","resigned",16]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1563018.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@1563018.zip.snap
@@ -37,5 +37,5 @@ input_file: assets/replays/1563018.zip
 00634 d=17 p=3650740 End        s=33e0c09a910e33fb o=87b449fe09c8b0cc
 00653 d=17 p=3625127 End        s=02c54c567dda2e83 o=8776798d430e42c2
 00687 d=18 p=3650740 End        s=01bebed862f34130 o=ea24f7d60fdff606
-00689 d=18 p=3650740 Resign     s=878078a56a4bb568 o=6d9d30f10ddabee1
+00689 d=18 p=3650740 Resign     s=878078a56a4bb568 o=d589fa9a0c8e12db
 final {"day":18,"match":{"outcome":{"reason":"resignation","type":"victory","winners":["player:3625127"]},"status":"finished"},"phase":"finished","players":[["3650740","resigned",18],["3625127","active",28]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@replay_1578186_d-day_2026-01-14.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@replay_1578186_d-day_2026-01-14.zip.snap
@@ -38,5 +38,5 @@ input_file: assets/replays/replay_1578186_d-day_2026-01-14.zip
 00765 d=17 p=3654564 End        s=afd285e70cc77ddc o=d5156dbc41a6eb8e
 00790 d=18 p=3653682 End        s=a3f9648db2ea84d6 o=e969c0ff0aaf25db
 00829 d=18 p=3654564 End        s=439f5740282b2452 o=bf25f9303cc64f51
-00846 d=18 p=3654564 Resign     s=7722668531323421 o=d855f96973fe811d
+00846 d=18 p=3654564 Resign     s=7722668531323421 o=19eda6dffb448b9e
 final {"day":18,"match":{"outcome":{"reason":"resignation","type":"victory","winners":["player:3653682"]},"status":"finished"},"phase":"finished","players":[["3653682","active",23],["3654564","resigned",17]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@replay_1714117_labs_2026-08-21.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@replay_1714117_labs_2026-08-21.zip.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/replay_1714117_labs_2026-08-21.zip
 ---
 00002 d=1 p=4117713 End        s=44dc0d3fbfa91509 o=cfe2127462398e53
 00003 d=2 p=4117712 End        s=db5628e6b3ca8c31 o=36a183a3dae036b8
-00005 d=2 p=4117712 Capt       s=9d149c778ac68b08 o=f45b102bd0b22551
+00005 d=2 p=4117712 Capt       s=9d149c778ac68b08 o=9c6442208e528da2
 final {"day":2,"match":{"outcome":{"reason":"lab-capture","type":"victory","winners":["player:4117712"]},"status":"finished"},"phase":"finished","players":[["4117712","active",4],["4117713","eliminated",0]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@replay_1714166_rout_2026-08-21.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@replay_1714166_rout_2026-08-21.zip.snap
@@ -3,5 +3,5 @@ source: crates/awvm-awbw/tests/integration/recorded_outcomes.rs
 expression: outcome.snapshot
 input_file: assets/replays/replay_1714166_rout_2026-08-21.zip
 ---
-00001 d=1 p=4117803 Fire       s=e77b0e0c5d757e72 o=f5db9b3c3ef2abb4
+00001 d=1 p=4117803 Fire       s=e77b0e0c5d757e72 o=a79cb840228cb9de
 final {"day":1,"match":{"outcome":{"reason":"rout","type":"victory","winners":["player:4117803"]},"status":"finished"},"phase":"finished","players":[["4117803","active",1],["4117804","eliminated",1]]}

--- a/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@replay_1714167_hq-cap_2026-08-21.zip.snap
+++ b/crates/awvm-awbw/tests/integration/snapshots/integration__recorded_outcomes__recorded_outcomes@replay_1714167_hq-cap_2026-08-21.zip.snap
@@ -7,5 +7,5 @@ input_file: assets/replays/replay_1714167_hq-cap_2026-08-21.zip
 00002 d=2 p=4117805 End        s=19db382e27d7af7f o=0f83b7b5e5292eb5
 00004 d=2 p=4117806 End        s=2540116608d48a11 o=bd3f5544528cbc32
 00005 d=3 p=4117805 End        s=9e939d19bd355c0a o=4d578da4439d1e4e
-00006 d=3 p=4117805 Capt       s=2e7af288d1535365 o=838160d04288b8c1
+00006 d=3 p=4117805 Capt       s=2e7af288d1535365 o=0c009efa32ef3f6b
 final {"day":3,"match":{"outcome":{"reason":"hq-capture","type":"victory","winners":["player:4117805"]},"status":"finished"},"phase":"finished","players":[["4117805","active",2],["4117806","eliminated",0]]}

--- a/crates/awvm/src/event.rs
+++ b/crates/awvm/src/event.rs
@@ -215,10 +215,17 @@ pub enum Event {
         player: PlayerId,
         offered: bool,
     },
+    /// A participant left the match, and why.
+    ///
+    /// The status alone does not say which defeat: a player eliminated while a
+    /// teammate plays on emits no `TeamEliminated` and no `MatchCompleted`, so
+    /// this is the only fact carrying their cause
+    /// (`spec/semantics/elimination.md`).
     PlayerStatusChanged {
         player: PlayerId,
         from: PlayerStatus,
         to: PlayerStatus,
+        reason: Reason,
     },
     TeamEliminated {
         team: TeamId,
@@ -292,6 +299,7 @@ impl Event {
             | Self::FundsChanged { reason, .. }
             | Self::PowerChargeChanged { reason, .. }
             | Self::WeatherChanged { reason, .. }
+            | Self::PlayerStatusChanged { reason, .. }
             | Self::TeamEliminated { reason, .. } => ObservedReason::Declared(reason.clone()),
             _ => ObservedReason::Kind(self.kind()),
         }

--- a/crates/awvm/src/generated/ruleset.rs
+++ b/crates/awvm/src/generated/ruleset.rs
@@ -1405,8 +1405,6 @@ pub enum KnownReason {
     LabCapture,
     #[serde(rename = "missile-silo")]
     MissileSilo,
-    #[serde(rename = "no-contest")]
-    NoContest,
     #[serde(rename = "random-weather")]
     RandomWeather,
     #[serde(rename = "resignation")]
@@ -1431,10 +1429,10 @@ pub enum KnownReason {
 
 impl KnownReason {
     /// Number of variants, and the length of any table keyed by this vocabulary.
-    pub const COUNT: usize = 29;
+    pub const COUNT: usize = 28;
 
     /// Every variant, in table order.
-    pub const ALL: [Self; 29] = [
+    pub const ALL: [Self; 28] = [
         Self::Aborted,
         Self::Agreement,
         Self::Attack,
@@ -1453,7 +1451,6 @@ impl KnownReason {
         Self::HqCapture,
         Self::LabCapture,
         Self::MissileSilo,
-        Self::NoContest,
         Self::RandomWeather,
         Self::Resignation,
         Self::Rout,
@@ -1487,7 +1484,6 @@ impl KnownReason {
             Self::HqCapture => "hq-capture",
             Self::LabCapture => "lab-capture",
             Self::MissileSilo => "missile-silo",
-            Self::NoContest => "no-contest",
             Self::RandomWeather => "random-weather",
             Self::Resignation => "resignation",
             Self::Rout => "rout",
@@ -1522,7 +1518,6 @@ impl KnownReason {
             "hq-capture" => Some(Self::HqCapture),
             "lab-capture" => Some(Self::LabCapture),
             "missile-silo" => Some(Self::MissileSilo),
-            "no-contest" => Some(Self::NoContest),
             "random-weather" => Some(Self::RandomWeather),
             "resignation" => Some(Self::Resignation),
             "rout" => Some(Self::Rout),
@@ -1633,19 +1628,16 @@ pub enum DrawReason {
     DayLimit,
     #[serde(rename = "agreement")]
     Agreement,
-    #[serde(rename = "no-contest")]
-    NoContest,
 }
 
 impl DrawReason {
     /// Number of variants, and the length of any table keyed by this vocabulary.
-    pub const COUNT: usize = 3;
+    pub const COUNT: usize = 2;
 
     /// Every variant, in table order.
-    pub const ALL: [Self; 3] = [
+    pub const ALL: [Self; 2] = [
         Self::DayLimit,
         Self::Agreement,
-        Self::NoContest,
     ];
 
     /// The identifier this variant is written as in the specification and on the wire.
@@ -1653,7 +1645,6 @@ impl DrawReason {
         match self {
             Self::DayLimit => "day-limit",
             Self::Agreement => "agreement",
-            Self::NoContest => "no-contest",
         }
     }
 
@@ -1662,7 +1653,6 @@ impl DrawReason {
         match id {
             "day-limit" => Some(Self::DayLimit),
             "agreement" => Some(Self::Agreement),
-            "no-contest" => Some(Self::NoContest),
             _ => None,
         }
     }
@@ -1698,7 +1688,6 @@ impl From<DrawReason> for KnownReason {
         match reason {
             DrawReason::DayLimit => KnownReason::DayLimit,
             DrawReason::Agreement => KnownReason::Agreement,
-            DrawReason::NoContest => KnownReason::NoContest,
         }
     }
 }

--- a/crates/awvm/src/transition.rs
+++ b/crates/awvm/src/transition.rs
@@ -2407,7 +2407,8 @@ mod tests {
                 Event::PlayerStatusChanged {
                     player: PlayerId::from("blue"),
                     from: PlayerStatus::Active,
-                    to: PlayerStatus::Eliminated
+                    to: PlayerStatus::Eliminated,
+                    reason: KnownReason::Rout.into()
                 },
                 Event::TeamEliminated {
                     team: crate::semantic::TeamId::from("blue-team"),

--- a/crates/awvm/src/transition/elimination.rs
+++ b/crates/awvm/src/transition/elimination.rs
@@ -33,6 +33,7 @@ pub(crate) fn eliminate_player(
         player: defeated_player.clone(),
         from: previous_status,
         to: state.player_mut(player_index).status,
+        reason: KnownReason::from(cause).into(),
     });
     if state
         .players

--- a/spec/fixtures/capture/capture-hq-victory.json
+++ b/spec/fixtures/capture/capture-hq-victory.json
@@ -162,7 +162,8 @@
             "type": "player-status-changed",
             "player": "blue",
             "from": "active",
-            "to": "eliminated"
+            "to": "eliminated",
+            "reason": "hq-capture"
           },
           { "type": "team-eliminated", "team": "blue-team", "reason": "hq-capture" },
           {

--- a/spec/fixtures/capture/lab-last-owned-lab.json
+++ b/spec/fixtures/capture/lab-last-owned-lab.json
@@ -344,6 +344,7 @@
           {
             "from": "active",
             "player": "blue",
+            "reason": "lab-capture",
             "to": "eliminated",
             "type": "player-status-changed"
           },

--- a/spec/fixtures/elimination/hq-capture-cascade-transfers.json
+++ b/spec/fixtures/elimination/hq-capture-cascade-transfers.json
@@ -225,7 +225,8 @@
             "type": "player-status-changed",
             "player": "blue",
             "from": "active",
-            "to": "eliminated"
+            "to": "eliminated",
+            "reason": "hq-capture"
           },
           { "type": "team-eliminated", "team": "blue-team", "reason": "hq-capture" },
           { "type": "unit-removed", "unit": 0, "reason": "elimination" },

--- a/spec/fixtures/elimination/resign-cascade-continues.json
+++ b/spec/fixtures/elimination/resign-cascade-continues.json
@@ -243,7 +243,13 @@
         },
         "events": [
           { "type": "phase-changed", "player": "red", "from": "unit-action", "to": "turn-end" },
-          { "type": "player-status-changed", "player": "red", "from": "active", "to": "resigned" },
+          {
+            "type": "player-status-changed",
+            "player": "red",
+            "from": "active",
+            "to": "resigned",
+            "reason": "resignation"
+          },
           { "type": "team-eliminated", "team": "red-team", "reason": "resignation" },
           { "type": "unit-removed", "unit": 2, "reason": "elimination" },
           { "type": "capture-changed", "position": [2, 1], "from": 15, "to": 20 },

--- a/spec/fixtures/elimination/resign-ends-match.json
+++ b/spec/fixtures/elimination/resign-ends-match.json
@@ -183,7 +183,13 @@
         },
         "events": [
           { "type": "phase-changed", "player": "red", "from": "unit-action", "to": "turn-end" },
-          { "type": "player-status-changed", "player": "red", "from": "active", "to": "resigned" },
+          {
+            "type": "player-status-changed",
+            "player": "red",
+            "from": "active",
+            "to": "resigned",
+            "reason": "resignation"
+          },
           { "type": "team-eliminated", "team": "red-team", "reason": "resignation" },
           {
             "type": "match-completed",

--- a/spec/fixtures/elimination/rout-crash-reselects-successor.json
+++ b/spec/fixtures/elimination/rout-crash-reselects-successor.json
@@ -229,7 +229,8 @@
             "type": "player-status-changed",
             "player": "blue",
             "from": "active",
-            "to": "eliminated"
+            "to": "eliminated",
+            "reason": "rout"
           },
           { "type": "team-eliminated", "team": "blue-team", "reason": "rout" },
           {

--- a/spec/model/events.md
+++ b/spec/model/events.md
@@ -58,6 +58,24 @@ consumer sees the tile's new identity before its new owner. The only transition
 in this revision that re-kinds a tile is the elimination cascade's demotion of a
 `capture-defeats-owner` property (`semantics/elimination.md`).
 
+## Facts that declare a reason
+
+Eleven event types carry a `reason`, a ruleset reason identifier naming why the
+fact occurred: `unit-action-changed`, `unit-removed`, `unit-damaged`,
+`unit-repaired`, `unit-resourced`, `tile-terrain-changed`, `funds-changed`,
+`power-charge-changed`, `weather-changed`, `player-status-changed`, and
+`team-eliminated`. Every other type omits it, and projection substitutes the
+event's own `type` where an observed element needs one (`model/observation.md`).
+
+An event declares a reason when its own payload cannot be re-derived from state
+and the surrounding stream. `player-status-changed` is in the list for that
+reason: a player eliminated while a teammate is still participating emits
+neither `team-eliminated` nor `match-completed`, so without its own `reason` the
+cause of that player's departure would leave no trace. Its value is the
+elimination cause fixed by `semantics/elimination.md`, and agrees with the
+`reason` of any `team-eliminated` or `match-completed` that follows in the same
+transition.
+
 ## `move-wait`
 
 An unobstructed accepted `move-wait` emits exactly one `unit-moved` event:

--- a/spec/model/state.md
+++ b/spec/model/state.md
@@ -176,8 +176,8 @@ a draw. A finished match has exactly one outcome. The outcome is a single union:
 
 - `victory` names one or more winning teams and a reason: `rout`, `hq-capture`,
   `lab-capture`, `capture-limit`, `day-limit`, `resignation`, or `timeout`;
-- `draw` names zero or more tied teams and a reason: `day-limit`, `agreement`,
-  or `no-contest`; or
+- `draw` names zero or more tied teams and a reason: `day-limit` or
+  `agreement`; or
 - `cancelled` has a stable machine-readable reason.
 
 Multiple winning/tied teams allow ruleset-defined alliances without rewriting

--- a/spec/rulesets/awbw/2026-07-10/reasons.json
+++ b/spec/rulesets/awbw/2026-07-10/reasons.json
@@ -19,7 +19,6 @@
     "hq-capture",
     "lab-capture",
     "missile-silo",
-    "no-contest",
     "random-weather",
     "resignation",
     "rout",
@@ -40,5 +39,5 @@
     "resignation",
     "timeout"
   ],
-  "draw": ["day-limit", "agreement", "no-contest"]
+  "draw": ["day-limit", "agreement"]
 }

--- a/spec/schema/event.schema.json
+++ b/spec/schema/event.schema.json
@@ -453,12 +453,13 @@
     "player-status-changed": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "player", "from", "to"],
+      "required": ["type", "player", "from", "to", "reason"],
       "properties": {
         "type": { "const": "player-status-changed" },
         "player": { "$ref": "#/$defs/player-id" },
         "from": { "enum": ["active", "resigned", "timed-out", "eliminated"] },
-        "to": { "enum": ["resigned", "timed-out", "eliminated"] }
+        "to": { "enum": ["resigned", "timed-out", "eliminated"] },
+        "reason": { "$ref": "#/$defs/reason" }
       }
     },
     "team-eliminated": {

--- a/spec/schema/state.schema.json
+++ b/spec/schema/state.schema.json
@@ -229,7 +229,7 @@
           "uniqueItems": true,
           "items": { "$ref": "common.schema.json#/$defs/team-id" }
         },
-        "reason": { "enum": ["day-limit", "agreement", "no-contest"] }
+        "reason": { "enum": ["day-limit", "agreement"] }
       }
     },
     "cancelled": {

--- a/spec/semantics/capture.md
+++ b/spec/semantics/capture.md
@@ -154,7 +154,8 @@ non-`null` previous owner `p`, execution continues immediately, before returning
 to `unit-action`:
 
 4. Set `S.players[p].status = eliminated` and emit
-   `player-status-changed { player: p, from: active, to: eliminated }`.
+   `player-status-changed { player: p, from: active, to: eliminated, reason:
+   "hq-capture" }`.
 5. If every player on `p`'s team is now eliminated, mark the team eliminated and
    emit `team-eliminated { team: p.team, reason: "hq-capture" }`.
 6. Evaluate the command-immediate victory checkpoint. When exactly one team
@@ -215,7 +216,7 @@ stream is:
 | 3 | `capture-changed` (`before`→`0`) | on completion; partial captures instead emit a single `before`→`after` here and stop |
 | 4 | `tile-owner-changed` | on completion |
 | 5 | `capture-changed` (`0`→`20`) | on completion |
-| 6 | `player-status-changed` | only on HQ completion with a non-`null` previous owner |
+| 6 | `player-status-changed` (`reason: "hq-capture"`) | only on HQ completion with a non-`null` previous owner |
 | 7 | `team-eliminated` | only when that player's whole team is now eliminated |
 | 8 | `match-completed` | only when exactly one team remains active |
 

--- a/spec/semantics/elimination.md
+++ b/spec/semantics/elimination.md
@@ -31,7 +31,10 @@ The causes in scope are `hq-capture` (from `semantics/capture.md`), `rout`, and
 - **`timeout`.** Timeout is a hosting-service clock/boot policy AWVM does not
   model. The `timed-out` player status and the `timeout` victory reason stay
   reserved for imported or server-projected terminal state. The procedure below
-  remains parameterized so an adapter can apply the same cascade.
+  remains parameterized so an adapter can apply the same cascade, and the
+  adapter contract below fixes what that adapter MUST produce. What stays out of
+  scope is the clock itself — when a timeout fires — not the shape of its
+  result.
 - **`lab-capture` and `capture-limit`.** Both are capture-driven checkpoints
   whose own conditions are unspecified. Once either fires it invokes exactly the
   procedure below, but neither is reachable in this feature.
@@ -96,9 +99,13 @@ For state `S`:
   `capture-defeats-owner` trait from a property that has served its purpose, so
   a demoted HQ can never eliminate its new owner.
 - The **cause** of an elimination is one of `rout`, `hq-capture`, or
-  `resignation`. It is not stored on the player record — `model/state.md` keeps
-  cause in history — and travels only in the `team-eliminated` and
-  `match-completed` events.
+  `resignation`; a host adapter adds `timeout` under the adapter contract
+  below. It is not stored on the player record — `model/state.md` keeps cause
+  in history — and travels in the `player-status-changed`, `team-eliminated`,
+  and `match-completed` events. Only the first of those is
+  always emitted: a player eliminated while a teammate plays on produces
+  neither of the other two, so `player-status-changed` is the one fact that
+  carries every elimination's cause.
 - The **beneficiary** of an elimination is the player who inherits the
   eliminated player's properties, or `null`. It is the capturing player when the
   cause is `hq-capture`, and `null` for every other cause.
@@ -114,17 +121,33 @@ The steps run in this exact order.
 
 ### 1. Player status
 
-Set `S.players[p].status` to `resigned` when the cause is `resignation`, and to
-`eliminated` for every other cause. Emit
+Set `S.players[p].status` to `resigned` when the cause is `resignation`, to
+`timed-out` when an adapter supplies the cause `timeout`, and to `eliminated`
+for every other cause. Emit
 
 ```json
-{ "type": "player-status-changed", "player": "blue", "from": "active", "to": "eliminated" }
+{
+  "type": "player-status-changed",
+  "player": "blue",
+  "from": "active",
+  "to": "eliminated",
+  "reason": "rout"
+}
 ```
 
-The status distinguishes a voluntary departure from a defeat; it does not record
-which defeat. `resigned` and `eliminated` are equivalent for every rule in this
-revision: neither participates, both make their team non-surviving, and both
-receive the identical cascade.
+`reason` is the cause, written as its reason identifier. The status
+distinguishes a voluntary departure from a defeat and the reason records which
+defeat, because the status alone cannot: `resigned` and `eliminated` are
+equivalent for every rule in this revision — neither participates, both make
+their team non-surviving, and both receive the identical cascade — and
+`eliminated` covers `rout` and `hq-capture` alike.
+
+The reason is carried here, and not left to the two later events, because
+neither is guaranteed to follow. `team-eliminated` fires only when the player's
+whole team stopped participating and `match-completed` only when the match
+ended, so in a team match a consumer recording a per-player result would
+otherwise have no cause to record. When a later event does follow, its reason
+is the same value; the events agree by construction.
 
 ### 2. Team elimination
 
@@ -240,6 +263,10 @@ its three causes accordingly.
 | `resignation` | within `resign`'s execution, before its boundary loop | this document |
 | `rout` | command-immediate for a command-caused removal; directly after the automatic hook for a hook-caused removal | this document |
 
+`timeout` has no row: it is not evaluated at any AWVM checkpoint. A host adapter
+decides it on its own clock and applies the procedure, as the adapter contract
+below fixes.
+
 ### The rout condition
 
 A player is routed when a transition removes their **last** living unit. The
@@ -345,6 +372,109 @@ are neutral before the successor's income is computed, so a successor who owned
 none of those properties gains nothing from the resignation — neutral property
 produces no income for anyone.
 
+## The `timeout` adapter contract
+
+AWVM does not model a clock. *When* a player's time expires is a
+hosting-service policy — bank size, boot delay, grace on disconnect — and no
+AWVM command, checkpoint, or random token expresses it. `resign`'s
+`AUTHORITY_REQUIRED` says as much from the command side: host-service timeout
+handling is outside the command surface, and this document adds no `time-out`
+command to reach it.
+
+What *is* specified is the shape of the result. An **adapter** is the host-side
+component that decides a player has timed out; this section fixes what it MUST
+then produce, so that a booted player leaves the same shaped state and event
+stream as a routed or resigned one, and a consumer recording match results needs
+no separate code path for the cause. It is a clarification of the existing
+procedure and introduces no new behavior, event type, or vocabulary.
+
+### The adapter runs the same procedure
+
+An adapter that has determined player `p` timed out invokes
+
+```text
+eliminate(S, p, "timeout", null)
+```
+
+exactly as specified above, with one substitution: step 1 sets
+`S.players[p].status` to `timed-out` rather than `eliminated`. Every other step
+is unchanged, and the beneficiary is `null` as it is for every cause but
+`hq-capture`.
+
+1. **Status.** Emit
+   `player-status-changed { player: p, from: "active", to: "timed-out", reason:
+   "timeout" }`.
+2. **Team elimination.** Emit `team-eliminated { team, reason: "timeout" }` when
+   no member of `p`'s team is still participating, and nothing otherwise.
+3. **Victory checkpoint.** If exactly one team now survives, that team wins with
+   the cause mapped identically to every other cause:
+   `{ "type": "victory", "winners": ["red-team"], "reason": "timeout" }`.
+   `timeout` is already a member of the `victory` reason vocabulary
+   (`rulesets/awbw/2026-07-10/reasons.json`), so a 1v1 timeout produces exactly
+   that outcome. Execution stops here on the same terms as any other cause: the
+   loser's units stay on the board and their properties stay owned, frozen at
+   the winning instant.
+4. **The cascade.** Reached only when two or more teams survive, and run in
+   full — an interrupted capture reset to `20`, every unit removed in ascending
+   unit-ID order, then every property in board order reset, a demotable HQ
+   demoted to its `elimination_replacement`, and every property disposed. With a
+   `null` beneficiary the disposition is neutral throughout. A timeout is not a
+   capture and enriches nobody: no `tile-owner-changed` names a player as the
+   new owner.
+
+The event ordering table below applies to a timeout unchanged, with row 1
+carrying `reason: "timeout"`.
+
+### `timed-out` is not a distinct standing
+
+`timed-out`, `resigned`, and `eliminated` are equivalent for every rule in this
+revision, extending the equivalence step 1 states for the first two. None
+participates in turn order, each makes its team non-surviving, each is skipped
+by successor selection, and each receives the identical cascade. No rule
+branches on which of the three a player carries.
+
+The three statuses are worth keeping distinct only because they record *how* a
+seat's run ended for a reader, and even that is a coarse record: `eliminated`
+covers `rout`, `hq-capture`, and `lab-capture` alike. A consumer that needs the
+cause reads the `reason` of `player-status-changed` (step 1), never the status.
+
+### The boundary
+
+A timeout normally strikes the player holding the turn, and the boundary must
+then be finished — otherwise the match sits in `unit-action` with a
+non-participating player as `S.turn.active_player`, a position successor
+selection would never have produced, since it skips every player whose status is
+not `active` (`model/phases.md`). Nothing would advance the match from there.
+
+- **`p` is `S.turn.active_player`.** The adapter applies exactly the `resign`
+  execution above, substituting the cause: set `S.turn.phase = turn-end` and
+  emit `phase-changed { player: p, from: unit-action, to: turn-end }`; run
+  `eliminate(S, p, "timeout", null)`; and, if the match continues, resume the
+  `semantics/turn.md` reduction from successor selection with the
+  `turn-hooks.md` hooks in their fixed positions. `p` is no longer selectable,
+  so the scan skips them. This mirrors AWBW, where a booted player's turn ends
+  and play passes on exactly as a resignation passes it.
+- **`p` is not the active player.** `S.turn` is untouched. No `phase-changed`,
+  `turn-selected`, or `day-advanced` is emitted, and the procedure's own events
+  are the whole transition. A host whose clock can expire off-turn takes this
+  branch; one that only boots on-turn never does.
+
+A timeout that eliminates the active player during their own `turn-start` — a
+host policy that boots on the boundary rather than during `unit-action` — takes
+the rout-during-`turn-start` resumption above verbatim, since that section is
+written on the elimination, not on the cause.
+
+### Conformance
+
+The clock is not conformance-testable, so no `elimination-v1` fixture exercises
+timeout and an implementation claiming `elimination-v1` is not required to ship
+an adapter. This contract fixes admissibility rather than conformance: a state
+carrying `timed-out`, or a `timeout` victory outcome, is a valid AWVM state; the
+cascade that produced it is the cascade specified here; and a consumer may read
+a timeout elimination with the same rules it reads a rout. Should a future
+revision bring the clock inside AWVM, it adds the checkpoint that fires this
+procedure and does not change the procedure.
+
 ## Event ordering
 
 The procedure's events, in order, for an elimination that does **not** end the
@@ -352,7 +482,7 @@ match:
 
 | # | Event | Emitted when |
 | --- | --- | --- |
-| 1 | `player-status-changed` | always |
+| 1 | `player-status-changed` (`reason: <cause>`) | always |
 | 2 | `team-eliminated` | only when the player's whole team stopped participating |
 | 3 | `capture-changed` (to `20`) | per removed unit that was a current capturer, immediately before its removal |
 | 4 | `unit-removed` (`reason: "elimination"`) | once per owned unit, ascending unit ID, interleaved with row 3 |
@@ -402,8 +532,10 @@ day-limit outcome stays deferred for want of a scoring rule.
 
 `rout`, `hq-capture`, and `resignation` are the terminal outcomes this feature
 can produce, each named by the cause of the elimination that left one surviving
-team. `lab-capture`, `capture-limit`, `day-limit`, `timeout`, and every `draw`
-are other features' checkpoints and are not reachable here.
+team. `lab-capture`, `capture-limit`, `day-limit`, and every `draw` are other
+features' checkpoints and are not reachable here. `timeout` is reachable only
+through the adapter contract above: no command and no checkpoint in this
+document produces it, and no fixture claims it.
 
 ## Evidence
 
@@ -470,9 +602,17 @@ Corroborated implementation:
 
 Known deferral:
 
-- The `timeout` cause, `lab-capture`, `capture-limit`, day-limit outcome naming,
-  the zero-active-team state, simultaneous elimination precedence, and the fate
-  of an eliminated player's power charge and commander-sourced weather all
-  require evidence this corpus does not contain, and are excluded rather than
-  guessed. WarsWorld's own source marks the last of these `TODO what happens
-  with olaf snow and other CO powers?`.
+- `lab-capture`, `capture-limit`, day-limit outcome naming, the zero-active-team
+  state, simultaneous elimination precedence, and the fate of an eliminated
+  player's power charge and commander-sourced weather all require evidence this
+  corpus does not contain, and are excluded rather than guessed. WarsWorld's own
+  source marks the last of these `TODO what happens with olaf snow and other CO
+  powers?`.
+- The `timeout` **clock** is deferred for a different reason: it is a hosting
+  policy, not an AWBW rule, and no corpus can supply it. Its *result* is not
+  deferred. The wiki's account of resignation — a departing player is
+  "eliminated from the game as if they were routed" — and the non-capture
+  cascade it fixes apply to a booted player on the same terms, which is what the
+  adapter contract states. No replay in the corpus ends by timeout, so its
+  boundary handling is specified by analogy with the observed `Resign` payload
+  rather than observed directly.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recorded replays now recognize terminal outcomes from captures, combat, resignations, and turn-end game-over events.
  * Player status-change events include specific departure or elimination reasons, such as resignation, rout, timeout, or HQ capture.
* **Behavior Changes**
  * Draw outcomes now support only “day-limit” and “agreement”; “no-contest” is no longer valid.
  * Timeout handling is formally supported, including the resulting timed-out status.
* **Documentation**
  * Updated event, state, capture, and elimination specifications to document reason requirements and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->