### PR TITLE
Measure the capture field in turns and count pairs in ai arena

### DIFF
--- a/crates/awbrn-ai/src/agents/greedy.rs
+++ b/crates/awbrn-ai/src/agents/greedy.rs
@@ -32,7 +32,9 @@
 //! alone scores it as a good one.
 
 use awvm::combat::Forecast;
-use awvm::ruleset::{self, Terrain, TerrainTrait, UnitKind};
+use awvm::commander;
+use awvm::query::{self};
+use awvm::ruleset::{self, MovementClass, Terrain, TerrainTrait, UnitKind};
 use awvm::semantic::{
     CellIdx, Location, Observation, PlayerIdx, Pos, State, Tile, TileOwner, Unit,
 };
@@ -88,8 +90,15 @@ pub struct Weights {
     /// on the next turn. Heavily weighted on purpose: it is the difference
     /// between a unit that is two turns from paying and one that is three.
     pub capture_two_turn: f64,
-    /// The decay for each tile of Manhattan distance between a tile and a
-    /// property, which is what "in close proximity" means here.
+    /// The decay for each step between a tile and what pulls it, which is
+    /// what "in close proximity" means here.
+    ///
+    /// The two fields do not measure a step the same way. [`CaptureFields`]
+    /// measures turns, through the movement points a route really costs;
+    /// [`Board::advance_field`] measures tiles of Manhattan distance, because
+    /// its targets are enemy units, which move and can be of any class. A turn
+    /// is worth several tiles, so one number serving both is a compromise and
+    /// is the first thing to split if the sweep asks for it.
     pub proximity_decay: f64,
 
     /// One point of funds, as a score. This prices an exchange: damage dealt
@@ -231,12 +240,13 @@ pub struct GreedyAgent {
     weights: Weights,
     /// Held across calls so that a turn's enumeration reuses one allocation.
     orders: Vec<Order>,
-    /// The pull each tile feels toward the properties worth capturing, and the
-    /// pull it feels toward the enemy. One entry for each tile of the board,
-    /// rebuilt once for each play rather than once for each candidate.
-    capture_field: Vec<f64>,
+    /// The pull each tile feels toward the properties worth capturing, one
+    /// field for each movement class that can capture, and the pull it feels
+    /// toward the enemy. One entry for each tile of the board, rebuilt once
+    /// for each play rather than once for each candidate.
+    capture_fields: CaptureFields,
     advance_field: Vec<f64>,
-    /// `proximity_decay` raised to each distance the board can hold, so that
+    /// `proximity_decay` raised to each turn a field can hold, so that
     /// building the fields is a multiply rather than a power.
     decay: Vec<f64>,
     /// The unit standing on each tile, by its index in the roster.
@@ -258,7 +268,7 @@ impl GreedyAgent {
             rng: Rng::from_seed(seed),
             weights,
             orders: Vec::new(),
-            capture_field: Vec::new(),
+            capture_fields: CaptureFields::new(),
             advance_field: Vec::new(),
             decay: Vec::new(),
             occupant: Vec::new(),
@@ -268,6 +278,124 @@ impl GreedyAgent {
 
     pub const fn weights(&self) -> &Weights {
         &self.weights
+    }
+}
+
+/// The pull toward capturable property, measured in turns rather than tiles.
+///
+/// Manhattan distance says a mountain and a road are the same distance apart,
+/// and that a river is no further than the bridge over it. On a board twenty
+/// tiles wide that is most of what the pull field is deciding, so the field
+/// asks [`query::Travel`] what a route really costs and divides by what a unit
+/// can spend in a turn.
+///
+/// One field for each movement class that can capture, because the two classes
+/// that can — foot at three points a turn and boot at two — are not the same
+/// distance from anything. Both fields are read by tile, so the extra work is
+/// all in the building.
+///
+/// The searches are grouped by what a property is worth and not run once for
+/// each property. A group's pull is `weight * decay^turns` and the field takes
+/// the best of them, so the best over the targets of one weight is that weight
+/// at the nearest of them — which is one search seeded at all of them at once.
+/// The board holds at most a handful of distinct weights, so this is a
+/// handful of searches rather than one for each of the thirty-eight
+/// properties.
+struct CaptureFields {
+    /// One field for each movement class, filled only for those that capture
+    /// and only while our side holds a unit of the class.
+    fields: [Vec<f64>; MovementClass::COUNT],
+    /// The targets of each distinct approach weight, rebuilt each play.
+    groups: Vec<(f64, Vec<Pos>)>,
+    /// Movement points to the nearest target of the group being walked.
+    points: Vec<Option<u16>>,
+}
+
+/// The movement classes that can capture, and what one of them spends in a
+/// turn.
+///
+/// Only two unit profiles carry `can_capture`, so the whole table is two
+/// classes wide however many kinds the ruleset grows. The field uses the
+/// effective movement allowance, including the active commander's power.
+/// Fuel is unit-specific and can change after resupply, so it is not a route
+/// property and does not limit this multi-turn estimate.
+const CAPTURE_CLASSES: [MovementClass; 2] = [MovementClass::Foot, MovementClass::Boot];
+
+impl CaptureFields {
+    const fn new() -> Self {
+        Self {
+            fields: [const { Vec::new() }; MovementClass::COUNT],
+            groups: Vec::new(),
+            points: Vec::new(),
+        }
+    }
+
+    /// The field a unit of this class reads. Empty for a class that cannot
+    /// capture, which answers no pull rather than a wrong one.
+    fn of(&self, class: MovementClass) -> &[f64] {
+        &self.fields[class.index()]
+    }
+
+    /// Rebuild both fields for the position in front of the agent.
+    ///
+    /// A property already carrying a capturer of ours pulls nothing. Without
+    /// that, every capturer on the board walks at the same property, and the
+    /// ones that arrive second stand next to it doing nothing at all.
+    fn build(&mut self, board: &Board<'_>, decay: &[f64], occupant: &[Option<u16>]) {
+        let cells = board.cells();
+        for field in &mut self.fields {
+            field.clear();
+        }
+        self.groups.clear();
+        for (position, tile) in board.state.board.iter() {
+            if !board.capturable(tile) {
+                continue;
+            }
+            let Some(cell) = board.cell(position) else {
+                continue;
+            };
+            if occupant[cell].is_some_and(|index| board.is_our_capturer(index)) {
+                continue;
+            }
+            let weight = board.approach_weight(tile.terrain);
+            match self.groups.iter_mut().find(|(known, _)| *known == weight) {
+                Some((_, targets)) => targets.push(position),
+                None => self.groups.push((weight, vec![position])),
+            }
+        }
+        if self.groups.is_empty() {
+            return;
+        }
+
+        let Some(mut travel) = query::Travel::open(board.state, board.seat) else {
+            return;
+        };
+        for class in CAPTURE_CLASSES {
+            // A class our side does not field costs a search for each weight
+            // on the board and is read by nothing.
+            let Some(allowance) = board.capture_allowance(class) else {
+                continue;
+            };
+            let field = &mut self.fields[class.index()];
+            field.resize(cells, 0.0);
+            for (weight, targets) in &self.groups {
+                travel.points_to(class, allowance, targets.iter().copied(), &mut self.points);
+                for (cell, value) in field.iter_mut().enumerate() {
+                    let Some(Some(points)) = self.points.get(cell).copied() else {
+                        continue;
+                    };
+                    let turns = usize::from(query::Travel::turns(points, allowance));
+                    // Past the end of the table the pull is smaller than
+                    // anything that decides a play, so the last entry stands
+                    // for every distance beyond it.
+                    let step = decay[turns.min(decay.len() - 1)];
+                    let pull = weight * step;
+                    if pull > *value {
+                        *value = pull;
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -286,7 +414,7 @@ impl Agent for GreedyAgent {
             rng,
             weights,
             orders,
-            capture_field,
+            capture_fields,
             advance_field,
             decay,
             occupant,
@@ -300,7 +428,7 @@ impl Agent for GreedyAgent {
         };
         board.decay_table(decay);
         board.occupants(occupant);
-        board.capture_field(capture_field, decay, occupant);
+        capture_fields.build(&board, decay, occupant);
         board.advance_field(advance_field, decay);
         // A map priced at nothing is never read, so it is never built. That
         // is what keeps the threatless weighting at the throughput it was
@@ -316,7 +444,7 @@ impl Agent for GreedyAgent {
         let scorer = Scorer {
             board: &board,
             legal: &legal,
-            capture_field,
+            capture_fields,
             advance_field,
             occupant,
             threat,
@@ -426,7 +554,13 @@ impl Board<'_> {
         }
     }
 
-    /// `proximity_decay` for each distance this board can hold.
+    /// `proximity_decay` for each turn, and for each tile of the board's
+    /// span, which is longer than any field needs and short enough to build.
+    ///
+    /// [`CaptureFields`] reads it by turns and [`Board::advance_field`] by
+    /// tiles, and the two are not the same unit. Both clamp at the end of the
+    /// table, where the pull is already smaller than anything that decides a
+    /// play.
     fn decay_table(&self, out: &mut Vec<f64>) {
         let span = usize::from(self.state.board.width()) + usize::from(self.state.board.height());
         out.clear();
@@ -451,32 +585,22 @@ impl Board<'_> {
         }
     }
 
-    /// How much each tile wants a capture-capable unit.
+    /// The effective allowance of our capturer in this movement class.
     ///
-    /// A property already carrying a capturer of ours pulls nothing. Without
-    /// that, every capturer on the board walks at the same property, and the
-    /// ones that arrive second stand next to it doing nothing at all.
-    fn capture_field(&self, out: &mut Vec<f64>, decay: &[f64], occupant: &[Option<u16>]) {
-        out.clear();
-        out.resize(self.cells(), 0.0);
-        for (target, tile) in self.state.board.iter() {
-            if !self.capturable(tile) {
-                continue;
-            }
-            let Some(cell) = self.cell(target) else {
-                continue;
-            };
-            if occupant[cell].is_some_and(|index| self.is_our_capturer(index)) {
-                continue;
-            }
-            let weight = self.approach_weight(tile.terrain);
-            for (from, value) in self.state.board.positions().zip(out.iter_mut()) {
-                let pull = weight * decay[target.distance(from) as usize];
-                if pull > *value {
-                    *value = pull;
-                }
-            }
-        }
+    /// A pull field is read only by capturers, so a class without one is a
+    /// search for each weight on the board that answers nobody.
+    fn capture_allowance(&self, class: MovementClass) -> Option<u16> {
+        self.state.units.iter().find_map(|unit| {
+            let profile = ruleset::profile(unit.kind);
+            (matches!(unit.location, Location::Board { .. })
+                && unit.owner == self.seat
+                && profile.can_capture
+                && profile.movement_class == class)
+                .then(|| {
+                    commander::effective_move(self.state, unit, profile.movement, profile.domain)
+                        .min(u64::from(u16::MAX)) as u16
+                })
+        })
     }
 
     /// How much each tile wants a unit that fights.
@@ -583,7 +707,7 @@ fn capture_value(weights: &Weights, weight: f64, points: u8, progress: u8) -> f6
 struct Scorer<'a> {
     board: &'a Board<'a>,
     legal: &'a Legal<'a>,
-    capture_field: &'a [f64],
+    capture_fields: &'a CaptureFields,
     advance_field: &'a [f64],
     occupant: &'a [Option<u16>],
     threat: &'a ThreatMap,
@@ -789,8 +913,9 @@ impl Scorer<'_> {
             return 0.0;
         };
         let cell = usize::from(order.destination().get());
-        let field = if ruleset::profile(unit.kind).can_capture {
-            self.capture_field
+        let profile = ruleset::profile(unit.kind);
+        let field = if profile.can_capture {
+            self.capture_fields.of(profile.movement_class)
         } else {
             self.advance_field
         };
@@ -831,7 +956,7 @@ impl Scorer<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::board::arena;
+    use crate::board::{amber_valley, arena};
     use awvm::semantic::{AwbwVisibility, Concealment, UnitAction, UnitId, observe};
 
     /// One unit of `kind`, at whole health, standing where it is put.
@@ -865,8 +990,11 @@ mod tests {
         );
         // A capture that wins the match is not one objective among several.
         assert!(weights.hq > weights.land * 10.0);
-        // The walk toward a headquarters is, and it beats a base two tiles
-        // further away and loses to one two tiles nearer.
+        // The walk toward a headquarters is, and it beats a base three turns
+        // further away and loses to one three turns nearer. The unit here is
+        // turns because that is what the capture field now measures; it was
+        // tiles when the field counted them, and the same three steps of decay
+        // is now a far longer reach.
         assert!(weights.hq_approach > weights.land);
         assert!(weights.hq_approach < weights.land / weights.proximity_decay.powi(3));
     }
@@ -914,6 +1042,132 @@ mod tests {
             ruleset::profile(kind).can_capture,
             "the opening build was a {kind:?}, which captures nothing"
         );
+    }
+
+    /// The whole reason for measuring turns: terrain is what a route costs.
+    ///
+    /// Manhattan distance says a mountain and a road are the same distance
+    /// apart, so a property behind a mountain range pulled exactly as hard as
+    /// one along a road. The field now asks what the route costs, so a tile
+    /// the terrain puts further away is further away.
+    ///
+    /// This drives the real board rather than a fixture, because the claim is
+    /// about a field built from a whole position. It asserts the two things
+    /// that separate the new field from the old one: it disagrees with a
+    /// straight line somewhere, and a foot unit and a boot unit — three points
+    /// a turn against two — do not read the same field.
+    #[test]
+    fn the_capture_field_measures_the_route_and_not_the_line() {
+        let mut state = amber_valley(false, 1);
+        let seat = state
+            .players
+            .seat(&state.turn.active_player)
+            .expect("the active player holds a seat");
+        // The opening position fields no mech, and a class we hold nothing of
+        // is skipped rather than searched for. Give the seat one, so that both
+        // fields are built and the two allowances can be compared.
+        let home = state
+            .units
+            .iter()
+            .find(|unit| unit.owner == seat)
+            .and_then(|unit| match unit.location {
+                Location::Board { position } => Some(position),
+                Location::Cargo { .. } => None,
+            })
+            .expect("the seat opens with a unit on the board");
+        let mut mech = test_unit(UnitKind::Mech, home, seat);
+        mech.id = UnitId::new(u32::from(u16::MAX));
+        state.units.push(mech);
+        let weights = Weights::DEFAULT;
+        let board = Board {
+            state: &state,
+            seat,
+            weights: &weights,
+        };
+        let mut decay = Vec::new();
+        let mut occupant = Vec::new();
+        board.decay_table(&mut decay);
+        board.occupants(&mut occupant);
+        let mut fields = CaptureFields::new();
+        fields.build(&board, &decay, &occupant);
+
+        let foot = fields.of(MovementClass::Foot);
+        let boot = fields.of(MovementClass::Boot);
+        assert_eq!(foot.len(), board.cells(), "a foot field covers the board");
+        assert_eq!(boot.len(), board.cells(), "a boot field covers the board");
+        assert!(
+            foot.iter().any(|pull| *pull > 0.0),
+            "a board with open property pulls somewhere"
+        );
+
+        // Two classes, two allowances, two fields. Equal fields would mean the
+        // allowance is not being read at all.
+        assert!(
+            foot != boot,
+            "foot spends three points a turn and boot two, so the two classes \
+             are not the same number of turns from the same property"
+        );
+
+        // And the field is not the old one under another name. A tile whose
+        // best pull differs from what a Manhattan field would give is a tile
+        // the terrain moved, which is the entire change.
+        let mut manhattan = vec![0.0; board.cells()];
+        for (target, tile) in board.state.board.iter() {
+            if !board.capturable(tile) {
+                continue;
+            }
+            let Some(cell) = board.cell(target) else {
+                continue;
+            };
+            if occupant[cell].is_some_and(|index| board.is_our_capturer(index)) {
+                continue;
+            }
+            let weight = board.approach_weight(tile.terrain);
+            for (from, value) in board.state.board.positions().zip(&mut manhattan) {
+                let pull = weight * decay[target.distance(from) as usize];
+                if pull > *value {
+                    *value = pull;
+                }
+            }
+        }
+        let moved = foot
+            .iter()
+            .zip(manhattan.iter())
+            .filter(|(route, line)| (*route - *line).abs() > f64::EPSILON)
+            .count();
+        assert!(
+            moved > 0,
+            "the route field agreed with a straight line everywhere"
+        );
+    }
+
+    #[test]
+    fn travel_rejects_an_entry_cost_above_the_turn_allowance() {
+        let mut state = amber_valley(false, 1);
+        state.weather.kind = awvm::ruleset::WeatherKind::Snow;
+        let seat = state
+            .players
+            .seat(&state.turn.active_player)
+            .expect("the active player holds a seat");
+        let mountain = state
+            .board
+            .iter()
+            .find_map(|(position, tile)| (tile.terrain == Terrain::Mountain).then_some(position))
+            .expect("Amber Valley contains a mountain");
+        let dimensions = state.board.dimensions();
+        let cell = dimensions
+            .cell_index(mountain)
+            .expect("the mountain is on the board");
+        let mut travel = query::Travel::open(&state, seat).expect("the seat has travel tables");
+        let mut points = Vec::new();
+
+        // Foot movement pays four points for a snowy mountain. Infantry can
+        // spend only three, so waiting for another turn cannot make it enter.
+        travel.points_to(MovementClass::Foot, 3, [mountain], &mut points);
+        assert_eq!(points[usize::from(cell.get())], None);
+
+        travel.points_to(MovementClass::Foot, 4, [mountain], &mut points);
+        assert_eq!(points[usize::from(cell.get())], Some(0));
     }
 
     /// The emergency the priorities did not name: an enemy soldier standing

--- a/crates/awbrn-ai/src/bin/arena.rs
+++ b/crates/awbrn-ai/src/bin/arena.rs
@@ -247,6 +247,17 @@ struct Tally {
     /// The shape of the games, from each side of the board.
     under_test: Side,
     opponent: Side,
+    /// Pairs completed, and the points the agent under test took over them.
+    ///
+    /// A pair is one observation and the interval counts these, not games.
+    /// See [`paired_interval`].
+    pairs: u32,
+    pair_points: f64,
+    pair_scores: Vec<f64>,
+    /// How the pairs went: both games, one each, neither.
+    swept: u32,
+    split: u32,
+    lost_both: u32,
 }
 
 impl Tally {
@@ -257,6 +268,24 @@ impl Tally {
     /// The score of the agent under test, a draw counting a half.
     fn score(&self) -> f64 {
         (f64::from(self.wins) + f64::from(self.draws) / 2.0) / f64::from(self.games())
+    }
+
+    /// Add one pair, worth the points the agent under test took over its two
+    /// games.
+    ///
+    /// `points` is 0, a half or 1, and a quarter or three quarters when one of
+    /// the two games was drawn.
+    fn add_pair(&mut self, points: f64) {
+        self.pairs += 1;
+        self.pair_points += points;
+        self.pair_scores.push(points);
+        if points > 0.75 {
+            self.swept += 1;
+        } else if points < 0.25 {
+            self.lost_both += 1;
+        } else {
+            self.split += 1;
+        }
     }
 
     fn mean_days(&self) -> f64 {
@@ -344,6 +373,7 @@ fn run(options: &Options) -> Result<Tally> {
     let mut session = Session::new(state(options, options.seed));
 
     for pair in 0..options.pairs {
+        let mut pair_points = 0.0;
         for under_test_first in [true, false] {
             let game = Rng::mix(options.seed ^ ((pair as u64) << 32));
             let mut entropy = Rng::from_seed(Rng::mix(game ^ 0x1));
@@ -399,8 +429,9 @@ fn run(options: &Options) -> Result<Tally> {
                     options.limits(),
                 )
             };
-            score(&mut tally, &record, &teams[seat], seat);
+            pair_points += score(&mut tally, &record, &teams[seat], seat);
         }
+        tally.add_pair(pair_points / 2.0);
     }
 
     Ok(tally)
@@ -545,7 +576,10 @@ impl Sample {
 ///
 /// `seat` is the seat the agent under test sat in, which changes with the seat
 /// order and is what keeps the shape of the game on the right side.
-fn score(tally: &mut Tally, record: &Record, team: &TeamId, seat: usize) {
+///
+/// Answers the points the agent under test took, which the pair it belongs to
+/// sums.
+fn score(tally: &mut Tally, record: &Record, team: &TeamId, seat: usize) -> f64 {
     tally.commands += record.commands;
     tally.refusals += record.refusals;
     tally.days += u64::from(record.days);
@@ -571,32 +605,46 @@ fn score(tally: &mut Tally, record: &Record, team: &TeamId, seat: usize) {
             }
             if winners.contains(team) {
                 tally.wins += 1;
+                1.0
             } else {
                 tally.losses += 1;
+                0.0
             }
         }
         Some(_) => {
             tally.endings.drawn += 1;
             tally.draws += 1;
+            0.5
         }
         None => {
             tally.abandoned += 1;
             tally.draws += 1;
+            0.5
         }
     }
 }
 
-/// The 95% Wilson score interval for a proportion.
+/// A 95% percentile-bootstrap interval over independent pair scores.
 ///
-/// A normal interval is wrong near zero and one, and a first agent against a
-/// random one lands near one. This one does not, and it never leaves `0..=1`.
-fn wilson(wins: f64, games: f64) -> (f64, f64) {
-    const Z: f64 = 1.96;
-    let p = wins / games;
-    let denominator = 1.0 + Z * Z / games;
-    let centre = (p + Z * Z / (2.0 * games)) / denominator;
-    let half = Z * (p * (1.0 - p) / games + Z * Z / (4.0 * games * games)).sqrt() / denominator;
-    ((centre - half).max(0.0), (centre + half).min(1.0))
+/// Each observation is the bounded score from a seat-swapped pair and can be
+/// 0, 0.25, 0.5, 0.75, or 1. Resampling those observations supports the
+/// fractional outcomes that a binomial interval does not. A fixed seed keeps
+/// repeated reports identical.
+fn paired_interval(scores: &[f64]) -> (f64, f64) {
+    const RESAMPLES: usize = 10_000;
+    assert!(!scores.is_empty(), "an interval needs at least one pair");
+
+    let mut rng = Rng::from_seed(0x7061_6972_2d63_6921);
+    let mut means = Vec::with_capacity(RESAMPLES);
+    for _ in 0..RESAMPLES {
+        let sum = (0..scores.len())
+            .map(|_| scores[rng.below(scores.len() as u64) as usize])
+            .sum::<f64>();
+        means.push(sum / scores.len() as f64);
+    }
+    means.sort_unstable_by(f64::total_cmp);
+    let percentile = |numerator: usize| means[(RESAMPLES - 1) * numerator / 1_000];
+    (percentile(25), percentile(975))
 }
 
 /// The rating difference a score implies.
@@ -610,10 +658,7 @@ fn elo(score: f64) -> Option<f64> {
 fn report(options: &Options, tally: &Tally, elapsed: f64) {
     let games = tally.games();
     let score = tally.score();
-    let (low, high) = wilson(
-        f64::from(tally.wins) + f64::from(tally.draws) / 2.0,
-        f64::from(games),
-    );
+    let (low, high) = paired_interval(&tally.pair_scores);
 
     println!(
         "{} vs {}   seed {}  fog {}  day cap {}",
@@ -631,7 +676,11 @@ fn report(options: &Options, tally: &Tally, elapsed: f64) {
         "wins {}  losses {}  draws {}",
         tally.wins, tally.losses, tally.draws
     );
-    println!("score                    {score:.4}  ({low:.4} to {high:.4}, Wilson 95%)");
+    println!("score                    {score:.4}  ({low:.4} to {high:.4}, paired bootstrap 95%)");
+    println!(
+        "pairs swept {}  split {}  lost {}",
+        tally.swept, tally.split, tally.lost_both
+    );
     match elo(score) {
         Some(elo) => println!("elo difference           {elo:+.0}"),
         None => println!(
@@ -794,19 +843,44 @@ mod tests {
     }
 
     #[test]
-    fn a_wilson_interval_holds_the_score_and_stays_in_range() {
-        let (low, high) = wilson(55.0, 100.0);
-        assert!(low < 0.55 && 0.55 < high);
-        // The reason for Wilson rather than a normal interval: at the ends the
-        // normal one leaves the range a proportion lives in.
-        let (low, high) = wilson(100.0, 100.0);
-        assert!(low > 0.9 && (high - 1.0).abs() < 1e-9);
-        let (low, high) = wilson(0.0, 100.0);
-        assert!(low.abs() < 1e-9 && high < 0.1);
-        // More games, a tighter interval.
-        let (few, _) = wilson(9.0, 10.0);
-        let (many, _) = wilson(900.0, 1000.0);
-        assert!(many > few);
+    fn the_paired_interval_supports_fractional_scores() {
+        let scores = [0.0, 0.25, 0.5, 0.75, 1.0];
+        let (low, high) = paired_interval(&scores);
+        assert!(low < 0.5 && 0.5 < high);
+        assert!(0.0 <= low && high <= 1.0);
+
+        // Fractional observations are values in their own right. They are not
+        // randomly rounded to wins and losses before the interval is built.
+        assert_eq!(paired_interval(&[0.5; 20]), (0.5, 0.5));
+    }
+
+    #[test]
+    fn the_interval_counts_pairs_and_is_wider_than_it_was() {
+        // Treating the games as independent duplicates each pair score and
+        // makes the interval too narrow.
+        let pairs = [0.0, 1.0].repeat(50);
+        let games = pairs
+            .iter()
+            .flat_map(|score| [*score, *score])
+            .collect::<Vec<_>>();
+        let over_pairs = paired_interval(&pairs);
+        let over_games = paired_interval(&games);
+        let width = |(low, high): (f64, f64)| high - low;
+        assert!(width(over_pairs) > width(over_games));
+    }
+
+    #[test]
+    fn a_pair_is_one_observation_however_its_games_went() {
+        let mut tally = Tally::default();
+        tally.add_pair(1.0);
+        tally.add_pair(0.5);
+        tally.add_pair(0.0);
+        // A pair with one drawn game is neither swept nor lost.
+        tally.add_pair(0.75);
+        assert_eq!(tally.pairs, 4);
+        assert!((tally.pair_points - 2.25).abs() < 1e-9);
+        assert_eq!(tally.pair_scores, [1.0, 0.5, 0.0, 0.75]);
+        assert_eq!((tally.swept, tally.split, tally.lost_both), (1, 2, 1));
     }
 
     #[test]

--- a/crates/awvm/src/query.rs
+++ b/crates/awvm/src/query.rs
@@ -915,6 +915,196 @@ fn reachable_with(
     })
 }
 
+/// Movement points from every tile to the nearest of a set of targets.
+///
+/// [`reachable`] answers "where can this unit go", which is a search for each
+/// unit from where it stands. This answers the other direction: "what does it
+/// cost to get to one of these tiles", which is one search for a whole set of
+/// targets and is then read for any number of units. A caller that scores
+/// every tile of the board against every property wants this and not the
+/// other one, because the properties do not move and the units do.
+///
+/// The answer is movement points and not turns. Turns need an allowance, and
+/// an allowance is not a property of the board: a commander power changes it
+/// and fuel caps it. Divide where it is read, and one table serves every unit
+/// of the class.
+///
+/// **This ignores units in the way.** It is a table about terrain, weather and
+/// the seat's commander, so it stays true for a whole turn while units move
+/// around inside it. That makes it a lower bound on what a route really costs,
+/// which is the same fidelity a straight-line distance already has, and it is
+/// why this does not build the blocking map [`reachable`] does.
+pub struct Travel<'a> {
+    maps: TurnMaps<'a>,
+    /// The class `costs` was flattened for, so that a caller asking about one
+    /// class again does not rebuild it.
+    flattened: Option<MovementClass>,
+    /// What each tile costs to enter, row-major, absent where it cannot be
+    /// entered. The same answer as the turn's entry-cost grid, in the shape
+    /// the search reads it in: a search settles every tile and looks at four
+    /// neighbours of each, and asking a grid costs a bounds check and a
+    /// multiply every time.
+    costs: Vec<Option<u16>>,
+    /// The largest entry cost on the board, which is the width of the ring
+    /// below.
+    widest: u16,
+    /// Dial's buckets, as a ring. Every edge of this graph costs at most
+    /// `widest`, so every tile still waiting sits within `widest` of the cost
+    /// being settled and a ring that long holds all of them.
+    ring: Vec<Vec<u16>>,
+}
+
+impl<'a> Travel<'a> {
+    /// Open the tables for one seat. `None` when the roster has no such seat.
+    ///
+    /// Entry costs follow the seat's commander and weather, so a table opened
+    /// for one player must not be read for another.
+    pub fn open(state: &'a State, seat: PlayerIdx) -> Option<Self> {
+        TurnMaps::for_seat(state, seat).map(|maps| Self {
+            maps,
+            flattened: None,
+            costs: Vec::new(),
+            widest: 0,
+            ring: Vec::new(),
+        })
+    }
+
+    /// Flatten the turn's entry costs for one class, if they are not already.
+    fn flatten(&mut self, class: MovementClass) {
+        if self.flattened == Some(class) {
+            return;
+        }
+        let entry = Arc::clone(self.maps.entry_costs(class));
+        let dimensions = self.maps.state.board.dimensions();
+        self.costs.clear();
+        self.costs.reserve(dimensions.len());
+        self.widest = 1;
+        for position in dimensions.positions() {
+            let points = dimensions
+                .cell(position)
+                .and_then(|cell| entry.at(cell).points());
+            if let Some(points) = points {
+                self.widest = self.widest.max(points);
+            }
+            self.costs.push(points);
+        }
+        self.ring.clear();
+        self.ring
+            .resize_with(usize::from(self.widest) + 1, Vec::new);
+        self.flattened = Some(class);
+    }
+
+    /// The cheapest movement points from each tile to the nearest target.
+    ///
+    /// `out` is written row-major, one entry per tile, and is `None` where no
+    /// route to any target exists for this movement class. A target a unit of
+    /// this class cannot enter is not a target and is skipped. `allowance` is
+    /// what the unit can spend in one turn. A finite entry cost above it is
+    /// impassable, because movement points cannot carry between turns.
+    ///
+    /// The search is seeded at the targets and expands outward, which is what
+    /// makes it one search rather than one for each tile. The cost of a tile
+    /// is charged on **leaving** it here, not on entering it: movement charges
+    /// on entry, so a route walked backward pays for the tile it came from,
+    /// and charging on entry instead would answer the cost of walking *out* of
+    /// a property rather than into it. The two differ by the endpoint costs.
+    pub fn points_to(
+        &mut self,
+        class: MovementClass,
+        allowance: u16,
+        targets: impl IntoIterator<Item = Pos>,
+        out: &mut Vec<Option<u16>>,
+    ) {
+        self.flatten(class);
+        let dimensions = self.maps.state.board.dimensions();
+        let width = usize::from(dimensions.width());
+        let cells = dimensions.len();
+        out.clear();
+        out.resize(cells, None);
+        for bucket in &mut self.ring {
+            bucket.clear();
+        }
+        let ring = self.ring.len();
+        let mut waiting = 0usize;
+
+        for target in targets {
+            let Some(index) = dimensions.cell_index(target) else {
+                continue;
+            };
+            let index = usize::from(index.get());
+            // A tile this class cannot enter cannot be walked to, so it is not
+            // a target however much the caller wants it.
+            if !self.costs[index].is_some_and(|cost| cost <= allowance) || out[index].is_some() {
+                continue;
+            }
+            out[index] = Some(0);
+            self.ring[0].push(index as u16);
+            waiting += 1;
+        }
+
+        let mut cost = 0u16;
+        while waiting > 0 {
+            let bucket = usize::from(cost) % ring;
+            while let Some(index) = self.ring[bucket].pop() {
+                waiting -= 1;
+                let index = usize::from(index);
+                // A tile is settled once, at the cost it was settled with. A
+                // later copy left in the ring by a cheaper route is stale.
+                if out[index] != Some(cost) {
+                    continue;
+                }
+                let Some(leaving) = self.costs[index] else {
+                    continue;
+                };
+                // A finite terrain cost can still exceed what this unit can
+                // spend in one turn. Such a tile can never occur in its path.
+                if leaving > allowance {
+                    continue;
+                }
+                let total = cost.saturating_add(leaving);
+                let column = index % width;
+                let west = (column > 0).then(|| index - 1);
+                let east = (column + 1 < width).then(|| index + 1);
+                let north = index.checked_sub(width);
+                let south = (index + width < cells).then_some(index + width);
+                for next in [west, east, north, south].into_iter().flatten() {
+                    // The neighbour is where the route would stand, so it must
+                    // be a tile this class can occupy at all.
+                    if self.costs[next].is_none() {
+                        continue;
+                    }
+                    if out[next].is_some_and(|best| best <= total) {
+                        continue;
+                    }
+                    out[next] = Some(total);
+                    self.ring[usize::from(total) % ring].push(next as u16);
+                    waiting += 1;
+                }
+            }
+            let Some(next) = cost.checked_add(1) else {
+                break;
+            };
+            cost = next;
+        }
+    }
+
+    /// Turns to cross `points` at an allowance, which is what a caller wants.
+    ///
+    /// **This is a lower bound.** A unit cannot always stop where its
+    /// allowance runs out: an occupied tile or a teleporter forces it short,
+    /// and a terrain cost can overshoot the boundary. It is optimistic by up
+    /// to a turn on awkward ground, and it is still far nearer the truth than
+    /// counting tiles.
+    ///
+    /// Zero points is the tile itself, which is nought turns away.
+    pub const fn turns(points: u16, allowance: u16) -> u16 {
+        if allowance == 0 {
+            return u16::MAX;
+        }
+        points.div_ceil(allowance)
+    }
+}
+
 /// What `unit` may do if it moves to `destination`.
 ///
 /// Every field is the reducer's own verdict on the corresponding command, so an

--- a/crates/awvm/tests/query.rs
+++ b/crates/awvm/tests/query.rs
@@ -1160,3 +1160,101 @@ fn destructible_damage(events: &[Event], position: Pos) -> u8 {
         })
         .unwrap_or(0)
 }
+
+/// `Travel` against `reachable`, over the whole corpus.
+///
+/// `reachable` searches forward from one unit and is already held to the
+/// reducer's own verdicts by the tests above. `Travel` searches backward from
+/// a set of targets, so it is the same movement rules read in the other
+/// direction and it needs its own equivalence coverage.
+///
+/// Two claims, and the second is the one that catches the mistake this search
+/// is easy to get wrong. A route walked backward must pay for the tile it came
+/// from rather than the tile it arrives at, because movement charges on entry.
+/// Charging the wrong end still gives a plausible-looking table: it differs
+/// from the truth only by the two endpoint costs, so it is right wherever the
+/// endpoints happen to cost the same and quietly wrong everywhere else. The
+/// equality below is what refuses it.
+#[test]
+fn travel_agrees_with_reachable_in_the_other_direction() {
+    let mut checked = 0usize;
+    let mut exact = 0usize;
+    for (name, case) in corpus() {
+        for state in states(&case) {
+            // The table ignores units in the way, so it can only be a lower
+            // bound while anything else stands on the board. With one unit
+            // there is nothing to block, and the bound must be tight.
+            let alone = state
+                .units
+                .iter()
+                .filter(|unit| matches!(unit.location, Location::Board { .. }))
+                .count()
+                == 1;
+            for unit in state.units.iter() {
+                let Location::Board { position: origin } = unit.location else {
+                    continue;
+                };
+                let seat = unit.owner;
+                let profile = awvm::ruleset::profile(unit.kind);
+                let class = profile.movement_class;
+                let allowance =
+                    awvm::commander::effective_move(&state, unit, profile.movement, profile.domain)
+                        as u16;
+                let Some(mut travel) = query::Travel::open(&state, seat) else {
+                    continue;
+                };
+                let Ok(field) = query::reachable(&state, unit.id) else {
+                    continue;
+                };
+                let dimensions = state.board.dimensions();
+                let Some(home) = dimensions.cell_index(origin) else {
+                    continue;
+                };
+                let mut points = Vec::new();
+                // The corpus holds boards built to exercise a rule rather
+                // than to be playable, and one of them stands a battleship on
+                // a plain. `reachable` always reports the tile a unit already
+                // occupies, whatever it costs to enter, so a unit standing
+                // where its own class cannot go has a reach this table is
+                // right to call unreachable. Nothing below can say anything
+                // about such a unit.
+                travel.points_to(class, allowance, [origin], &mut points);
+                if points[usize::from(home.get())].is_none() {
+                    continue;
+                }
+                for (destination, forward) in field.reach() {
+                    if destination == origin {
+                        continue;
+                    }
+                    travel.points_to(class, allowance, [destination], &mut points);
+                    let backward = u64::from(points[usize::from(home.get())]
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "{name}: {origin:?} reaches {destination:?} forward, so a route exists"
+                            )
+                        }));
+                    assert!(
+                        backward <= forward,
+                        "{name}: travel {backward} beats the reducer's own route {forward} \
+                         from {origin:?} to {destination:?}"
+                    );
+                    checked += 1;
+                    if alone {
+                        assert_eq!(
+                            backward, forward,
+                            "{name}: nothing is in the way from {origin:?} to {destination:?}, \
+                             so the backward cost must be the forward one"
+                        );
+                        exact += 1;
+                    }
+                }
+            }
+        }
+    }
+    assert!(checked > 0, "the corpus offered no routes to check");
+    assert!(
+        exact > 0,
+        "no single-unit board was found, so the equality above never ran and \
+         the direction of the search is untested"
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * AI capture planning now evaluates actual travel routes and turn costs rather than straight-line distance.
  * Capture estimates account for different movement types, improving decisions for units with varied mobility.
  * Travel calculations better handle terrain costs, movement allowances, and inaccessible targets.

* **Tournament Reporting**
  * Tournament results now summarize mirrored games as pairs, including swept, split, and lost outcomes.
  * Statistical confidence reporting is based on game-pair results for more meaningful comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->