### PR TITLE
Add threat map and denial model in ai

### DIFF
--- a/crates/awbrn-ai/src/agents/greedy.rs
+++ b/crates/awbrn-ai/src/agents/greedy.rs
@@ -23,10 +23,15 @@
 //! set that is nearest its best target, which is the same answer on open
 //! ground and a slightly worse one across a mountain.
 //!
-//! What this agent does not do: it does not read the threat a tile is under,
-//! so it walks into fire that a unit one tile further back is safe from. That
-//! is the influence map, and it is the next tier rather than this one.
+//! Against that sum the agent prices what a tile is exposed to. The threat
+//! map ([`crate::threat`]) says what the enemy can take off each tile, by the
+//! kind of unit that stands there, and every arrival pays it. That is what
+//! stops the agent parking an artillery where a tank can reach it, and it is
+//! what prices the reply to a trade: a tank that kills a weak soldier and
+//! stops where three tanks can answer made a bad exchange, and the forecast
+//! alone scores it as a good one.
 
+use awvm::combat::Forecast;
 use awvm::ruleset::{self, Terrain, TerrainTrait, UnitKind};
 use awvm::semantic::{
     CellIdx, Location, Observation, PlayerIdx, Pos, State, Tile, TileOwner, Unit,
@@ -35,6 +40,7 @@ use awvm::session::{Legal, Order, OrderKind, Session, UnitIdx};
 
 use crate::agent::{Agent, Play};
 use crate::rng::Rng;
+use crate::threat::{self, ThreatMap};
 
 /// What each objective is worth, in one place.
 ///
@@ -106,6 +112,45 @@ pub struct Weights {
     /// scaled by that enemy's cost. Without it an army with no target in
     /// range stands still, and a greedy agent that never closes never trades.
     pub advance: f64,
+    /// Stopping an enemy capturer, as a share of the weight of the property
+    /// it stands on.
+    ///
+    /// A property is worth what it is worth whichever way it changes hands,
+    /// so this is priced against the same weights a capture of ours is. It is
+    /// what makes an enemy soldier standing on our base worth killing, when
+    /// the funds it costs to replace say it is worth almost nothing: an
+    /// infantry is 1000 funds and a base is not.
+    ///
+    /// The headquarters needs no special arm. `property_weight` already
+    /// answers `hq` for it, so a soldier one turn from taking our
+    /// headquarters outranks every other play on the board, which is what it
+    /// is.
+    pub deny: f64,
+    /// The share of that when the property is neutral rather than ours.
+    ///
+    /// Denying a neutral property is worth less than holding one we already
+    /// have: they gain it, but we have not lost anything we held.
+    pub deny_neutral: f64,
+    /// The decay for each further turn an enemy needs to finish its capture.
+    ///
+    /// A soldier that completes on its next turn is the emergency. One that
+    /// needs four more turns is a problem for a later turn, and the board may
+    /// answer it without a strike.
+    pub deny_decay: f64,
+
+    /// One point of funds a tile is exposed to, as a score. It is priced
+    /// level with a point of funds won in an exchange: ground the enemy can
+    /// take a whole tank off is worth as much to avoid as a whole tank is
+    /// worth to kill.
+    pub threat: f64,
+    /// The share of the deferred threat layer that is counted.
+    ///
+    /// The deferred layer is the ring an indirect unit opens only after it
+    /// has spent a turn walking to a firing position, so it is ground that is
+    /// safe to hold for one turn. Counting it whole gives an agent that never
+    /// closes on an artillery, which is the one thing that answers one.
+    pub deferred_threat: f64,
+
     /// A commander power, whenever the position offers one. The power is
     /// worth more on some turns than on others, and reading which is a term
     /// this tier does not carry.
@@ -136,8 +181,38 @@ impl Weights {
 
         capturer_shortfall: 150.0,
         advance: 0.01,
+        deny: 1.0,
+        deny_neutral: 0.5,
+        deny_decay: 0.5,
+        threat: 0.02,
+        deferred_threat: 0.35,
         power: 200.0,
         supply: 10.0,
+    };
+
+    /// The threat map, but with an enemy capture priced only by what the
+    /// capturer costs to replace.
+    ///
+    /// The baseline the denial term is measured against.
+    pub const WITHOUT_DENIAL: Self = Self {
+        deny: 0.0,
+        ..Self::DEFAULT
+    };
+
+    /// The same ranking again with what a tile is exposed to priced at
+    /// nothing.
+    ///
+    /// This is what tier 1 landed with: neither the threat map nor the
+    /// denial term. It is the baseline the arena measures the threat map
+    /// against, and it holds one term less than [`Weights::WITHOUT_DENIAL`]
+    /// so that the pair measures the threat map and nothing else. Keeping it
+    /// named rather than deleted is what lets a later change be compared with
+    /// the score that is already published rather than with a rebuilt
+    /// approximation of it.
+    pub const THREATLESS: Self = Self {
+        threat: 0.0,
+        deferred_threat: 0.0,
+        ..Self::WITHOUT_DENIAL
     };
 }
 
@@ -165,6 +240,11 @@ pub struct GreedyAgent {
     decay: Vec<f64>,
     /// The unit standing on each tile, by its index in the roster.
     occupant: Vec<Option<u16>>,
+    /// What the enemy can take off each tile. Built once for each position,
+    /// which is once for each play: the harness applies one command between
+    /// calls, and a command moves a unit, so a map held across calls would be
+    /// a map of a board that is gone.
+    threat: ThreatMap,
 }
 
 impl GreedyAgent {
@@ -181,6 +261,7 @@ impl GreedyAgent {
             advance_field: Vec::new(),
             decay: Vec::new(),
             occupant: Vec::new(),
+            threat: ThreatMap::new(),
         }
     }
 
@@ -208,6 +289,7 @@ impl Agent for GreedyAgent {
             advance_field,
             decay,
             occupant,
+            threat,
         } = self;
 
         let board = Board {
@@ -219,6 +301,12 @@ impl Agent for GreedyAgent {
         board.occupants(occupant);
         board.capture_field(capture_field, decay, occupant);
         board.advance_field(advance_field, decay);
+        // A map priced at nothing is never read, so it is never built. That
+        // is what keeps the threatless weighting at the throughput it was
+        // measured at, and it is what makes the two a comparison of one term.
+        if weights.threat != 0.0 {
+            threat.build(state, seat);
+        }
 
         orders.clear();
         session.legal().orders(orders);
@@ -230,6 +318,7 @@ impl Agent for GreedyAgent {
             capture_field,
             advance_field,
             occupant,
+            threat,
             shortfall: board.capturer_shortfall(occupant),
         };
 
@@ -285,16 +374,7 @@ impl Board<'_> {
 
     /// Whether `seat` is one this player is at war with.
     fn hostile(&self, other: PlayerIdx) -> bool {
-        let team = |seat: PlayerIdx| {
-            self.state
-                .players
-                .get(seat.get())
-                .map(|player| &player.team)
-        };
-        match (team(self.seat), team(other)) {
-            (Some(mine), Some(theirs)) => mine != theirs,
-            _ => false,
-        }
+        threat::hostile(self.state, self.seat, other)
     }
 
     /// What one property is worth as a place to walk to.
@@ -505,6 +585,7 @@ struct Scorer<'a> {
     capture_field: &'a [f64],
     advance_field: &'a [f64],
     occupant: &'a [Option<u16>],
+    threat: &'a ThreatMap,
     shortfall: f64,
 }
 
@@ -588,8 +669,7 @@ impl Scorer<'_> {
             // A fogged defender has no exact health, so there is nothing to
             // forecast against. A strike is still usually worth making, and
             // this says so without pretending to know how much.
-            return weights.blind_attack * weights.funds * cost(defender.kind)
-                + self.arrival(order);
+            return weights.blind_attack * weights.funds * cost(defender.kind) + self.pull(order);
         };
 
         let mean = |low: u16, high: u16| f64::from(low + high) / 2.0;
@@ -612,15 +692,98 @@ impl Scorer<'_> {
         if taken * 100.0 >= f64::from(forecast.attacker_hp) {
             score -= weights.unit_count;
         }
-        score + self.arrival(order)
+        score += self.denial(target, defender, &forecast);
+        // The pull of the tile, and not the arrival: a strike is not charged
+        // for what the tile it fires from is exposed to. The forecast above
+        // already prices the reply, and charging the exposure on top prices
+        // the same exchange twice. The arena is plain about it — the more of
+        // the exposure an attack pays, the worse the agent plays, and it is
+        // worst at the whole of it.
+        score + self.pull(order)
+    }
+
+    /// What stopping this defender's capture is worth.
+    ///
+    /// Only a capture-capable enemy standing on a property counts, and only a
+    /// property we would rather it did not have. The value is the property's
+    /// own weight, scaled by how much later this strike makes the capture:
+    /// destroying the unit resets the tile to whole (`reset_capture_on_removal`
+    /// in `transition/attack.rs`), and merely damaging it slows the unit,
+    /// because the ruleset spends visible health for capture points.
+    ///
+    /// The worst roll is what proves a kill, the same rule the unit count
+    /// above plays by. A strike that only might destroy the capturer is
+    /// scored as the damage it certainly does.
+    fn denial(&self, target: CellIdx, defender: &Unit, forecast: &Forecast) -> f64 {
+        let weights = self.weights();
+        if !ruleset::profile(defender.kind).can_capture {
+            return 0.0;
+        }
+        let Some(position) = self.board.position(target) else {
+            return 0.0;
+        };
+        let Some(tile) = self.board.state.board.get(position) else {
+            return 0.0;
+        };
+        if !ruleset::terrain_has(tile.terrain, TerrainTrait::Capturable) {
+            return 0.0;
+        }
+        // A property of ours is a loss. A neutral one is a gain we are denied.
+        // One held by somebody else at war with us is neither.
+        let stake = match tile.owner {
+            TileOwner::Owned(holder) if holder == self.board.seat => 1.0,
+            TileOwner::Neutral => weights.deny_neutral,
+            _ => return 0.0,
+        };
+
+        let points = tile.capture_points.unwrap_or(WHOLE_PROPERTY);
+        let before = self.urgency(points, capture_progress(defender));
+        // A kill resets the tile, so the whole of the urgency goes away. The
+        // worst roll is what proves one.
+        let after = if f64::from(forecast.attack.low) >= f64::from(forecast.target_hp) {
+            0.0
+        } else {
+            let dealt = u8::try_from(forecast.attack.low).unwrap_or(u8::MAX);
+            self.urgency(
+                points,
+                forecast.target_hp.saturating_sub(dealt).div_ceil(10),
+            )
+        };
+
+        weights.deny * stake * self.board.property_weight(tile.terrain) * (before - after)
+    }
+
+    /// How near a capture of `points` is, for a unit taking `progress` a turn.
+    ///
+    /// One at the next turn, and `deny_decay` for each turn after that. A unit
+    /// that takes nothing a turn never finishes and is worth nothing to stop.
+    fn urgency(&self, points: u8, progress: u8) -> f64 {
+        if progress == 0 {
+            return 0.0;
+        }
+        let turns = points.div_ceil(progress);
+        self.weights()
+            .deny_decay
+            .powi(i32::from(turns.saturating_sub(1)))
     }
 
     /// What arriving on a tile is worth, whatever the unit does there.
     ///
-    /// A unit that captures walks at properties; a unit that fights walks at
-    /// the enemy. This is the whole of the agent's movement: the destination
-    /// of the reachable set with the strongest pull.
+    /// The pull of the destination, less what the enemy can take off it. This
+    /// is the whole of the agent's movement.
     fn arrival(&self, order: Order) -> f64 {
+        let Some(unit) = order.unit().and_then(|index| self.unit(index)) else {
+            return 0.0;
+        };
+        self.pull(order) - self.exposure(order.destination(), unit)
+    }
+
+    /// How much the destination wants this unit, before any exposure.
+    ///
+    /// A unit that captures walks at properties; a unit that fights walks at
+    /// the enemy. The destination of the reachable set with the strongest
+    /// pull is where the unit goes.
+    fn pull(&self, order: Order) -> f64 {
         let Some(unit) = order.unit().and_then(|index| self.unit(index)) else {
             return 0.0;
         };
@@ -631,6 +794,20 @@ impl Scorer<'_> {
             self.advance_field
         };
         field.get(cell).copied().unwrap_or(0.0)
+    }
+
+    /// What standing on `cell` costs this unit, in score.
+    ///
+    /// The two layers of the threat map are read apart and the deferred one
+    /// is discounted, because ground an artillery can only shoot after it has
+    /// walked to a firing position is ground this unit may safely hold for a
+    /// turn. Merging them gives an agent that never closes.
+    ///
+    fn exposure(&self, cell: CellIdx, unit: &Unit) -> f64 {
+        let weights = self.weights();
+        let immediate = self.threat.immediate(cell, unit.kind);
+        let deferred = self.threat.deferred(cell, unit.kind);
+        weights.threat * (immediate + weights.deferred_threat * deferred)
     }
 
     /// What building this kind is worth.
@@ -654,7 +831,23 @@ impl Scorer<'_> {
 mod tests {
     use super::*;
     use crate::board::arena;
-    use awvm::semantic::{AwbwVisibility, observe};
+    use awvm::semantic::{AwbwVisibility, Concealment, UnitAction, UnitId, observe};
+
+    /// One unit of `kind`, at whole health, standing where it is put.
+    fn test_unit(kind: UnitKind, position: Pos, owner: PlayerIdx) -> Unit {
+        let profile = ruleset::profile(kind);
+        Unit {
+            id: UnitId::new(1),
+            kind,
+            owner,
+            hp: 100,
+            fuel: profile.max_fuel,
+            ammo: profile.max_ammo,
+            action: UnitAction::Ready,
+            concealment: Concealment::Exposed,
+            location: Location::Board { position },
+        }
+    }
 
     /// The priorities, read back off the weights.
     #[test]
@@ -720,6 +913,179 @@ mod tests {
             ruleset::profile(kind).can_capture,
             "the opening build was a {kind:?}, which captures nothing"
         );
+    }
+
+    /// The emergency the priorities did not name: an enemy soldier standing
+    /// on our headquarters, one turn from winning the match.
+    ///
+    /// Tier 1 scored that strike at what an infantry costs to replace, which
+    /// is 1000 funds and loses to walking one tile nearer a property. So the
+    /// one unit that could answer spent its turn capturing something else and
+    /// the headquarters fell. Production is not what was in the way — a build
+    /// costs no unit its turn, and the agent still built. What was in the way
+    /// is that a unit acts once, and capture outbid defence.
+    ///
+    /// This drives the whole turn rather than reading the first play, because
+    /// the first play is not the question. The question is what the one unit
+    /// beside the headquarters did with its turn.
+    #[test]
+    fn the_unit_beside_our_headquarters_answers_instead_of_walking_away() {
+        let (mut session, guard, raider) = headquarters_under_capture();
+        let mut agent = GreedyAgent::from_seed(1);
+        let mut entropy = Rng::from_seed(7);
+        let mut answered = false;
+
+        for _ in 0..12 {
+            let state = session.state();
+            let Ok(view) = observe(&AwbwVisibility, state, &state.turn.active_player) else {
+                break;
+            };
+            let Some(play) = agent.act(&view) else { break };
+            if play.unit() == Some(guard) {
+                answered = matches!(play.kind(), OrderKind::Attack(_));
+            }
+            let Some(command) = play.command(&session) else {
+                break;
+            };
+            if session
+                .apply_command::<()>(command, &mut entropy, &mut ())
+                .is_err()
+            {
+                break;
+            }
+        }
+
+        assert!(
+            answered,
+            "the unit beside our headquarters spent its turn on something \
+             other than the soldier taking it"
+        );
+        // The strike does not have to kill. A damaged capturer takes fewer
+        // capture points a turn, which is the whole of what denial buys here.
+        assert!(
+            session
+                .state()
+                .units
+                .get(raider)
+                .is_some_and(|unit| unit.hp < 100),
+            "the raider was not touched"
+        );
+    }
+
+    /// Our headquarters, one enemy turn from falling, and one unit of ours
+    /// beside it. Every other unit is off the board so that the position asks
+    /// exactly one question.
+    fn headquarters_under_capture() -> (Session, UnitId, UnitId) {
+        let mut state = arena(false, 1);
+        let ours = state
+            .players
+            .seat(&state.turn.active_player)
+            .expect("the active player holds a seat");
+        let theirs = state
+            .players
+            .seats()
+            .map(|(seat, _)| seat)
+            .find(|seat| *seat != ours)
+            .expect("the arena seats two players");
+
+        let hq = state
+            .board
+            .iter()
+            .find(|(_, tile)| {
+                ruleset::terrain_has(tile.terrain, TerrainTrait::CaptureDefeatsOwner)
+                    && tile.owner == TileOwner::Owned(ours)
+            })
+            .map(|(position, _)| position)
+            .expect("the arena gives each seat a headquarters");
+        let beside = hq
+            .orthogonal()
+            .find(|position| {
+                state.board.get(*position).is_some_and(|tile| {
+                    ruleset::movement_cost(
+                        tile.terrain,
+                        state.weather.kind,
+                        ruleset::profile(UnitKind::Infantry).movement_class,
+                    )
+                    .is_some()
+                })
+            })
+            .expect("the headquarters has a walkable neighbour");
+
+        let (guard, raider) = (UnitId::new(9_002), UnitId::new(9_001));
+        state.units.retain(|_| false);
+        let mut soldier = test_unit(UnitKind::Infantry, hq, theirs);
+        soldier.id = raider;
+        state.units.push(soldier);
+        let mut ours_soldier = test_unit(UnitKind::Infantry, beside, ours);
+        ours_soldier.id = guard;
+        state.units.push(ours_soldier);
+        state.board.tile_mut(hq).capture_points = Some(10);
+
+        (Session::new(state), guard, raider)
+    }
+
+    /// The urgency ramp, and what it is multiplied by.
+    #[test]
+    fn a_capture_is_worth_more_to_stop_the_sooner_it_lands() {
+        let weights = Weights::DEFAULT;
+        // A property is worth what it is worth whichever way it changes hands,
+        // so stopping a capture of our base is priced against making one.
+        assert_eq!(weights.deny, weights.capture);
+        // Denying a neutral property is worth less than keeping one we hold.
+        assert!(weights.deny_neutral < 1.0);
+        // Each further turn the enemy needs is worth less.
+        assert!(weights.deny_decay < 1.0);
+        // The headquarters needs no arm of its own: it carries `hq`, which is
+        // not on the same scale as the properties below it.
+        assert!(weights.hq > weights.land * 10.0);
+    }
+
+    /// The guard that skips an unpriced map must be invisible.
+    ///
+    /// The threatless weighting is the baseline every measurement of the
+    /// threat map is read against, so it has to play the game tier 1 played.
+    /// A map priced at nothing and a map never built must give the same game.
+    #[test]
+    fn a_map_priced_at_nothing_changes_no_decision() {
+        use crate::harness::{Limits, play};
+        use awvm::session::Session;
+
+        fn game(weights: Weights) -> String {
+            let mut first = GreedyAgent::with_weights(1, weights);
+            let mut second = GreedyAgent::with_weights(2, weights);
+            let mut agents: [&mut dyn Agent; 2] = [&mut first, &mut second];
+            let state = arena(false, 1);
+            let mut session = Session::new(state.clone());
+            let record = play(
+                state,
+                &mut session,
+                &mut agents,
+                &mut Rng::from_seed(3),
+                Limits {
+                    days: 20,
+                    ..Limits::default()
+                },
+            );
+            let end = session.state();
+            format!(
+                "{:?} {} {:?}",
+                record.days,
+                end.units.iter().count(),
+                end.players
+                    .seats()
+                    .map(|(_, player)| player.funds)
+                    .collect::<Vec<_>>()
+            )
+        }
+
+        // A threat priced too low to outrank anything still builds the map
+        // and still reads it, which is the half of the guard under test.
+        let read = game(Weights {
+            threat: f64::MIN_POSITIVE,
+            deferred_threat: 0.0,
+            ..Weights::THREATLESS
+        });
+        assert_eq!(game(Weights::THREATLESS), read);
     }
 
     /// A board with nothing left to take is a board that builds soldiers no

--- a/crates/awbrn-ai/src/bin/arena.rs
+++ b/crates/awbrn-ai/src/bin/arena.rs
@@ -15,7 +15,7 @@
 use std::time::Instant;
 
 use awbrn_ai::agent::Agent;
-use awbrn_ai::agents::{GreedyAgent, RandomAgent};
+use awbrn_ai::agents::{GreedyAgent, RandomAgent, Weights};
 use awbrn_ai::board::arena;
 use awbrn_ai::harness::{Limits, Record, play};
 use awbrn_ai::rng::Rng;
@@ -48,7 +48,7 @@ usage: arena [--seed N] [--games N] [--fog] [--day-cap N] [--first NAME] [--seco
   --first NAME   The agent under test. Default random.
   --second NAME  The agent it plays. Default random.
 
-agents: random, greedy";
+agents: random, greedy, greedy-threat, greedy-deny";
 
 struct Options {
     seed: u64,
@@ -113,7 +113,12 @@ fn parse_number<T: std::str::FromStr>(text: &str) -> Result<T, String> {
 }
 
 /// The agents this binary can seat, by the name the arguments use.
-const AGENTS: [&str; 2] = ["random", "greedy"];
+///
+/// Each name adds one term to the one before it, so any adjacent pair is the
+/// measurement of that term and nothing else. `greedy` is tier 1 as it
+/// landed, `greedy-threat` adds the threat map, and `greedy-deny` adds the
+/// price of stopping an enemy capture.
+const AGENTS: [&str; 4] = ["random", "greedy", "greedy-threat", "greedy-deny"];
 
 fn agent_name(name: &str) -> Result<&'static str, String> {
     AGENTS
@@ -130,7 +135,9 @@ fn agent_name(name: &str) -> Result<&'static str, String> {
 fn build(name: &str, seed: u64) -> Box<dyn Agent> {
     match name {
         "random" => Box::new(RandomAgent::from_seed(seed)),
-        "greedy" => Box::new(GreedyAgent::from_seed(seed)),
+        "greedy" => Box::new(GreedyAgent::with_weights(seed, Weights::THREATLESS)),
+        "greedy-threat" => Box::new(GreedyAgent::with_weights(seed, Weights::WITHOUT_DENIAL)),
+        "greedy-deny" => Box::new(GreedyAgent::from_seed(seed)),
         other => unreachable!("{other} passed the argument check"),
     }
 }

--- a/crates/awbrn-ai/src/lib.rs
+++ b/crates/awbrn-ai/src/lib.rs
@@ -19,7 +19,9 @@ pub mod agents;
 pub mod board;
 pub mod harness;
 pub mod rng;
+pub mod threat;
 
 pub use agent::{Agent, Play};
 pub use harness::{Limits, Record, play};
 pub use rng::Rng;
+pub use threat::ThreatMap;

--- a/crates/awbrn-ai/src/threat.rs
+++ b/crates/awbrn-ai/src/threat.rs
@@ -1,0 +1,623 @@
+//! What the enemy can take off each tile, by the kind of unit that stands
+//! there.
+//!
+//! This is the smallest useful influence map. It is a grid of rows, not a
+//! grid of numbers: `threat[tile][kind]` is the funds an enemy could take off
+//! a whole unit of `kind` standing on `tile`. One number for each tile cannot
+//! be written honestly, because the damage table is indexed by the defender.
+//! An anti-air and a b-copter read opposite answers from the same tile, and a
+//! fighter does no damage at all to a tank while it destroys the copter. A
+//! map of one number for each tile must choose one defender, and it is then
+//! wrong for every other.
+//!
+//! # The two layers
+//!
+//! Which tiles one unit threatens depends on how it fires.
+//! `transition/attack.rs` refuses a moving attack to an indirect unit on any
+//! path longer than one tile: an artillery moves or it fires, never both in a
+//! turn. So the map holds two layers, and a reader keeps them apart:
+//!
+//! - [`ThreatMap::immediate`], what can strike on the enemy's next turn. A
+//!   direct unit threatens every tile beside a tile it can stop on, because
+//!   it moves and fires in one turn. An indirect unit threatens only the
+//!   range ring around the tile it stands on now.
+//! - [`ThreatMap::deferred`], the turn after that: the range ring around
+//!   every tile an indirect unit can stop on. Those tiles are firing
+//!   positions only once it has spent a turn moving to one.
+//!
+//! An agent that merges the two is too timid. It reads ground it could safely
+//! hold for a turn as ground under fire, and closing on an artillery through
+//! that window is how an artillery is answered. An agent that keeps only the
+//! immediate layer walks into a ring that shuts the turn after.
+//!
+//! # What the numbers carry
+//!
+//! - **Terrain defense belongs to the build.** An air unit gets no terrain
+//!   stars anywhere; a ground or sea unit gets the stars of the tile
+//!   (`transition/attack.rs`, `base_terrain_stars`). The tile and the
+//!   defender kind are both known while the row is written, so the discount
+//!   is exact here and could not be applied to a map of one number at all.
+//! - **Ammo.** Enemy ammo is hidden under fog, so every enemy is assumed to
+//!   hold a full magazine. That errs toward caution.
+//! - **A damage row of `None` is zero, not a small number.** A fighter adds
+//!   nothing to the row of any ground unit.
+//! - Commander effects are not read. The probe that turns a commander into
+//!   multipliers is a later tier, and until it lands both sides are scored
+//!   with the plain table.
+//!
+//! The rows are close to free. The cost is one reachability search for each
+//! enemy unit, and that search says the same thing whoever stands on the
+//! tile, so filling twenty-five numbers instead of one is a few thousand adds
+//! against the tens of thousands of commands this crate plays each second.
+
+use awvm::combat::{self, Side};
+use awvm::query::{self, MoveScratch};
+use awvm::ruleset::{self, Domain, FireMode, UnitKind};
+use awvm::semantic::{CellIdx, Dimensions, Location, PlayerIdx, Pos, State, Unit};
+
+/// Terrain defense runs from no stars to four, so a row holds five columns.
+const STAR_LEVELS: usize = 5;
+
+/// The neutral attack and defense a commander with no combat rule presents.
+///
+/// [`combat::damage`] reads both as percentages, so a hundred leaves the
+/// formula with the plain table value.
+const NEUTRAL: i64 = 100;
+
+/// A defender at whole health, which is what a row is priced for.
+const WHOLE: u8 = 100;
+
+/// What the enemy can take off each tile.
+///
+/// Build it once for a position with [`ThreatMap::build`] and read it as
+/// often as the caller likes. It says nothing about whose turn it is: every
+/// enemy is scored from where it stands now, with the movement it will have
+/// when the turn comes back to it, so a spent enemy threatens exactly as much
+/// as a fresh one.
+#[derive(Debug)]
+pub struct ThreatMap {
+    dimensions: Dimensions,
+    /// `UnitKind::COUNT` funds for each tile, the tiles in cell order.
+    immediate: Vec<f32>,
+    deferred: Vec<f32>,
+    /// Which tiles the attacker being walked has already been added to. It
+    /// holds the serial of that attacker rather than a flag, so the sweep
+    /// clears it by counting up instead of by writing the board.
+    stamp: Vec<u32>,
+    serial: u32,
+    /// The terrain stars of each tile, in cell order. Read once for every
+    /// tile every attacker threatens, so it is worked out once for the board
+    /// rather than looked up through the board each time.
+    stars: Vec<u8>,
+    /// The tiles the attacker being walked can stop on, taken out of its
+    /// movement field so that the field is dropped before the rows are
+    /// written.
+    stops: Vec<Pos>,
+    /// The grids and buckets every search after the first one reuses.
+    scratch: MoveScratch,
+}
+
+impl Default for ThreatMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ThreatMap {
+    /// An empty map, sized by the first position it is built for.
+    pub const fn new() -> Self {
+        Self {
+            dimensions: Dimensions::new(0, 0),
+            immediate: Vec::new(),
+            deferred: Vec::new(),
+            stamp: Vec::new(),
+            serial: 0,
+            stars: Vec::new(),
+            stops: Vec::new(),
+            scratch: MoveScratch::new(),
+        }
+    }
+
+    /// Work out what every player at war with `seat` threatens.
+    ///
+    /// `state` is the position the asking player can see, so a hidden enemy
+    /// threatens nothing here. That is the same blindness the agent plays
+    /// under everywhere else, and not a defect of the map.
+    pub fn build(&mut self, state: &State, seat: PlayerIdx) {
+        self.dimensions = state.board.dimensions();
+        let cells = self.dimensions.len();
+
+        self.immediate.clear();
+        self.immediate.resize(cells * UnitKind::COUNT, 0.0);
+        self.deferred.clear();
+        self.deferred.resize(cells * UnitKind::COUNT, 0.0);
+        self.stamp.clear();
+        self.stamp.resize(cells, 0);
+        self.serial = 0;
+
+        self.stars.clear();
+        self.stars.extend(
+            state
+                .board
+                .positions()
+                .map(|position| stars_of(state, position)),
+        );
+
+        for unit in state.units.iter() {
+            let Location::Board { position } = unit.location else {
+                continue;
+            };
+            if !hostile(state, seat, unit.owner) {
+                continue;
+            }
+            self.add(state, unit, position);
+        }
+    }
+
+    /// The funds an enemy could take off a whole unit of `kind` standing on
+    /// `cell` on the enemy's next turn.
+    pub fn immediate(&self, cell: CellIdx, kind: UnitKind) -> f64 {
+        f64::from(read(&self.immediate, cell, kind))
+    }
+
+    /// The same for the turn after that, from the firing positions an
+    /// indirect unit must first walk to.
+    ///
+    /// This does not include [`ThreatMap::immediate`]. A reader that wants
+    /// both adds them, and discounts this one.
+    pub fn deferred(&self, cell: CellIdx, kind: UnitKind) -> f64 {
+        f64::from(read(&self.deferred, cell, kind))
+    }
+
+    /// Add one enemy unit's threat to both layers.
+    fn add(&mut self, state: &State, unit: &Unit, position: Pos) {
+        let profile = ruleset::profile(unit.kind);
+        // A unit with no weapon threatens nothing, and neither does one with
+        // no health left to fire with.
+        if profile.fire_mode == FireMode::None || unit.hp == 0 {
+            return;
+        }
+        let table = DamageTable::of(unit);
+        if table.is_empty() {
+            return;
+        }
+
+        match profile.fire_mode {
+            // A direct unit moves and fires in one turn, so every tile beside
+            // a tile it can stop on is under fire now.
+            FireMode::Direct => {
+                self.collect_stops(state, unit);
+                self.serial += 1;
+                for index in 0..self.stops.len() {
+                    let stop = self.stops[index];
+                    for target in stop.orthogonal() {
+                        self.mark(&table, target, Layer::Immediate);
+                    }
+                }
+            }
+            // An indirect unit fires from where it stands, and from anywhere
+            // it can walk to only on the turn after it walks there.
+            FireMode::Indirect => {
+                let range = profile.indirect_range.unwrap_or(ruleset::AttackRange {
+                    minimum: 1,
+                    maximum: 1,
+                });
+                self.serial += 1;
+                self.ring(&table, position, range, Layer::Immediate);
+
+                self.collect_stops(state, unit);
+                self.serial += 1;
+                for index in 0..self.stops.len() {
+                    let stop = self.stops[index];
+                    // The tile it stands on is already the immediate ring
+                    // above. Firing from where it is takes no turn, so the
+                    // same ring must not also read as a turn away.
+                    if stop == position {
+                        continue;
+                    }
+                    self.ring(&table, stop, range, Layer::Deferred);
+                }
+            }
+            FireMode::None => {}
+        }
+    }
+
+    /// Every tile `unit` can come to rest on, its own tile included.
+    fn collect_stops(&mut self, state: &State, unit: &Unit) {
+        self.stops.clear();
+        let Ok(field) = query::reachable_into(state, unit.id, &mut self.scratch) else {
+            return;
+        };
+        self.stops
+            .extend(field.destinations().map(|(position, _)| position));
+        field.recycle(&mut self.scratch);
+    }
+
+    /// Add the row to every tile in the range ring around `center`.
+    fn ring(
+        &mut self,
+        table: &DamageTable,
+        center: Pos,
+        range: ruleset::AttackRange,
+        layer: Layer,
+    ) {
+        let reach = i16::try_from(range.maximum).unwrap_or(i16::MAX);
+        for dy in -reach..=reach {
+            let span = reach - dy.abs();
+            for dx in -span..=span {
+                let Some(target) = center.offset(dx, dy) else {
+                    continue;
+                };
+                if center.distance(target) < range.minimum {
+                    continue;
+                }
+                self.mark(table, target, layer);
+            }
+        }
+    }
+
+    /// Add the attacker's row to one tile, at most once for this attacker.
+    fn mark(&mut self, table: &DamageTable, target: Pos, layer: Layer) {
+        let Some(cell) = self.dimensions.cell_index(target) else {
+            return;
+        };
+        let index = usize::from(cell.get());
+        if self.stamp[index] == self.serial {
+            return;
+        }
+        self.stamp[index] = self.serial;
+
+        let stars = usize::from(self.stars[index]);
+        let row = index * UnitKind::COUNT;
+        let out = match layer {
+            Layer::Immediate => &mut self.immediate,
+            Layer::Deferred => &mut self.deferred,
+        };
+        for (kind, value) in out[row..row + UnitKind::COUNT].iter_mut().enumerate() {
+            *value += table.funds[kind][stars];
+        }
+    }
+}
+
+/// The terrain defense of one tile, clamped to the table the rows carry.
+fn stars_of(state: &State, position: Pos) -> u8 {
+    state
+        .board
+        .get(position)
+        .map(|tile| clamp_stars(ruleset::defense_stars(tile.terrain)))
+        .unwrap_or(0)
+}
+
+/// Terrain past the widest row the ruleset holds is read as the widest one,
+/// rather than dropped.
+const fn clamp_stars(stars: u8) -> u8 {
+    if stars as usize >= STAR_LEVELS {
+        STAR_LEVELS as u8 - 1
+    } else {
+        stars
+    }
+}
+
+/// Which layer a ring is written into.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Layer {
+    Immediate,
+    Deferred,
+}
+
+fn read(layer: &[f32], cell: CellIdx, kind: UnitKind) -> f32 {
+    layer
+        .get(usize::from(cell.get()) * UnitKind::COUNT + kind.index())
+        .copied()
+        .unwrap_or(0.0)
+}
+
+/// Whether `other` is a seat `seat` is at war with.
+pub fn hostile(state: &State, seat: PlayerIdx, other: PlayerIdx) -> bool {
+    let team = |seat: PlayerIdx| state.players.get(seat.get()).map(|player| &player.team);
+    match (team(seat), team(other)) {
+        (Some(mine), Some(theirs)) => mine != theirs,
+        _ => false,
+    }
+}
+
+/// What one attacker takes off a whole defender of each kind, in funds.
+///
+/// The columns are the terrain stars the defender stands in. A row is written
+/// once for each enemy unit and read once for every tile it threatens, which
+/// is what makes the rows cheap next to the search that finds those tiles.
+struct DamageTable {
+    funds: [[f32; STAR_LEVELS]; UnitKind::COUNT],
+    /// Whether any entry is above zero. An attacker that can hurt nothing on
+    /// the board is dropped before its reachable set is searched for.
+    armed: bool,
+}
+
+impl DamageTable {
+    /// The table one enemy unit presents, at the health it has now.
+    fn of(unit: &Unit) -> Self {
+        let profile = ruleset::profile(unit.kind);
+        let mut funds = [[0.0; STAR_LEVELS]; UnitKind::COUNT];
+        let mut armed = false;
+
+        // The striker's own terrain never enters the damage formula, which
+        // reads defense and stars off the target alone, so one attacking side
+        // serves the whole table.
+        let attacker = Side {
+            kind: unit.kind,
+            hp: unit.hp,
+            // Enemy ammo is hidden under fog. A full magazine is the cautious
+            // guess.
+            ammo: profile.max_ammo,
+            attack: NEUTRAL,
+            defense: NEUTRAL,
+            terrain_stars: 0,
+        };
+
+        for defender in UnitKind::ALL {
+            let cost = ruleset::profile(defender).cost as f32;
+            // An air unit takes no terrain stars anywhere, so its row is one
+            // column repeated. A ground or sea unit gets a column for each
+            // rung of terrain the board can put it on.
+            let flat = ruleset::profile(defender).domain == Domain::Air;
+            let row = &mut funds[defender.index()];
+
+            for (stars, entry) in row.iter_mut().enumerate() {
+                let target = Side {
+                    kind: defender,
+                    hp: WHOLE,
+                    ammo: 0,
+                    attack: NEUTRAL,
+                    defense: NEUTRAL,
+                    terrain_stars: if flat { 0 } else { stars as u8 },
+                };
+                // No weapon reaches this defender at all, and the answer does
+                // not change with the ground it stands on.
+                let Some(hit) = combat::damage(attacker, target, 0) else {
+                    break;
+                };
+                *entry = f32::from(hit.damage) / 100.0 * cost;
+                armed |= hit.damage > 0;
+            }
+        }
+
+        Self { funds, armed }
+    }
+
+    fn is_empty(&self) -> bool {
+        !self.armed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::board::arena;
+    use awvm::semantic::{Concealment, UnitAction, UnitId};
+
+    /// A seat off a real roster. [`PlayerIdx`] has no public constructor, on
+    /// purpose: one built out of thin air is only correct against the roster
+    /// it is read against.
+    fn a_seat() -> PlayerIdx {
+        let state = arena(false, 1);
+        state
+            .players
+            .seat(&state.turn.active_player)
+            .expect("the active player holds a seat")
+    }
+
+    /// One enemy unit, at whole health, standing where it is put.
+    fn unit(kind: UnitKind, position: Pos) -> Unit {
+        let profile = ruleset::profile(kind);
+        Unit {
+            id: UnitId::new(1),
+            kind,
+            owner: a_seat(),
+            hp: WHOLE,
+            fuel: profile.max_fuel,
+            ammo: profile.max_ammo,
+            action: UnitAction::Ready,
+            concealment: Concealment::Exposed,
+            location: Location::Board { position },
+        }
+    }
+
+    fn funds(table: &DamageTable, defender: UnitKind, stars: usize) -> f32 {
+        table.funds[defender.index()][stars]
+    }
+
+    /// The reason the map is a grid of rows. One attacker answers two
+    /// defenders with numbers that do not follow from each other, and a
+    /// fighter answers a ground unit with nothing at all.
+    #[test]
+    fn one_attacker_answers_each_defender_differently() {
+        let table = DamageTable::of(&unit(UnitKind::Fighter, Pos::new(0, 0)));
+        assert_eq!(
+            funds(&table, UnitKind::Tank, 0),
+            0.0,
+            "a fighter has no weapon that reaches a tank"
+        );
+        assert!(
+            funds(&table, UnitKind::BCopter, 0) > 0.0,
+            "a fighter destroys a copter"
+        );
+
+        let anti_air = DamageTable::of(&unit(UnitKind::AntiAir, Pos::new(0, 0)));
+        assert!(
+            funds(&anti_air, UnitKind::BCopter, 0) > funds(&table, UnitKind::Tank, 0),
+            "the same tile reads opposite answers for a copter and a tank"
+        );
+    }
+
+    /// Terrain defense belongs to the build, and only a ground or sea unit
+    /// gets any.
+    #[test]
+    fn terrain_stars_discount_the_row_of_a_ground_unit_alone() {
+        let table = DamageTable::of(&unit(UnitKind::Tank, Pos::new(0, 0)));
+
+        let open = funds(&table, UnitKind::Infantry, 0);
+        let covered = funds(&table, UnitKind::Infantry, 4);
+        assert!(open > 0.0);
+        assert!(
+            covered < open,
+            "four stars of terrain must take something off {open}, not {covered}"
+        );
+
+        let air = &table.funds[UnitKind::BCopter.index()];
+        assert!(
+            air.iter().all(|value| *value == air[0]),
+            "an air unit gets no terrain stars anywhere: {air:?}"
+        );
+    }
+
+    /// A damaged attacker takes less off its target, in the same proportion
+    /// the damage formula spends health.
+    #[test]
+    fn a_damaged_attacker_threatens_less() {
+        let whole = DamageTable::of(&unit(UnitKind::Tank, Pos::new(0, 0)));
+        let mut hurt = unit(UnitKind::Tank, Pos::new(0, 0));
+        hurt.hp = 50;
+        let hurt = DamageTable::of(&hurt);
+
+        let whole = funds(&whole, UnitKind::Infantry, 0);
+        let hurt = funds(&hurt, UnitKind::Infantry, 0);
+        assert!(
+            (hurt - whole / 2.0).abs() < whole * 0.05,
+            "half a tank should threaten about half of {whole}, not {hurt}"
+        );
+    }
+
+    /// A unit with no weapon threatens nothing, so it is never searched for.
+    #[test]
+    fn a_unit_that_cannot_fire_has_an_empty_table() {
+        assert!(DamageTable::of(&unit(UnitKind::Apc, Pos::new(0, 0))).is_empty());
+        assert!(!DamageTable::of(&unit(UnitKind::Infantry, Pos::new(0, 0))).is_empty());
+    }
+
+    /// The arena, emptied of units, with one enemy standing where the map's
+    /// predeployed unit stood.
+    ///
+    /// That tile is known to hold a ground unit, which is the only thing the
+    /// tests below need of it.
+    fn one_enemy(kind: UnitKind) -> (State, PlayerIdx, Pos) {
+        let mut state = arena(false, 1);
+        let ours = state
+            .players
+            .seat(&state.turn.active_player)
+            .expect("the active player holds a seat");
+        let (theirs, position) = state
+            .units
+            .iter()
+            .find_map(|unit| match unit.location {
+                Location::Board { position } if unit.owner != ours => Some((unit.owner, position)),
+                _ => None,
+            })
+            .expect("the arena starts one predeployed enemy unit");
+
+        state.units.retain(|_| false);
+        let mut enemy = unit(kind, position);
+        enemy.id = UnitId::new(9_999);
+        enemy.owner = theirs;
+        state.units.push(enemy);
+
+        (state, ours, position)
+    }
+
+    /// A direct unit moves and fires in one turn, so its threat is the tiles
+    /// beside everywhere it can stop, and it defers nothing.
+    #[test]
+    fn a_direct_unit_threatens_beside_everywhere_it_can_reach() {
+        let (state, ours, origin) = one_enemy(UnitKind::Tank);
+        let mut map = ThreatMap::new();
+        map.build(&state, ours);
+
+        let cell = |position: Pos| {
+            state
+                .board
+                .dimensions()
+                .cell_index(position)
+                .expect("the position is on the board")
+        };
+        let beside = origin
+            .orthogonal()
+            .next()
+            .expect("the origin has a neighbour");
+        assert!(
+            map.immediate(cell(beside), UnitKind::Infantry) > 0.0,
+            "a tank threatens the tile beside it"
+        );
+
+        // A tank moves six, so a tile seven away is past everywhere it can
+        // stop and past everything beside that.
+        let far = state
+            .board
+            .positions()
+            .find(|position| origin.distance(*position) > 7)
+            .expect("the arena is wider than seven tiles");
+        assert_eq!(map.immediate(cell(far), UnitKind::Infantry), 0.0);
+
+        assert!(
+            state
+                .board
+                .positions()
+                .all(|position| map.deferred(cell(position), UnitKind::Infantry) == 0.0),
+            "a direct unit defers nothing"
+        );
+    }
+
+    /// An indirect unit fires from where it stands, and from anywhere it
+    /// walks to only on the turn after it walks there. The two go into
+    /// different layers.
+    #[test]
+    fn an_indirect_unit_defers_the_ring_it_must_walk_to() {
+        let (state, ours, origin) = one_enemy(UnitKind::Artillery);
+        let range = ruleset::profile(UnitKind::Artillery)
+            .indirect_range
+            .expect("an artillery fires at range");
+        let mut map = ThreatMap::new();
+        map.build(&state, ours);
+
+        let cell = |position: Pos| {
+            state
+                .board
+                .dimensions()
+                .cell_index(position)
+                .expect("the position is on the board")
+        };
+        let at = |position: Pos| map.immediate(cell(position), UnitKind::Infantry);
+
+        // Nothing inside the minimum range, including the tile beside it,
+        // and something out at the maximum.
+        let beside = origin
+            .orthogonal()
+            .next()
+            .expect("the origin has a neighbour");
+        assert_eq!(at(beside), 0.0, "an artillery cannot fire at its own feet");
+
+        let in_range = state
+            .board
+            .positions()
+            .find(|position| origin.distance(*position) == range.maximum)
+            .expect("the arena holds a tile at the artillery's range");
+        assert!(
+            at(in_range) > 0.0,
+            "the ring it stands in is under fire now"
+        );
+
+        // The tile it must first walk to is not under fire yet, but it is
+        // deferred: an artillery moves or it fires, never both.
+        let walked = state
+            .board
+            .positions()
+            .find(|position| {
+                let distance = origin.distance(*position);
+                distance > range.maximum && map.deferred(cell(*position), UnitKind::Infantry) > 0.0
+            })
+            .expect("an artillery that can move defers a wider ring");
+        assert_eq!(
+            at(walked),
+            0.0,
+            "a tile only a walked-to firing position reaches is not immediate"
+        );
+    }
+}

--- a/crates/awbrn-ai/tests/greedy_game.rs
+++ b/crates/awbrn-ai/tests/greedy_game.rs
@@ -61,7 +61,7 @@ fn assert_greedy_wins(fog: bool) {
 }
 
 #[test]
-fn greedy_beats_random_in_the_open() {
+fn greedy_beats_random_in_a_standard_game() {
     assert_greedy_wins(false);
 }
 

--- a/crates/awvm/src/query.rs
+++ b/crates/awvm/src/query.rs
@@ -147,11 +147,21 @@ pub struct MoveField {
 /// [`MoveField::recycle`] puts it back. A grid that is never given back is
 /// dropped, and a caller with no pool always gets that.
 #[derive(Debug, Default)]
-pub(crate) struct MoveScratch {
+pub struct MoveScratch {
     /// Arrival grids handed back by spent fields.
     grids: Vec<Grid<Option<Arrival>>>,
     /// Dial's buckets, cleared and resized rather than rebuilt.
     buckets: Vec<Vec<Pos>>,
+}
+
+impl MoveScratch {
+    /// An empty pool. The first search fills it.
+    pub const fn new() -> Self {
+        Self {
+            grids: Vec::new(),
+            buckets: Vec::new(),
+        }
+    }
 }
 
 /// The cheapest route the search found into one tile.
@@ -448,7 +458,7 @@ impl MoveField {
     /// The grid is the only board-sized thing a search owns. A caller done
     /// with a field that will search again hands it back here, and the next
     /// search writes into this allocation instead of asking for one.
-    pub(crate) fn recycle(self, scratch: &mut MoveScratch) {
+    pub fn recycle(self, scratch: &mut MoveScratch) {
         scratch.grids.push(self.arrivals);
     }
 
@@ -759,12 +769,30 @@ impl<'a> ActiveTurn<'a> {
 /// hidden occupancy out of validation and resolves it as a trap during
 /// execution instead. Removing it would leak the hidden unit.
 pub fn reachable(state: &State, unit: UnitId) -> Result<MoveField, QueryError> {
+    reachable_into(state, unit, &mut MoveScratch::default())
+}
+
+/// [`reachable`], writing into memory the caller keeps.
+///
+/// The search allocates one board-sized grid, and a caller that asks about
+/// unit after unit pays for one of those per unit. Hand the same scratch to
+/// each search, and give each spent field back with [`MoveField::recycle`],
+/// and the whole sweep allocates once.
+///
+/// The board tables are not shared this way, because they belong to one
+/// player's turn and this entry point answers for any owner. A caller
+/// sweeping the units of a single player wants the turn instead.
+pub fn reachable_into(
+    state: &State,
+    unit: UnitId,
+    scratch: &mut MoveScratch,
+) -> Result<MoveField, QueryError> {
     let subject = lookup(state, unit)?;
     let maps = TurnMaps::for_seat(state, subject.owner).ok_or(QueryError::UnknownOwner {
         unit,
         seat: subject.owner,
     })?;
-    reachable_with(state, unit, &maps, &mut MoveScratch::default())
+    reachable_with(state, unit, &maps, scratch)
 }
 
 /// [`reachable`] against maps the caller already holds.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added threat-aware AI decision-making, helping units account for immediate and future enemy attacks.
  * Added capture-denial and headquarters-defense priorities to improve strategic choices.
  * Added `greedy-threat` and `greedy-deny` AI variants in the arena tool.
  * Added a reusable threat map for evaluating enemy influence across the battlefield.
* **Improvements**
  * Improved movement and attack selection by considering destination exposure and fogged attacks.
  * Improved repeated movement calculations through reusable search resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->