### PR TITLE
Unify AWBRN and AWBW playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "approx",
  "awbrn-bevy",
  "awbrn-content",
+ "awbrn-game",
  "awbrn-map",
  "awbrn-protocol",
  "awbrn-types",

--- a/crates/awbrn-client/Cargo.toml
+++ b/crates/awbrn-client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 awbrn-content = { path = "../awbrn-content", features = ["bevy"] }
 awbrn-bevy = { path = "../awbrn-bevy" }
+awbrn-game = { path = "../awbrn-game" }
 awbrn-map = { path = "../awbrn-map", features = ["bevy"] }
 awbrn-protocol = { path = "../awbrn-protocol" }
 awbrn-types = { path = "../awbrn-types", features = ["bevy"] }

--- a/crates/awbrn-client/src/lib.rs
+++ b/crates/awbrn-client/src/lib.rs
@@ -6,6 +6,7 @@ pub mod loading;
 pub mod modes;
 pub mod projection;
 pub mod render;
+pub mod replay_archive;
 mod ui_atlas;
 
 pub use awbrn_plugin::AwbrnPlugin;

--- a/crates/awbrn-client/src/loading.rs
+++ b/crates/awbrn-client/src/loading.rs
@@ -6,7 +6,7 @@ use awbrn_bevy::world::GameMap;
 use awbrn_content::co_portrait_by_awbw_id;
 use awbrn_map::{AwbrnMap, AwbwMap, AwbwMapData, Pos};
 use awbw_replay::game_models::AwbwPlayer;
-use awbw_replay::{AwbwReplay, ReplayParser, game_models::AwbwBuilding};
+use awbw_replay::{AwbwReplay, game_models::AwbwBuilding};
 use awvm::semantic::{Observation, ObservedTransition};
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
@@ -58,7 +58,7 @@ pub struct ReplayToLoad(pub Vec<u8>);
 
 /// Resource containing the loaded replay data
 #[derive(Resource)]
-pub struct LoadedReplay(pub AwbwReplay);
+pub struct LoadedReplay(pub crate::replay_archive::ReplayArchive);
 
 /// Resource to mark that a new game should be started
 #[derive(Resource)]
@@ -191,8 +191,7 @@ pub(crate) fn detect_replay_to_load(
 ) {
     commands.remove_resource::<ReplayToLoad>();
 
-    let parser = ReplayParser::new();
-    let replay = match parser.parse(&replay_to_load.0) {
+    let replay = match crate::replay_archive::ReplayArchive::parse(&replay_to_load.0) {
         Ok(replay) => replay,
         Err(e) => {
             error!("Failed to parse replay: {:?}", e);
@@ -200,20 +199,43 @@ pub(crate) fn detect_replay_to_load(
         }
     };
 
-    if let Some(replay_loaded) = replay_loaded_event(&replay) {
-        commands.insert_resource(PendingReplayLoadedEvent(replay_loaded));
-    }
-
-    if let Some(first_game) = replay.games.first() {
-        let map_id = first_game.maps_id;
-        info!("Found map ID: {:?} in replay", map_id);
-
-        let map_handle = asset_loader.load_map(map_id.as_u32());
-        commands.insert_resource(MapAssetHandle(map_handle));
-    } else {
-        error!("No games found in replay");
-        let map_handle = asset_loader.load_map(162795);
-        commands.insert_resource(MapAssetHandle(map_handle));
+    match &replay {
+        crate::replay_archive::ReplayArchive::Awbw(awbw) => {
+            if let Some(replay_loaded) = replay_loaded_event(awbw) {
+                commands.insert_resource(PendingReplayLoadedEvent(replay_loaded));
+            }
+            let map_id = awbw
+                .games
+                .first()
+                .map_or(162795, |game| game.maps_id.as_u32());
+            commands.insert_resource(MapAssetHandle(asset_loader.load_map(map_id)));
+        }
+        crate::replay_archive::ReplayArchive::Awbrn(native) => {
+            let setup = match native.game_setup() {
+                Ok(setup) => setup,
+                Err(error) => {
+                    error!("Failed to initialize AWBRN replay: {error}");
+                    return;
+                }
+            };
+            let authority = match awbrn_game::Authority::new(&setup) {
+                Ok(authority) => authority,
+                Err(error) => {
+                    error!("Failed to initialize AWBRN replay: {error}");
+                    return;
+                }
+            };
+            let map = setup.map.clone();
+            commands.insert_resource(
+                crate::modes::replay::presentation::ReplayTransitionSource::new(
+                    crate::replay_archive::ReplayTimeline::Awbrn {
+                        setup,
+                        current: Box::new(authority),
+                    },
+                ),
+            );
+            commands.insert_resource(PendingLoadedMatchMap(map));
+        }
     }
 
     commands.insert_resource(asset_loader.load_pending_ui_atlas());
@@ -318,9 +340,10 @@ pub(crate) fn check_assets_loaded(
 
     let mut awbw_map = awbw_map_asset.to_awbw_map();
     if let Some(replay) = assets.replay
-        && let Some(first_game) = replay.0.games.first()
+        && let Some(awbw_replay) = replay.0.awbw()
+        && let Some(first_game) = awbw_replay.games.first()
     {
-        match awvm_awbw::RecordedAdapter::new(&replay.0, &awbw_map_asset.0) {
+        match awvm_awbw::RecordedAdapter::new(awbw_replay, &awbw_map_asset.0) {
             Ok(adapter) => {
                 commands.insert_resource(
                     crate::modes::replay::presentation::ReplayTransitionSource::new(adapter),

--- a/crates/awbrn-client/src/modes/replay/bootstrap.rs
+++ b/crates/awbrn-client/src/modes/replay/bootstrap.rs
@@ -1,4 +1,3 @@
-use awbw_replay::AwbwReplay;
 use bevy::prelude::*;
 
 use crate::features::player_display::PlayerDisplayFactionOverrides;
@@ -36,22 +35,34 @@ fn seed_initial_observations(world: &mut World) {
 }
 
 pub fn initialize_replay_semantic_world_for_client(world: &mut World) {
-    let replay = world
+    let is_awbrn = world
         .get_resource::<LoadedReplay>()
-        .map(|r| r.0.clone())
-        .unwrap_or_else(|| AwbwReplay {
+        .is_some_and(|replay| replay.0.awbw().is_none());
+    if is_awbrn {
+        initialize_awbrn_replay_world(world);
+    } else {
+        let empty = awbw_replay::AwbwReplay {
             games: Vec::new(),
             turns: Vec::new(),
-        });
-
-    initialize_replay_semantic_world(&replay, world);
+        };
+        let replay = world
+            .get_resource::<LoadedReplay>()
+            .and_then(|replay| replay.0.awbw())
+            .cloned()
+            .unwrap_or(empty);
+        initialize_replay_semantic_world(&replay, world);
+    }
     let initial_terrain_knowledge = world.resource::<ReplayTerrainKnowledge>().clone();
     if let Some(mut source) = world.get_resource_mut::<ReplayTransitionSource>() {
         source.set_initial_terrain_knowledge(initial_terrain_knowledge);
     }
     seed_initial_observations(world);
 
-    if let Some((config, funds, unit_costs)) = player_roster_seed_from_replay(&replay) {
+    if let Some(replay) = world
+        .get_resource::<LoadedReplay>()
+        .and_then(|replay| replay.0.awbw())
+        && let Some((config, funds, unit_costs)) = player_roster_seed_from_replay(replay)
+    {
         world.insert_resource(config);
         world.insert_resource(funds);
         world.insert_resource(unit_costs);
@@ -68,6 +79,77 @@ pub fn initialize_replay_semantic_world_for_client(world: &mut World) {
 
     world.insert_resource(ReplayAdvanceLock::default());
     emit_player_roster_updated(world);
+}
+
+fn initialize_awbrn_replay_world(world: &mut World) {
+    awbrn_bevy::world::initialize_terrain_semantic_world(world);
+    let players = {
+        let Some(LoadedReplay(crate::replay_archive::ReplayArchive::Awbrn(replay))) =
+            world.get_resource::<LoadedReplay>()
+        else {
+            return;
+        };
+        replay
+            .setup
+            .players
+            .iter()
+            .enumerate()
+            .map(|(index, player)| crate::loading::LiveMatchPlayer {
+                player_id: index as u32,
+                faction_id: player.faction_id,
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut registry = awbrn_bevy::replay::ReplayPlayerRegistry::default();
+    for player in &players {
+        if let Some(faction) = awbrn_types::PlayerFaction::from_id(player.faction_id) {
+            registry.add_player(
+                awbrn_types::AwbwGamePlayerId::new(player.player_id),
+                faction,
+                0,
+            );
+        }
+    }
+    let knowledge = ReplayTerrainKnowledge::from_map_and_registry(
+        world.resource::<awbrn_bevy::world::GameMap>(),
+        &registry,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(knowledge);
+    world.insert_resource(awbrn_bevy::replay::ReplayState::default());
+    world.insert_resource(awbrn_bevy::replay::RecipientObservations::default());
+    world.insert_resource(awbrn_bevy::world::ViewerVisibility::default());
+    world.insert_resource(awbrn_bevy::world::FriendlyFactions::default());
+    let observations = match world
+        .get_resource::<ReplayTransitionSource>()
+        .map(ReplayTransitionSource::initial_observations)
+    {
+        Some(Ok(observations)) => observations,
+        Some(Err(error)) => {
+            error!("Could not observe the opening AWBRN replay state: {error}");
+            return;
+        }
+        None => return,
+    };
+    let Some(first) = observations.first() else {
+        return;
+    };
+    let (config, funds, unit_costs, power_meters) =
+        crate::features::player_roster::player_roster_seed_from_live_match(&players, first);
+    world.insert_resource(config);
+    world.insert_resource(funds);
+    world.insert_resource(unit_costs);
+    world.insert_resource(power_meters);
+    let transitions = observations
+        .into_iter()
+        .map(|post| awvm::semantic::ObservedTransition {
+            post,
+            events: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    if let Err(error) = awbrn_bevy::replay::apply_observed_transitions(world, &transitions) {
+        error!("Could not initialize AWBRN replay presentation: {error}");
+    }
 }
 
 #[cfg(test)]
@@ -122,7 +204,9 @@ mod tests {
         );
         app.world_mut().resource_mut::<GameMap>().set(map);
         app.world_mut()
-            .insert_resource(crate::loading::LoadedReplay(replay));
+            .insert_resource(crate::loading::LoadedReplay(
+                crate::replay_archive::ReplayArchive::Awbw(replay),
+            ));
 
         initialize_replay_semantic_world_for_client(app.world_mut());
 

--- a/crates/awbrn-client/src/modes/replay/controls.rs
+++ b/crates/awbrn-client/src/modes/replay/controls.rs
@@ -20,25 +20,20 @@ pub(crate) fn advance_replay_action(
     replay_state: &mut ReplayState,
     loaded_replay: &LoadedReplay,
 ) -> ReplayAdvanceResult {
-    let Some(action) = loaded_replay
-        .0
-        .turns
-        .get(replay_state.next_action_index as usize)
-        .cloned()
-    else {
+    let index = replay_state.next_action_index as usize;
+    if index >= loaded_replay.0.len() {
         return ReplayAdvanceResult::Exhausted;
-    };
+    }
 
-    commands.queue(ReplayTurnCommand { action });
+    commands.queue(ReplayTurnCommand { index });
     replay_state.next_action_index += 1;
 
-    if action_requires_path_animation(
-        loaded_replay
-            .0
-            .turns
-            .get((replay_state.next_action_index - 1) as usize)
-            .expect("queued replay action should still exist"),
-    ) {
+    let awbw_requires_animation = loaded_replay
+        .0
+        .awbw()
+        .and_then(|replay| replay.turns.get(index))
+        .is_some_and(action_requires_path_animation);
+    if awbw_requires_animation || loaded_replay.0.awbw().is_none() {
         ReplayAdvanceResult::AdvancedWithLock
     } else {
         ReplayAdvanceResult::Advanced
@@ -288,8 +283,8 @@ mod tests {
     #[test]
     fn replay_left_repeat_is_ignored_while_advance_is_locked() {
         let (mut app, replay) = replay_rewind_controls_test_app();
-        for action in replay.turns.iter().cloned() {
-            ReplayTurnCommand { action }.apply(app.world_mut());
+        for index in 0..replay.turns.len() {
+            ReplayTurnCommand { index }.apply(app.world_mut());
             if app.world().resource::<ReplayAdvanceLock>().is_active() {
                 break;
             }
@@ -329,10 +324,12 @@ mod tests {
         app.insert_resource(ReplayState::default());
         app.insert_resource(ReplayAdvanceLock::default());
         app.insert_resource(StrongIdMap::<AwbwUnitId>::default());
-        app.insert_resource(LoadedReplay(AwbwReplay {
-            games: Vec::new(),
-            turns: actions,
-        }));
+        app.insert_resource(LoadedReplay(crate::replay_archive::ReplayArchive::Awbw(
+            AwbwReplay {
+                games: Vec::new(),
+                turns: actions,
+            },
+        )));
         app.init_resource::<crate::features::visibility::ViewerVisibility>();
         app.init_resource::<crate::features::visibility::FriendlyFactions>();
         app.init_resource::<awbrn_bevy::replay::ReplayTerrainKnowledge>();
@@ -362,7 +359,9 @@ mod tests {
         app.world_mut()
             .resource_mut::<GameMap>()
             .set(AwbrnMap::from_map(&graphical_map));
-        app.insert_resource(LoadedReplay(replay.clone()));
+        app.insert_resource(LoadedReplay(crate::replay_archive::ReplayArchive::Awbw(
+            replay.clone(),
+        )));
         app.insert_resource(
             crate::modes::replay::presentation::ReplayTransitionSource::new(adapter),
         );

--- a/crates/awbrn-client/src/modes/replay/presentation.rs
+++ b/crates/awbrn-client/src/modes/replay/presentation.rs
@@ -7,7 +7,6 @@
 use awbw_replay::turn_models::Action;
 use awvm::semantic::{ObservedEvent, ObservedTransition, ObservedUnitRef, PlayerId};
 use bevy::{log, prelude::*};
-use std::collections::BTreeMap;
 
 use crate::features::event_bus::{EventSink, NewDay as ExternalNewDay};
 use crate::features::player_roster::{
@@ -29,19 +28,14 @@ use awbrn_types::UnitExt;
 /// AWVM command or reconstructs random tokens.
 #[derive(Resource)]
 pub struct ReplayTransitionSource {
-    initial_adapter: awvm_awbw::RecordedAdapter,
-    adapter: awvm_awbw::RecordedAdapter,
-    checkpoints: BTreeMap<usize, awvm_awbw::RecordedAdapter>,
+    timeline: crate::replay_archive::ReplayTimeline,
     initial_terrain_knowledge: Option<ReplayTerrainKnowledge>,
 }
 
 impl ReplayTransitionSource {
-    pub fn new(adapter: awvm_awbw::RecordedAdapter) -> Self {
-        let checkpoints = BTreeMap::from([(0, adapter.clone())]);
+    pub fn new(timeline: impl Into<crate::replay_archive::ReplayTimeline>) -> Self {
         Self {
-            initial_adapter: adapter.clone(),
-            adapter,
-            checkpoints,
+            timeline: timeline.into(),
             initial_terrain_knowledge: None,
         }
     }
@@ -56,65 +50,16 @@ impl ReplayTransitionSource {
     /// already populated; these projections are what a viewpoint switch made
     /// before the first action selects between.
     pub fn initial_observations(&self) -> Result<Vec<awvm::semantic::Observation>, String> {
-        observations_for_state(self.initial_adapter.state())
+        self.timeline.initial_observations()
     }
 
     fn rebuild_to(
         &mut self,
-        replay: &awbw_replay::AwbwReplay,
+        replay: &crate::replay_archive::ReplayArchive,
         target_index: usize,
-    ) -> Result<(awvm_awbw::RecordedAdapter, Vec<ObservedTransition>), String> {
-        const CHECKPOINT_INTERVAL: usize = 64;
-
-        let (checkpoint_index, mut adapter) = self
-            .checkpoints
-            .range(..=target_index)
-            .next_back()
-            .map(|(index, adapter)| (*index, adapter.clone()))
-            .unwrap_or_else(|| (0, self.initial_adapter.clone()));
-        for (index, action) in replay
-            .turns
-            .iter()
-            .enumerate()
-            .take(target_index)
-            .skip(checkpoint_index)
-        {
-            adapter.advance(action).map_err(|error| {
-                format!(
-                    "Could not rebuild recorded replay through action {index} ({}): {error}",
-                    action.kind_name()
-                )
-            })?;
-            let completed = index + 1;
-            if completed % CHECKPOINT_INTERVAL == 0 {
-                self.checkpoints
-                    .entry(completed)
-                    .or_insert_with(|| adapter.clone());
-            }
-        }
-
-        let transitions = observations_for_state(adapter.state())?
-            .into_iter()
-            .map(|post| ObservedTransition {
-                post,
-                events: Vec::new(),
-            })
-            .collect();
-        Ok((adapter, transitions))
+    ) -> Result<Vec<ObservedTransition>, String> {
+        self.timeline.rebuild(replay, target_index)
     }
-}
-
-fn observations_for_state(
-    state: &awvm::semantic::State,
-) -> Result<Vec<awvm::semantic::Observation>, String> {
-    state
-        .players
-        .iter()
-        .map(|player| {
-            awvm::semantic::observe(&awvm::semantic::AwbwVisibility, state, player.id())
-                .map_err(|error| format!("Could not project the archive state: {error}"))
-        })
-        .collect()
 }
 
 /// Terminal marker for a replay whose typed source can no longer be trusted.
@@ -213,7 +158,7 @@ impl Command for LiveTransitionCommand {
 
 /// A custom Command for processing replay turn actions.
 pub struct ReplayTurnCommand {
-    pub action: Action,
+    pub index: usize,
 }
 
 impl Command for ReplayTurnCommand {
@@ -252,7 +197,7 @@ impl Command for ReplayRewindCommand {
         };
         let target_index = usize::try_from(self.target_index)
             .unwrap_or(usize::MAX)
-            .min(replay.0.turns.len());
+            .min(replay.0.len());
 
         if !world.contains_resource::<ReplayTransitionSource>() {
             log::error!("Cannot rewind replay without a typed transition source");
@@ -262,7 +207,7 @@ impl Command for ReplayRewindCommand {
             let replay = &world.resource::<crate::loading::LoadedReplay>().0;
             source.rebuild_to(replay, target_index)
         });
-        let (adapter, transitions) = match rebuilt {
+        let transitions = match rebuilt {
             Ok(rebuilt) => rebuilt,
             Err(error) => {
                 log::error!("{error}");
@@ -286,7 +231,6 @@ impl Command for ReplayRewindCommand {
             return;
         }
         world.resource_mut::<ReplayState>().next_action_index = target_index as u32;
-        world.resource_mut::<ReplayTransitionSource>().adapter = adapter;
         world.remove_resource::<ReplayTransitionFailed>();
     }
 }
@@ -298,21 +242,10 @@ impl ReplayTurnCommand {
         }
 
         let observed = {
-            let mut source = world.resource_mut::<ReplayTransitionSource>();
-            source
-                .adapter
-                .advance(&self.action)
-                .map_err(|error| format!("Could not advance recorded replay outcome: {error}"))
-                .and_then(|transition| {
-                    let players = transition.post_state().players.clone();
-                    players
-                        .iter()
-                        .map(|player| transition.observe(player.id()))
-                        .collect::<Result<Vec<_>, _>>()
-                        .map_err(|error| {
-                            format!("Could not project recorded replay outcome: {error}")
-                        })
-                })
+            world.resource_scope(|world, mut source: Mut<ReplayTransitionSource>| {
+                let replay = &world.resource::<crate::loading::LoadedReplay>().0;
+                source.timeline.advance(replay, self.index)
+            })
         };
         let observed = match observed {
             Ok(observed) => observed,
@@ -323,7 +256,18 @@ impl ReplayTurnCommand {
             }
         };
 
-        update_player_roster_unit_costs(&self.action, world);
+        let cost_updates = world
+            .resource::<crate::loading::LoadedReplay>()
+            .0
+            .awbw()
+            .and_then(|replay| replay.turns.get(self.index))
+            .map(collect_player_roster_unit_cost_updates)
+            .unwrap_or_default();
+        if let Some(mut unit_costs) = world.get_resource_mut::<PlayerUnitCosts>() {
+            for (unit_id, cost) in cost_updates {
+                unit_costs.set(unit_id, cost);
+            }
+        }
 
         if start_typed_movement_animation(
             &observed,
@@ -377,6 +321,9 @@ fn apply_typed_transitions(
 fn reset_player_roster_for_rewind(target_index: usize, world: &mut World) {
     let rebuilt = {
         let replay = &world.resource::<crate::loading::LoadedReplay>().0;
+        let Some(replay) = replay.awbw() else {
+            return;
+        };
         let Some((config, funds, mut unit_costs)) = player_roster_seed_from_replay(replay) else {
             return;
         };
@@ -480,22 +427,6 @@ fn sync_player_roster_from_transition(transitions: &[ObservedTransition], world:
                 entry.eliminated = status != awvm::semantic::PlayerStatus::Active;
             }
         }
-    }
-}
-
-/// Record what a built unit actually cost.
-///
-/// Transitions carry no purchase price, and the ruleset base cost is already
-/// the fallback in `player_roster_snapshot`, so only the archived action can
-/// supply a discounted CO price.
-fn update_player_roster_unit_costs(action: &Action, world: &mut World) {
-    let updates = collect_player_roster_unit_cost_updates(action);
-    let Some(mut unit_costs) = world.get_resource_mut::<PlayerUnitCosts>() else {
-        return;
-    };
-
-    for (unit_id, cost) in updates {
-        unit_costs.set(unit_id, cost);
     }
 }
 

--- a/crates/awbrn-client/src/replay_archive.rs
+++ b/crates/awbrn-client/src/replay_archive.rs
@@ -1,0 +1,339 @@
+use std::collections::BTreeMap;
+use std::num::NonZeroU8;
+
+use awbrn_game::{Authority, GameSetup, PlayerSetup, StoredActionEvent};
+use awbrn_map::{AwbrnMap, AwbwMap, AwbwMapData};
+use awbrn_types::{AwbwCoId, Co, CoExt, PlayerFaction};
+use awvm::semantic::{Observation, ObservedTransition};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AwbrnReplayPlayer {
+    pub user_id: String,
+    pub faction_id: u8,
+    pub team: Option<NonZeroU8>,
+    pub starting_funds: u32,
+    pub co_id: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AwbrnReplaySetup {
+    pub match_id: String,
+    pub map_id: u32,
+    pub map: AwbwMapData,
+    pub players: Vec<AwbrnReplayPlayer>,
+    pub fog_enabled: bool,
+    pub starting_funds: u32,
+    #[serde(default)]
+    pub rng_seed: Option<u64>,
+}
+
+#[derive(Deserialize)]
+pub struct AwbrnReplayFile {
+    pub version: u32,
+    pub setup: AwbrnReplaySetup,
+    pub actions: Vec<StoredActionEvent>,
+}
+
+impl AwbrnReplayFile {
+    pub fn parse(data: &[u8]) -> Result<Self, String> {
+        let replay: Self = serde_json::from_slice(data)
+            .map_err(|error| format!("Could not parse AWBRN replay JSON: {error}"))?;
+        if replay.version != 1 {
+            return Err(format!(
+                "Unsupported AWBRN replay version {}",
+                replay.version
+            ));
+        }
+        replay.game_setup()?;
+        Ok(replay)
+    }
+
+    pub fn game_setup(&self) -> Result<GameSetup, String> {
+        let map = AwbwMap::try_from(&self.setup.map).map_err(|error| error.to_string())?;
+        let players = self
+            .setup
+            .players
+            .iter()
+            .map(|player| {
+                let faction = PlayerFaction::from_awbw_id(player.faction_id)
+                    .ok_or_else(|| format!("Unknown AWBW faction ID {}", player.faction_id))?;
+                let co_id = AwbwCoId::new(player.co_id);
+                let co = Co::from_awbw_id(co_id)
+                    .ok_or_else(|| format!("Unknown AWBW CO ID {}", player.co_id))?;
+                Ok(PlayerSetup {
+                    faction,
+                    team: player.team,
+                    starting_funds: player.starting_funds,
+                    co,
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok(GameSetup {
+            map: AwbrnMap::from_map(&map),
+            players,
+            fog_enabled: self.setup.fog_enabled,
+            rng_seed: self.setup.rng_seed.unwrap_or(0),
+        })
+    }
+}
+
+pub enum ReplayArchive {
+    Awbw(awbw_replay::AwbwReplay),
+    Awbrn(AwbrnReplayFile),
+}
+
+impl ReplayArchive {
+    pub fn parse(data: &[u8]) -> Result<Self, String> {
+        if data
+            .iter()
+            .copied()
+            .find(|byte| !byte.is_ascii_whitespace())
+            == Some(b'{')
+        {
+            return AwbrnReplayFile::parse(data).map(Self::Awbrn);
+        }
+        awbw_replay::ReplayParser::new()
+            .parse(data)
+            .map(Self::Awbw)
+            .map_err(|error| format!("Could not parse AWBW replay archive: {error:?}"))
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Awbw(replay) => replay.turns.len(),
+            Self::Awbrn(replay) => replay.actions.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn awbw(&self) -> Option<&awbw_replay::AwbwReplay> {
+        match self {
+            Self::Awbw(replay) => Some(replay),
+            Self::Awbrn(_) => None,
+        }
+    }
+}
+
+pub enum ReplayTimeline {
+    Awbw {
+        initial: Box<awvm_awbw::RecordedAdapter>,
+        current: Box<awvm_awbw::RecordedAdapter>,
+        checkpoints: BTreeMap<usize, awvm_awbw::RecordedAdapter>,
+    },
+    Awbrn {
+        setup: GameSetup,
+        current: Box<Authority>,
+    },
+}
+
+impl From<awvm_awbw::RecordedAdapter> for ReplayTimeline {
+    fn from(adapter: awvm_awbw::RecordedAdapter) -> Self {
+        Self::Awbw {
+            initial: Box::new(adapter.clone()),
+            current: Box::new(adapter),
+            checkpoints: BTreeMap::new(),
+        }
+    }
+}
+
+impl ReplayTimeline {
+    pub fn initial_observations(&self) -> Result<Vec<Observation>, String> {
+        match self {
+            Self::Awbw { initial, .. } => observe_awbw_state(initial),
+            Self::Awbrn { setup, .. } => {
+                let initial = Authority::new(setup).map_err(|error| error.to_string())?;
+                initial
+                    .players()
+                    .map(|player| {
+                        awvm::semantic::observe(
+                            &awvm::semantic::AwbwVisibility,
+                            initial.state(),
+                            &initial.player(player),
+                        )
+                        .map_err(|error| error.to_string())
+                    })
+                    .collect()
+            }
+        }
+    }
+
+    pub fn advance(
+        &mut self,
+        archive: &ReplayArchive,
+        index: usize,
+    ) -> Result<Vec<ObservedTransition>, String> {
+        match (self, archive) {
+            (
+                Self::Awbw {
+                    current,
+                    checkpoints,
+                    ..
+                },
+                ReplayArchive::Awbw(replay),
+            ) => {
+                let action = replay
+                    .turns
+                    .get(index)
+                    .ok_or_else(|| format!("Missing AWBW action {index}"))?;
+                let transition = current.advance(action).map_err(|error| error.to_string())?;
+                let players = transition.post_state().players.clone();
+                let observations = players
+                    .iter()
+                    .map(|player| {
+                        transition
+                            .observe(player.id())
+                            .map_err(|error| error.to_string())
+                    })
+                    .collect();
+                let completed = index + 1;
+                if completed.is_multiple_of(64) {
+                    checkpoints
+                        .entry(completed)
+                        .or_insert_with(|| (**current).clone());
+                }
+                observations
+            }
+            (Self::Awbrn { current, .. }, ReplayArchive::Awbrn(replay)) => {
+                let event = replay
+                    .actions
+                    .get(index)
+                    .ok_or_else(|| format!("Missing AWBRN action {index}"))?;
+                let transition = current
+                    .execute_recorded(event.player, &event.command, &event.random)
+                    .map_err(|error| format!("Could not replay AWBRN action {index}: {error}"))?;
+                current
+                    .players()
+                    .map(|player| {
+                        transition
+                            .observe(current, &current.player(player))
+                            .map_err(|error| error.to_string())
+                    })
+                    .collect()
+            }
+            _ => Err("Replay archive and timeline formats do not match".to_string()),
+        }
+    }
+
+    pub fn rebuild(
+        &mut self,
+        archive: &ReplayArchive,
+        target: usize,
+    ) -> Result<Vec<ObservedTransition>, String> {
+        match self {
+            Self::Awbw {
+                initial,
+                current,
+                checkpoints,
+            } => {
+                let (checkpoint_index, checkpoint) = checkpoints
+                    .range(..=target)
+                    .next_back()
+                    .map(|(index, adapter)| (*index, adapter.clone()))
+                    .unwrap_or_else(|| (0, (**initial).clone()));
+                **current = checkpoint;
+                let mut observations = observe_awbw_state(current)?
+                    .into_iter()
+                    .map(|post| ObservedTransition {
+                        post,
+                        events: Vec::new(),
+                    })
+                    .collect();
+                for index in checkpoint_index..target {
+                    observations = self.advance(archive, index)?;
+                }
+                return Ok(observations);
+            }
+            Self::Awbrn { setup, current } => {
+                **current = Authority::new(setup).map_err(|error| error.to_string())?
+            }
+        }
+        let mut observations = self
+            .initial_observations()?
+            .into_iter()
+            .map(|post| ObservedTransition {
+                post,
+                events: Vec::new(),
+            })
+            .collect();
+        for index in 0..target {
+            observations = self.advance(archive, index)?;
+        }
+        Ok(observations)
+    }
+}
+
+fn observe_awbw_state(adapter: &awvm_awbw::RecordedAdapter) -> Result<Vec<Observation>, String> {
+    adapter
+        .state()
+        .players
+        .iter()
+        .map(|player| {
+            awvm::semantic::observe(
+                &awvm::semantic::AwbwVisibility,
+                adapter.state(),
+                player.id(),
+            )
+            .map_err(|error| error.to_string())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn replay_json(version: u32) -> Vec<u8> {
+        let map: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("../../assets/maps/162795.json"),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        serde_json::to_vec(&json!({
+            "version": version,
+            "setup": {
+                "matchId": "0123456789abcdef",
+                "mapId": 162795,
+                "map": map,
+                "players": [
+                    { "userId": "one", "factionId": 1, "team": null, "startingFunds": 0, "coId": 1 },
+                    { "userId": "two", "factionId": 2, "team": null, "startingFunds": 0, "coId": 2 }
+                ],
+                "fogEnabled": false,
+                "startingFunds": 0,
+                "creatorUserId": "one"
+            },
+            "actions": []
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn detects_awbrn_json_and_uses_the_embedded_map() {
+        let replay = ReplayArchive::parse(&replay_json(1)).unwrap();
+        let ReplayArchive::Awbrn(replay) = replay else {
+            panic!("JSON replay should use the AWBRN adapter");
+        };
+        assert_eq!(replay.setup.map_id, 162795);
+        assert_eq!(replay.actions.len(), 0);
+        assert_eq!(replay.game_setup().unwrap().players.len(), 2);
+    }
+
+    #[test]
+    fn rejects_unknown_awbrn_versions() {
+        let error = match ReplayArchive::parse(&replay_json(2)) {
+            Ok(_) => panic!("unknown version should fail"),
+            Err(error) => error,
+        };
+        assert!(error.contains("Unsupported AWBRN replay version 2"));
+    }
+}

--- a/crates/awbrn-client/tests/replay_semantic_snapshots.rs
+++ b/crates/awbrn-client/tests/replay_semantic_snapshots.rs
@@ -97,6 +97,9 @@ fn replay_semantic_snapshot_rows(replay_file: &str, map_file: &str) -> Vec<Repla
     let actions = replay.turns.clone();
     let adapter = RecordedAdapter::new(&replay, &map_data).unwrap();
     app.insert_resource(ReplayTransitionSource::new(adapter));
+    app.insert_resource(awbrn_client::loading::LoadedReplay(
+        awbrn_client::replay_archive::ReplayArchive::Awbw(replay.clone()),
+    ));
     app.insert_resource(ReplayAdvanceLock::default());
     app.insert_resource(ReplayViewpoint::Spectator);
     let last_index = actions.len().saturating_sub(1);
@@ -109,7 +112,10 @@ fn replay_semantic_snapshot_rows(replay_file: &str, map_file: &str) -> Vec<Repla
     let mut rows = Vec::new();
     for (action_index, action) in actions.into_iter().enumerate() {
         let action_kind = action.kind_name();
-        ReplayTurnCommand { action }.apply(app.world_mut());
+        ReplayTurnCommand {
+            index: action_index,
+        }
+        .apply(app.world_mut());
         if let Some(entity) = app.world().resource::<ReplayAdvanceLock>().active_entity() {
             let followup = app
                 .world_mut()

--- a/crates/awbrn-client/tests/replay_typed_presentation.rs
+++ b/crates/awbrn-client/tests/replay_typed_presentation.rs
@@ -27,8 +27,8 @@ fn archived_movement_animates_and_applies_only_typed_transitions() {
         serde_json::from_slice(&std::fs::read(map_fixture_path("162795.json")).unwrap()).unwrap();
     let mut app = replay_test_app(&replay, &map_data);
 
-    for action in replay.turns.iter().cloned() {
-        ReplayTurnCommand { action }.apply(app.world_mut());
+    for index in 0..replay.turns.len() {
+        ReplayTurnCommand { index }.apply(app.world_mut());
         let Some(entity) = app.world().resource::<ReplayAdvanceLock>().active_entity() else {
             continue;
         };
@@ -101,8 +101,8 @@ fn typed_transitions_record_public_power_meter() {
     let mut app = replay_test_app(&replay, &map_data);
 
     let mut charged = false;
-    for action in replay.turns.iter().cloned() {
-        ReplayTurnCommand { action }.apply(app.world_mut());
+    for index in 0..replay.turns.len() {
+        ReplayTurnCommand { index }.apply(app.world_mut());
         if let Some(entity) = app.world().resource::<ReplayAdvanceLock>().active_entity() {
             let followup = app
                 .world_mut()
@@ -320,17 +320,16 @@ fn replay_test_app(replay: &awbw_replay::AwbwReplay, map_data: &AwbwMapData) -> 
     app.world_mut()
         .resource_mut::<GameMap>()
         .set(AwbrnMap::from_map(&graphical_map));
-    app.insert_resource(LoadedReplay(replay.clone()));
+    app.insert_resource(LoadedReplay(
+        awbrn_client::replay_archive::ReplayArchive::Awbw(replay.clone()),
+    ));
     app.insert_resource(ReplayTransitionSource::new(adapter));
     initialize_replay_semantic_world_for_client(app.world_mut());
     app
 }
 
-fn apply_settled_action(app: &mut App, replay: &awbw_replay::AwbwReplay, index: usize) {
-    ReplayTurnCommand {
-        action: replay.turns[index].clone(),
-    }
-    .apply(app.world_mut());
+fn apply_settled_action(app: &mut App, _replay: &awbw_replay::AwbwReplay, index: usize) {
+    ReplayTurnCommand { index }.apply(app.world_mut());
     if let Some(entity) = app.world().resource::<ReplayAdvanceLock>().active_entity() {
         let followup = app
             .world_mut()

--- a/crates/awbrn-wasm/src/lib.rs
+++ b/crates/awbrn-wasm/src/lib.rs
@@ -441,7 +441,8 @@ impl BevyApp {
 
     #[wasm_bindgen]
     pub fn new_replay(&mut self, data: Vec<u8>) -> Result<(), JsError> {
-        // Signal that a new replay should be loaded
+        awbrn_client::replay_archive::ReplayArchive::parse(&data)
+            .map_err(|error| JsError::new(&error))?;
         self.app.world_mut().insert_resource(ReplayToLoad(data));
 
         Ok(())

--- a/web/src/replay/ReplayPage.tsx
+++ b/web/src/replay/ReplayPage.tsx
@@ -122,9 +122,9 @@ export function ReplayPage() {
 
   const replayLoader = (
     <FileInput
-      accept=".zip"
+      accept=".zip,.json"
       changeAction={handleReplayFileChange}
-      description={playerRoster ? undefined : "AWBW replay archives, in .zip format"}
+      description={playerRoster ? undefined : "AWBW .zip or AWBRN .json replay archives"}
       isLabelHidden={Boolean(playerRoster)}
       label="Load a replay"
       mode={playerRoster ? "input" : "dropzone"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and playing AWBRN JSON replay archives alongside AWBW ZIP replays.
  * AWBRN replays can use embedded maps and recorded match data.
  * Replay controls now support consistent advancement, rewinding, and timeline rebuilding across both formats.
  * Replay uploads now accept `.json` and `.zip` files.

* **Bug Fixes**
  * Invalid replay data is rejected before loading with a clear error.
  * Replay setup, map, version, and action validation errors now stop loading safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->