### PR TITLE
Fix ci by pinning nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
           rust: beta
         - build: nightly
           os: ubuntu-latest
-          rust: nightly
+          # Current nightly does not compile Bevy 0.19.1.
+          rust: nightly-2026-07-09
         - build: macos
           os: macos-latest
           rust: stable


### PR DESCRIPTION
@coderabbitai skip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly CI validation to use a pinned Rust toolchain.
  * Documented the current compatibility limitation with Bevy 0.19.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->