### PR TITLE
Add match history

### DIFF
--- a/web/src/auth/AuthPage.tsx
+++ b/web/src/auth/AuthPage.tsx
@@ -43,6 +43,7 @@ export function AuthPage({ isRegister }: { isRegister: boolean }) {
       }
 
       queryClient.removeQueries({ queryKey: matchKeys.mine() });
+      queryClient.removeQueries({ queryKey: matchKeys.completed() });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: authKeys.all }),
         queryClient.invalidateQueries({ queryKey: matchKeys.details() }),

--- a/web/src/layouts/Layout.tsx
+++ b/web/src/layouts/Layout.tsx
@@ -39,6 +39,7 @@ export function Layout({ children }: { children: ReactNode }) {
       }
 
       queryClient.removeQueries({ queryKey: matchKeys.mine() });
+      queryClient.removeQueries({ queryKey: matchKeys.completed() });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: authKeys.all }),
         queryClient.invalidateQueries({ queryKey: matchKeys.details() }),
@@ -69,11 +70,18 @@ export function Layout({ children }: { children: ReactNode }) {
             label="Matches"
           />
           {session ? (
-            <RouterTopNavItem
-              to="/my/matches"
-              isSelected={pathname === "/my/matches"}
-              label="My Matches"
-            />
+            <>
+              <RouterTopNavItem
+                to="/my/matches"
+                isSelected={pathname === "/my/matches"}
+                label="My Matches"
+              />
+              <RouterTopNavItem
+                to="/my/history"
+                isSelected={pathname === "/my/history"}
+                label="History"
+              />
+            </>
           ) : null}
           <RouterTopNavItem
             to="/matches/new"

--- a/web/src/matches/cursor.ts
+++ b/web/src/matches/cursor.ts
@@ -1,0 +1,13 @@
+import type { z } from "zod";
+
+/** Decode and validate a JSON cursor. */
+export function decodeCursor<T>(cursor: string | undefined, schema: z.ZodType<T>): T | null {
+  if (!cursor) return null;
+
+  try {
+    const result = schema.safeParse(JSON.parse(cursor));
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/matches/match_browse.test.ts
+++ b/web/src/matches/match_browse.test.ts
@@ -9,12 +9,12 @@ describe("cursor encoding", () => {
   it("round-trips a valid browse cursor", () => {
     const encoded = encodeMatchBrowseCursor({
       createdAt: "2026-04-06T12:00:00.000Z",
-      matchId: "abc123",
+      matchId: "abc123def4567",
     });
 
     expect(decodeMatchBrowseCursor(encoded)).toEqual({
       createdAt: "2026-04-06T12:00:00.000Z",
-      matchId: "abc123",
+      matchId: "abc123def4567",
     });
   });
 

--- a/web/src/matches/match_browse.ts
+++ b/web/src/matches/match_browse.ts
@@ -1,33 +1,20 @@
+import { z } from "zod";
+import { decodeCursor } from "./cursor";
+import { matchIdSchema } from "./match_id";
+
 export const MATCH_BROWSE_PAGE_SIZE = 12;
 
-export interface MatchBrowseCursor {
-  createdAt: string;
-  matchId: string;
-}
+const matchBrowseCursorSchema = z.object({
+  createdAt: z.iso.datetime(),
+  matchId: matchIdSchema,
+});
+
+export type MatchBrowseCursor = z.infer<typeof matchBrowseCursorSchema>;
 
 export function encodeMatchBrowseCursor(cursor: MatchBrowseCursor): string {
   return JSON.stringify(cursor);
 }
 
 export function decodeMatchBrowseCursor(cursor: string | undefined): MatchBrowseCursor | null {
-  if (!cursor) {
-    return null;
-  }
-
-  try {
-    const value = JSON.parse(cursor) as Partial<MatchBrowseCursor>;
-    if (
-      typeof value.createdAt === "string" &&
-      value.createdAt.length > 0 &&
-      typeof value.matchId === "string" &&
-      value.matchId.length > 0
-    ) {
-      return {
-        createdAt: value.createdAt,
-        matchId: value.matchId,
-      };
-    }
-  } catch {}
-
-  return null;
+  return decodeCursor(cursor, matchBrowseCursorSchema);
 }

--- a/web/src/matches/match_history.test.ts
+++ b/web/src/matches/match_history.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeMatchHistoryCursor,
+  encodeMatchHistoryCursor,
+  formatMatchDuration,
+  formatSeatResultReason,
+  formatVerdict,
+  opposingSeats,
+  viewerOutcome,
+} from "./match_history";
+import type { MatchHistorySeat } from "./schemas";
+
+function seat(overrides: Partial<MatchHistorySeat> = {}): MatchHistorySeat {
+  return {
+    slotIndex: 0,
+    userId: "user-1",
+    userName: "Andy",
+    factionId: 1,
+    coId: null,
+    outcome: null,
+    placement: null,
+    reason: null,
+    ...overrides,
+  };
+}
+
+describe("viewerOutcome", () => {
+  it("reports the best outcome across the seats the viewer held", () => {
+    const outcome = viewerOutcome([
+      seat({ slotIndex: 0, outcome: "loss", reason: "rout" }),
+      seat({ slotIndex: 1, outcome: "win" }),
+    ]);
+    expect(outcome).toBe("win");
+  });
+
+  it("prefers a draw to a loss", () => {
+    const outcome = viewerOutcome([
+      seat({ slotIndex: 0, outcome: "loss", reason: "resignation" }),
+      seat({ slotIndex: 1, outcome: "draw", reason: "day-limit" }),
+    ]);
+    expect(outcome).toBe("draw");
+  });
+
+  it("is null when no seat has a recorded result", () => {
+    expect(viewerOutcome([seat(), seat({ slotIndex: 1 })])).toBeNull();
+  });
+});
+
+describe("match history cursors", () => {
+  it("round-trips the completion time and match id", () => {
+    const cursor = { completedAt: "2026-01-02T03:04:05.000Z", matchId: "abc123def4567" };
+    expect(decodeMatchHistoryCursor(encodeMatchHistoryCursor(cursor))).toEqual(cursor);
+  });
+
+  it("rejects missing and malformed cursors", () => {
+    expect(decodeMatchHistoryCursor(undefined)).toBeNull();
+    expect(decodeMatchHistoryCursor("not json")).toBeNull();
+    expect(decodeMatchHistoryCursor('{"completedAt":"","matchId":"abc123def4567"}')).toBeNull();
+  });
+});
+
+describe("formatVerdict", () => {
+  it("names each outcome", () => {
+    expect(formatVerdict("win")).toBe("Victory");
+    expect(formatVerdict("loss")).toBe("Defeat");
+    expect(formatVerdict("draw")).toBe("Draw");
+    expect(formatVerdict(null)).toBe("No result");
+  });
+});
+
+describe("formatSeatResultReason", () => {
+  it("reads a win with no reason as the surviving army", () => {
+    expect(formatSeatResultReason("win", null)).toBe("Last army standing");
+  });
+
+  it("reads a missing reason on any other outcome as an unrecorded result", () => {
+    expect(formatSeatResultReason("loss", null)).toBe("Result not recorded");
+    expect(formatSeatResultReason(null, null)).toBe("Result not recorded");
+  });
+
+  it("names every reason the engine can record", () => {
+    expect(formatSeatResultReason("loss", "rout")).toBe("Army destroyed");
+    expect(formatSeatResultReason("loss", "hq-capture")).toBe("HQ captured");
+    expect(formatSeatResultReason("loss", "lab-capture")).toBe("Lab captured");
+    expect(formatSeatResultReason("win", "capture-limit")).toBe("Capture limit");
+    expect(formatSeatResultReason("draw", "day-limit")).toBe("Day limit");
+    expect(formatSeatResultReason("loss", "resignation")).toBe("Resigned");
+    expect(formatSeatResultReason("loss", "timeout")).toBe("Timed out");
+    expect(formatSeatResultReason("draw", "agreement")).toBe("Agreed draw");
+  });
+});
+
+describe("formatMatchDuration", () => {
+  it("reports minutes below an hour", () => {
+    expect(formatMatchDuration("2026-01-01T00:00:00.000Z", "2026-01-01T00:42:00.000Z")).toBe(
+      "42 min",
+    );
+  });
+
+  it("never reports a finished match as zero minutes", () => {
+    expect(formatMatchDuration("2026-01-01T00:00:00.000Z", "2026-01-01T00:00:10.000Z")).toBe(
+      "1 min",
+    );
+  });
+
+  it("reports hours up to two days, then days", () => {
+    expect(formatMatchDuration("2026-01-01T00:00:00.000Z", "2026-01-01T06:00:00.000Z")).toBe(
+      "6 hr",
+    );
+    expect(formatMatchDuration("2026-01-01T00:00:00.000Z", "2026-01-05T00:00:00.000Z")).toBe(
+      "4 days",
+    );
+  });
+
+  it("is null when the match has no start time or the times disagree", () => {
+    expect(formatMatchDuration(null, "2026-01-01T00:00:00.000Z")).toBeNull();
+    expect(formatMatchDuration("2026-01-02T00:00:00.000Z", "2026-01-01T00:00:00.000Z")).toBeNull();
+  });
+});
+
+describe("opposingSeats", () => {
+  it("keeps every seat the viewer did not hold, in order", () => {
+    const seats = [
+      seat({ slotIndex: 0 }),
+      seat({ slotIndex: 1, userId: "user-2", userName: "Max" }),
+      seat({ slotIndex: 2, userId: "user-3", userName: "Sami" }),
+    ];
+    expect(opposingSeats(seats, [0]).map((entry) => entry.userName)).toEqual(["Max", "Sami"]);
+  });
+
+  it("is empty when the viewer held every seat", () => {
+    const seats = [seat({ slotIndex: 0 }), seat({ slotIndex: 1 })];
+    expect(opposingSeats(seats, [0, 1])).toEqual([]);
+  });
+});

--- a/web/src/matches/match_history.ts
+++ b/web/src/matches/match_history.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import { decodeCursor } from "./cursor";
+import { matchIdSchema } from "./match_id";
+import type { MatchOutcome, MatchPhase, MatchHistorySeat, SeatResultReason } from "./schemas";
+
+/** Finished matches are the only ones this record holds. */
+export const COMPLETED_MATCH_PHASE: MatchPhase = "completed";
+
+export const MATCH_HISTORY_PAGE_SIZE = 30;
+
+const matchHistoryCursorSchema = z.object({
+  completedAt: z.iso.datetime(),
+  matchId: matchIdSchema,
+});
+
+export type MatchHistoryCursor = z.infer<typeof matchHistoryCursorSchema>;
+
+export function encodeMatchHistoryCursor(cursor: MatchHistoryCursor): string {
+  return JSON.stringify(cursor);
+}
+
+export function decodeMatchHistoryCursor(cursor: string | undefined): MatchHistoryCursor | null {
+  return decodeCursor(cursor, matchHistoryCursorSchema);
+}
+
+/** Best outcome first, so a viewer who held several seats reads their best. */
+const outcomeRank: Record<MatchOutcome, number> = {
+  win: 0,
+  draw: 1,
+  loss: 2,
+};
+
+/**
+ * The outcome to report for a viewer who held one or more seats.
+ *
+ * Null when no seat has a recorded result, which happens while a match ended
+ * but its results were not written.
+ */
+export function viewerOutcome(seats: readonly MatchHistorySeat[]): MatchOutcome | null {
+  let best: MatchOutcome | null = null;
+  for (const seat of seats) {
+    if (seat.outcome === null) continue;
+    if (best === null || outcomeRank[seat.outcome] < outcomeRank[best]) {
+      best = seat.outcome;
+    }
+  }
+  return best;
+}
+
+/** The verdict, in the HUD voice the readouts use. */
+export function formatVerdict(outcome: MatchOutcome | null): string {
+  switch (outcome) {
+    case "win":
+      return "Victory";
+    case "loss":
+      return "Defeat";
+    case "draw":
+      return "Draw";
+    case null:
+      return "No result";
+  }
+}
+
+/**
+ * Why the seat ended where it did, in the game's own words.
+ *
+ * A win with no reason is the army that was still standing at the end.
+ */
+export function formatSeatResultReason(
+  outcome: MatchOutcome | null,
+  reason: SeatResultReason | null,
+): string {
+  if (reason === null) {
+    return outcome === "win" ? "Last army standing" : "Result not recorded";
+  }
+
+  switch (reason) {
+    case "rout":
+      return "Army destroyed";
+    case "hq-capture":
+      return "HQ captured";
+    case "lab-capture":
+      return "Lab captured";
+    case "capture-limit":
+      return "Capture limit";
+    case "day-limit":
+      return "Day limit";
+    case "resignation":
+      return "Resigned";
+    case "timeout":
+      return "Timed out";
+    case "agreement":
+      return "Agreed draw";
+  }
+}
+
+/**
+ * How long the match ran, from the first day to the last.
+ *
+ * Null while a match has no start time, which no finished match written by the
+ * current server lacks, but older rows can.
+ */
+export function formatMatchDuration(startedAt: string | null, completedAt: string): string | null {
+  if (startedAt === null) {
+    return null;
+  }
+
+  const started = Date.parse(startedAt);
+  const completed = Date.parse(completedAt);
+  if (!Number.isFinite(started) || !Number.isFinite(completed) || completed < started) {
+    return null;
+  }
+
+  const minutes = Math.round((completed - started) / 60_000);
+  if (minutes < 60) {
+    return `${Math.max(1, minutes)} min`;
+  }
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) {
+    return `${hours} hr`;
+  }
+
+  return `${Math.round(hours / 24)} days`;
+}
+
+/** The seats the viewer did not hold, in slot order. */
+export function opposingSeats(
+  seats: readonly MatchHistorySeat[],
+  viewerSlotIndexes: readonly number[],
+): MatchHistorySeat[] {
+  const held = new Set(viewerSlotIndexes);
+  return seats.filter((seat) => !held.has(seat.slotIndex));
+}

--- a/web/src/matches/matches.functions.ts
+++ b/web/src/matches/matches.functions.ts
@@ -7,12 +7,14 @@ import {
   createMatch,
   getMatchSnapshot,
   listMatches,
+  listMyCompletedMatches,
   listMyMatches,
   mutateMatch,
 } from "./matches.server";
 import {
   matchBrowseRequestSchema,
   matchCreateRequestSchema,
+  matchHistoryRequestSchema,
   matchMutationRequestSchema,
 } from "./schemas";
 
@@ -29,6 +31,16 @@ export const listMyMatchesFn = createServerFn({ method: "GET" })
   .handler(async ({ context }) => {
     if (!context.session) throw new Response("Unauthorized", { status: 401 });
     const result = await listMyMatches(context.session.user.id);
+    if (!result.ok) throw new Error(result.error.message);
+    return result.value;
+  });
+
+export const listMyCompletedMatchesFn = createServerFn({ method: "GET" })
+  .middleware([sessionMiddleware])
+  .validator(matchHistoryRequestSchema)
+  .handler(async ({ data, context }) => {
+    if (!context.session) throw new Response("Unauthorized", { status: 401 });
+    const result = await listMyCompletedMatches(context.session.user.id, data);
     if (!result.ok) throw new Error(result.error.message);
     return result.value;
   });

--- a/web/src/matches/matches.keys.ts
+++ b/web/src/matches/matches.keys.ts
@@ -6,6 +6,7 @@ export const matchKeys = {
   all: ["matches"] as const,
   browse: () => [...matchKeys.all, "browse"] as const,
   mine: () => [...matchKeys.all, "mine"] as const,
+  completed: () => [...matchKeys.all, "completed"] as const,
   details: () => [...matchKeys.all, "detail"] as const,
   detail: (matchId: string, joinSlug: string | null | undefined) =>
     [...matchKeys.details(), matchId, normalizeJoinSlug(joinSlug)] as const,

--- a/web/src/matches/matches.queries.ts
+++ b/web/src/matches/matches.queries.ts
@@ -1,5 +1,10 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
-import { getMatchFn, listMatchesFn, listMyMatchesFn } from "./matches.functions";
+import {
+  getMatchFn,
+  listMatchesFn,
+  listMyCompletedMatchesFn,
+  listMyMatchesFn,
+} from "./matches.functions";
 import { matchKeys, normalizeJoinSlug } from "./matches.keys";
 import type { MyMatchesResponse } from "./schemas";
 
@@ -28,6 +33,16 @@ export function myMatchesQueryOptions() {
         loadedAt: new Date().toISOString(),
       };
     },
+  });
+}
+
+export function myCompletedMatchesQueryOptions() {
+  return infiniteQueryOptions({
+    queryKey: matchKeys.completed(),
+    queryFn: ({ pageParam }) =>
+      listMyCompletedMatchesFn({ data: pageParam ? { cursor: pageParam } : {} }),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 }
 

--- a/web/src/matches/matches.server.ts
+++ b/web/src/matches/matches.server.ts
@@ -13,10 +13,21 @@ import type {
   MatchSettings,
   MatchSetup,
   MatchSnapshot,
+  MatchHistoryEntry,
+  MatchHistoryRequest,
+  MatchHistoryResponse,
+  MatchHistorySeat,
   MyMatchesResponse,
   MyMatchSummary,
 } from "./schemas";
 import { groupMyMatchRows, ONGOING_MATCH_PHASES } from "./my_matches";
+import {
+  COMPLETED_MATCH_PHASE,
+  decodeMatchHistoryCursor,
+  encodeMatchHistoryCursor,
+  MATCH_HISTORY_PAGE_SIZE,
+} from "./match_history";
+import { matchReplaysExist } from "./replay_archive";
 import {
   MATCH_BROWSE_PAGE_SIZE,
   decodeMatchBrowseCursor,
@@ -28,10 +39,23 @@ import { err, ok, type MatchResult } from "./match_protocol";
 import { generateMatchId } from "./match_id";
 import { getMatchStub } from "./match_service";
 import { drizzle } from "drizzle-orm/d1";
-import { and, asc, count, desc, eq, exists, gt, inArray, lt, or, sql } from "drizzle-orm";
-import { matches, matchParticipants, user } from "#/db/global.ts";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  exists,
+  gt,
+  inArray,
+  isNotNull,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
+import { matches, matchParticipants, matchResults, user } from "#/db/global.ts";
 
-const db = drizzle(env.DB, { schema: { matches, matchParticipants, user } });
+const db = drizzle(env.DB, { schema: { matches, matchParticipants, matchResults, user } });
 
 const PUBLIC_MATCH_PHASE: MatchPhase = "lobby";
 const STARTING_MATCH_PHASE: MatchPhase = "starting";
@@ -54,6 +78,7 @@ type MatchRow = Awaited<ReturnType<typeof queryMatchRow>>;
 type MatchParticipantRow = Awaited<ReturnType<typeof queryParticipantRows>>[number];
 type MatchBrowseRow = Awaited<ReturnType<typeof queryBrowseRows>>[number];
 type MyMatchRow = Awaited<ReturnType<typeof queryMyMatchRows>>[number];
+type MatchHistoryRow = Awaited<ReturnType<typeof queryMatchHistoryRows>>[number];
 
 export async function createMatch(
   input: MatchCreateRequest,
@@ -185,6 +210,98 @@ export async function listMyMatches(viewerUserId: string): Promise<MatchResult<M
   }
 
   return ok({ matches: myMatches });
+}
+
+/**
+ * The viewer's finished matches, newest first.
+ *
+ * Two queries rather than one: the page is a count of matches, not of seats,
+ * so the ids are picked first and every seat of those matches is read second.
+ */
+export async function listMyCompletedMatches(
+  viewerUserId: string,
+  input: MatchHistoryRequest,
+): Promise<MatchResult<MatchHistoryResponse>> {
+  const cursor = decodeMatchHistoryCursor(input.cursor);
+  const cursorCompletedAt = cursor ? new Date(cursor.completedAt) : null;
+  const cursorPredicate =
+    cursor && cursorCompletedAt && !Number.isNaN(cursorCompletedAt.getTime())
+      ? or(
+          lt(matches.completedAt, cursorCompletedAt),
+          and(eq(matches.completedAt, cursorCompletedAt), lt(matches.id, cursor.matchId)),
+        )
+      : undefined;
+  const recent = await db
+    .select({ matchId: matches.id, completedAt: matches.completedAt })
+    .from(matches)
+    .innerJoin(
+      matchParticipants,
+      and(eq(matchParticipants.matchId, matches.id), eq(matchParticipants.userId, viewerUserId)),
+    )
+    .where(
+      and(
+        eq(matches.phase, COMPLETED_MATCH_PHASE),
+        isNotNull(matches.completedAt),
+        cursorPredicate,
+      ),
+    )
+    .groupBy(matches.id)
+    .orderBy(desc(matches.completedAt), desc(matches.id))
+    .limit(MATCH_HISTORY_PAGE_SIZE + 1)
+    .all();
+
+  const hasNextPage = recent.length > MATCH_HISTORY_PAGE_SIZE;
+  const visibleRows = hasNextPage ? recent.slice(0, MATCH_HISTORY_PAGE_SIZE) : recent;
+  const matchIds = visibleRows.map((row) => row.matchId);
+  if (matchIds.length === 0) {
+    return ok({
+      matches: [],
+      pageSize: MATCH_HISTORY_PAGE_SIZE,
+      hasNextPage: false,
+      nextCursor: null,
+    });
+  }
+
+  const [rows, storedReplays] = await Promise.all([
+    queryMatchHistoryRows(matchIds),
+    matchReplaysExist(env.CONTENT, matchIds),
+  ]);
+
+  const rowsByMatchId = new Map<string, MatchHistoryRow[]>();
+  for (const row of rows) {
+    const current = rowsByMatchId.get(row.matchId);
+    if (current) current.push(row);
+    else rowsByMatchId.set(row.matchId, [row]);
+  }
+
+  const history: MatchHistoryEntry[] = [];
+  for (const matchId of matchIds) {
+    const matchRows = rowsByMatchId.get(matchId);
+    if (!matchRows) continue;
+
+    const settings = parseMatchSettingsValue(matchRows[0]!.settings);
+    if (!settings.ok) {
+      return settings;
+    }
+
+    history.push(
+      toMatchHistoryEntry(matchRows, settings.value, viewerUserId, storedReplays.has(matchId)),
+    );
+  }
+
+  const lastVisibleRow = visibleRows[visibleRows.length - 1] ?? null;
+  return ok({
+    matches: history,
+    pageSize: MATCH_HISTORY_PAGE_SIZE,
+    hasNextPage,
+    nextCursor:
+      hasNextPage && lastVisibleRow
+        ? encodeMatchHistoryCursor({
+            completedAt: lastVisibleRow.completedAt!.toISOString(),
+            matchId: lastVisibleRow.matchId,
+          })
+        : null,
+  });
 }
 
 export async function mutateMatch(
@@ -729,6 +846,41 @@ async function queryMyMatchRows(viewerUserId: string) {
     .all();
 }
 
+/** Every seat of the named matches, with the result recorded for each. */
+async function queryMatchHistoryRows(matchIds: string[]) {
+  return db
+    .select({
+      matchId: matches.id,
+      name: matches.name,
+      mapId: matches.mapId,
+      isPrivate: matches.isPrivate,
+      settings: matches.settings,
+      startedAt: matches.startedAt,
+      completedAt: matches.completedAt,
+      seatSlotIndex: matchParticipants.slotIndex,
+      seatUserId: matchParticipants.userId,
+      seatUserName: user.name,
+      seatFactionId: matchParticipants.factionId,
+      seatCoId: matchParticipants.coId,
+      seatOutcome: matchResults.outcome,
+      seatPlacement: matchResults.placement,
+      seatReason: matchResults.reason,
+    })
+    .from(matches)
+    .innerJoin(matchParticipants, eq(matchParticipants.matchId, matches.id))
+    .innerJoin(user, eq(user.id, matchParticipants.userId))
+    .leftJoin(
+      matchResults,
+      and(
+        eq(matchResults.matchId, matchParticipants.matchId),
+        eq(matchResults.slotIndex, matchParticipants.slotIndex),
+      ),
+    )
+    .where(inArray(matches.id, matchIds))
+    .orderBy(asc(matchParticipants.slotIndex))
+    .all();
+}
+
 function parseMatchSettingsValue(value: unknown): MatchResult<MatchSettings> {
   try {
     const result = matchSettingsSchema.safeParse(value);
@@ -806,6 +958,42 @@ function toMyMatchSummary(rows: MyMatchRow[], settings: MatchSettings): MyMatchS
         updatedAt: viewerRow.viewerUpdatedAt.toISOString(),
       }))
       .sort((a, b) => a.slotIndex - b.slotIndex),
+  };
+}
+
+/** One finished match, as the report the viewer reads. */
+function toMatchHistoryEntry(
+  rows: MatchHistoryRow[],
+  settings: MatchSettings,
+  viewerUserId: string,
+  hasReplay: boolean,
+): MatchHistoryEntry {
+  const row = rows[0]!;
+  const seats: MatchHistorySeat[] = rows.map((seatRow) => ({
+    slotIndex: seatRow.seatSlotIndex,
+    userId: seatRow.seatUserId,
+    userName: seatRow.seatUserName,
+    factionId: seatRow.seatFactionId,
+    coId: seatRow.seatCoId,
+    outcome: seatRow.seatOutcome,
+    placement: seatRow.seatPlacement,
+    reason: seatRow.seatReason,
+  }));
+
+  return {
+    matchId: row.matchId,
+    name: row.name,
+    mapId: row.mapId,
+    isPrivate: row.isPrivate,
+    settings,
+    startedAt: row.startedAt === null ? null : row.startedAt.toISOString(),
+    // Only matches with a completion time are selected, so this is never null.
+    completedAt: (row.completedAt ?? row.startedAt ?? new Date(0)).toISOString(),
+    viewerSlotIndexes: seats
+      .filter((seat) => seat.userId === viewerUserId)
+      .map((seat) => seat.slotIndex),
+    seats,
+    hasReplay,
   };
 }
 

--- a/web/src/matches/replay_archive.test.ts
+++ b/web/src/matches/replay_archive.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
-import { getMatchReplayResponse, matchReplayKey, uploadMatchReplay } from "./replay_archive";
+import {
+  getMatchReplayResponse,
+  isMatchReplayDownload,
+  matchReplayFileName,
+  matchReplayKey,
+  matchReplayDownloadPath,
+  matchReplayPath,
+  matchReplaysExist,
+  parseMatchReplay,
+  uploadMatchReplay,
+} from "./replay_archive";
 import type { MatchSetup } from "./schemas";
 
 const setup = {
@@ -65,5 +75,61 @@ describe("match replay archive", () => {
     const response = await getMatchReplayResponse({ get } as unknown as R2Bucket, setup.matchId);
 
     expect(response.status).toBe(404);
+  });
+});
+
+describe("parseMatchReplay", () => {
+  it("accepts an archive the uploader wrote", () => {
+    const replay = parseMatchReplay({ version: 1, setup, actions: [{ command: "endTurn" }] });
+
+    expect(replay.version).toBe(1);
+    expect(replay.setup.matchId).toBe(setup.matchId);
+    expect(replay.actions).toHaveLength(1);
+  });
+
+  it("rejects a file that is not an AWBRN archive", () => {
+    expect(() => parseMatchReplay({ version: 2, setup, actions: [] })).toThrow(
+      /not a valid AWBRN archive/,
+    );
+    expect(() => parseMatchReplay({ version: 1, actions: [] })).toThrow(
+      /not a valid AWBRN archive/,
+    );
+    expect(() => parseMatchReplay("nope")).toThrow(/not a valid AWBRN archive/);
+  });
+});
+
+describe("matchReplayPath", () => {
+  it("points at the route that serves the archive", () => {
+    expect(matchReplayPath("abc123def456g")).toBe("/replays/abc123def456g.json");
+  });
+
+  it("names the downloaded file after its match", () => {
+    expect(matchReplayFileName("abc123def456g")).toBe("awbrn-replay-abc123def456g.json");
+  });
+
+  it("asks for the file to keep on its own path, so the two do not share a cache entry", () => {
+    expect(matchReplayDownloadPath("abc123def456g")).toBe("/replays/abc123def456g.json?download=1");
+    expect(isMatchReplayDownload(new URL("https://awbrn.test/replays/x.json?download=1"))).toBe(
+      true,
+    );
+    expect(isMatchReplayDownload(new URL("https://awbrn.test/replays/x.json"))).toBe(false);
+  });
+});
+
+describe("matchReplaysExist", () => {
+  it("reports only the matches that have a stored archive", async () => {
+    const head = vi.fn(async (key: string) => (key.includes("kept") ? {} : null));
+
+    const stored = await matchReplaysExist({ head } as unknown as R2Bucket, ["kept", "missing"]);
+
+    expect(stored).toEqual(new Set(["kept"]));
+    expect(head).toHaveBeenCalledWith("replays/kept.json");
+    expect(head).toHaveBeenCalledWith("replays/missing.json");
+  });
+
+  it("checks nothing when no match is named", async () => {
+    const head = vi.fn();
+    expect(await matchReplaysExist({ head } as unknown as R2Bucket, [])).toEqual(new Set());
+    expect(head).not.toHaveBeenCalled();
   });
 });

--- a/web/src/matches/replay_archive.ts
+++ b/web/src/matches/replay_archive.ts
@@ -1,15 +1,90 @@
-import type { MatchSetup } from "./schemas";
+import { z } from "zod";
+import { matchSetupSchema, type MatchSetup } from "./schemas";
 
 const REPLAY_CACHE_CONTROL = "public, max-age=31536000, immutable";
+/** Marks a request for the archive as a file rather than as a document. */
+const REPLAY_DOWNLOAD_PARAM = "download";
 
-export interface MatchReplay {
-  version: 1;
-  setup: MatchSetup;
-  actions: unknown[];
-}
+/**
+ * A stored match archive: the setup the match started from, and every action
+ * that was taken in it.
+ *
+ * The actions stay unvalidated here. They are the engine's own action events,
+ * and the engine is the only thing that can read them; a schema restated on
+ * this side would be a second, weaker copy of the rules the spec already owns.
+ */
+export const matchReplaySchema = z.object({
+  version: z.literal(1),
+  setup: matchSetupSchema,
+  actions: z.array(z.unknown()),
+});
+
+export type MatchReplay = z.infer<typeof matchReplaySchema>;
 
 export function matchReplayKey(matchId: string): string {
   return `replays/${matchId}.json`;
+}
+
+/** The path the archive is served from, for reading it in the page. */
+export function matchReplayPath(matchId: string): string {
+  return `/replays/${matchId}.json`;
+}
+
+/**
+ * The same archive, asked for as a file to keep.
+ *
+ * The query is what separates the two: the plain path stays a cacheable
+ * document the page can read, and this one carries the disposition that names
+ * the saved file.
+ */
+export function matchReplayDownloadPath(matchId: string): string {
+  return `${matchReplayPath(matchId)}?${REPLAY_DOWNLOAD_PARAM}=1`;
+}
+
+/** Whether a request asked for the archive as a file to keep. */
+export function isMatchReplayDownload(url: URL): boolean {
+  return url.searchParams.get(REPLAY_DOWNLOAD_PARAM) === "1";
+}
+
+/** The name a downloaded archive is saved under. */
+export function matchReplayFileName(matchId: string): string {
+  return `awbrn-replay-${matchId}.json`;
+}
+
+/**
+ * Read a served archive and check it.
+ *
+ * This is the step playback starts from: it turns the file into a `MatchSetup`
+ * the engine can be started with and the action log to feed it, both measured
+ * against the schemas the server wrote them with. Nothing plays a stored
+ * archive back yet, so today only the download uses the file.
+ */
+export async function fetchMatchReplay(
+  matchId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MatchReplay> {
+  const response = await fetchImpl(matchReplayPath(matchId));
+  if (!response.ok) {
+    throw new Error(
+      response.status === 404
+        ? "this match has no stored replay"
+        : `the replay could not be read (${response.status})`,
+    );
+  }
+
+  return parseMatchReplay(await response.json());
+}
+
+/** Check a decoded archive. Throws with the first failing field. */
+export function parseMatchReplay(value: unknown): MatchReplay {
+  const result = matchReplaySchema.safeParse(value);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue?.path.join(".");
+    throw new Error(`the replay file is not a valid AWBRN archive${path ? ` (${path})` : ""}`);
+  }
+
+  return result.data;
 }
 
 export async function uploadMatchReplay(
@@ -26,7 +101,26 @@ export async function uploadMatchReplay(
   });
 }
 
-export async function getMatchReplayResponse(bucket: R2Bucket, matchId: string): Promise<Response> {
+/** Whether an archive was stored for each of these matches. */
+export async function matchReplaysExist(
+  bucket: R2Bucket,
+  matchIds: readonly string[],
+): Promise<Set<string>> {
+  const found = await Promise.all(
+    matchIds.map(async (matchId) => {
+      const head = await bucket.head(matchReplayKey(matchId));
+      return head === null ? null : matchId;
+    }),
+  );
+
+  return new Set(found.filter((matchId): matchId is string => matchId !== null));
+}
+
+export async function getMatchReplayResponse(
+  bucket: R2Bucket,
+  matchId: string,
+  { asAttachment = false }: { asAttachment?: boolean } = {},
+): Promise<Response> {
   const replay = await bucket.get(matchReplayKey(matchId));
   if (replay === null) {
     return new Response("Replay not found", { status: 404 });
@@ -36,5 +130,8 @@ export async function getMatchReplayResponse(bucket: R2Bucket, matchId: string):
   replay.writeHttpMetadata(headers);
   headers.set("Cache-Control", REPLAY_CACHE_CONTROL);
   headers.set("ETag", replay.httpEtag);
+  if (asAttachment) {
+    headers.set("Content-Disposition", `attachment; filename="${matchReplayFileName(matchId)}"`);
+  }
   return new Response(replay.body, { headers });
 }

--- a/web/src/matches/schemas.ts
+++ b/web/src/matches/schemas.ts
@@ -22,6 +22,10 @@ export const matchBrowseRequestSchema = z.object({
   cursor: z.string().min(1).optional(),
 });
 
+export const matchHistoryRequestSchema = z.object({
+  cursor: z.string().min(1).optional(),
+});
+
 export const matchMutationRequestSchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("join"),
@@ -78,6 +82,7 @@ export type RankedPool = (typeof rankedPools)[number];
 export type MatchSettings = z.infer<typeof matchSettingsSchema>;
 export type MatchCreateRequest = z.infer<typeof matchCreateRequestSchema>;
 export type MatchBrowseRequest = z.infer<typeof matchBrowseRequestSchema>;
+export type MatchHistoryRequest = z.infer<typeof matchHistoryRequestSchema>;
 export type MatchMutationRequest = z.infer<typeof matchMutationRequestSchema>;
 
 export interface MatchCreateResponse {
@@ -188,3 +193,39 @@ export const matchSetupSchema = z.object({
 
 export type MatchSetupPlayer = z.infer<typeof matchSetupPlayerSchema>;
 export type MatchSetup = z.infer<typeof matchSetupSchema>;
+
+/** One seat in a finished match, with the result recorded for it. */
+export interface MatchHistorySeat {
+  slotIndex: number;
+  userId: string;
+  userName: string;
+  factionId: number;
+  coId: number | null;
+  /** Null while a completed match has no recorded result for the seat. */
+  outcome: MatchOutcome | null;
+  placement: number | null;
+  reason: SeatResultReason | null;
+}
+
+/** One finished match, as the viewer's own after action report. */
+export interface MatchHistoryEntry {
+  matchId: string;
+  name: string;
+  mapId: number;
+  isPrivate: boolean;
+  settings: MatchSettings;
+  startedAt: string | null;
+  completedAt: string;
+  /** Every seat the viewer held. More than one means a hotseat match. */
+  viewerSlotIndexes: number[];
+  seats: MatchHistorySeat[];
+  /** False when the archive is missing, so the page never offers a dead file. */
+  hasReplay: boolean;
+}
+
+export interface MatchHistoryResponse {
+  matches: MatchHistoryEntry[];
+  pageSize: number;
+  hasNextPage: boolean;
+  nextCursor: string | null;
+}

--- a/web/src/matches/screens/MatchHistoryPage.tsx
+++ b/web/src/matches/screens/MatchHistoryPage.tsx
@@ -1,0 +1,465 @@
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { Banner } from "@astryxdesign/core/Banner";
+import { EmptyState } from "@astryxdesign/core/EmptyState";
+import { Grid } from "@astryxdesign/core/Grid";
+import { Heading } from "@astryxdesign/core/Heading";
+import { Section } from "@astryxdesign/core/Section";
+import { HStack, VStack } from "@astryxdesign/core/Stack";
+import { Text } from "@astryxdesign/core/Text";
+import { VisuallyHidden } from "@astryxdesign/core/VisuallyHidden";
+import { colorVars, spacingVars } from "@astryxdesign/core/theme/tokens.stylex";
+import { Download as DownloadIcon } from "pixelarticons/react/Download";
+import * as stylex from "@stylexjs/stylex";
+import { useState } from "react";
+import { awbwSmallMapAssetPath } from "#/awbw/paths.ts";
+import { CoPortrait } from "#/components/CoPortrait.tsx";
+import { getCoPortraitByAwbwId, loadCoPortraitCatalog } from "#/components/co_portraits.ts";
+import { FactionLogo } from "#/components/FactionLogo.tsx";
+import { getFactionById } from "#/factions.ts";
+import {
+  formatMatchDuration,
+  formatSeatResultReason,
+  formatVerdict,
+  opposingSeats,
+  viewerOutcome,
+} from "#/matches/match_history.ts";
+import { myCompletedMatchesQueryOptions } from "#/matches/matches.queries.ts";
+import { matchReplayDownloadPath } from "#/matches/replay_archive.ts";
+import type { MatchHistoryEntry, MatchHistorySeat, MatchOutcome } from "#/matches/schemas.ts";
+import { awbrnVars, matchHistoryVars } from "#/themes/awbrnTokens.stylex.ts";
+import { Button } from "#/ui/Button.tsx";
+import { RouterButton, RouterTextLink } from "#/ui/astryx-links.tsx";
+import { Thumbnail } from "#/ui/Thumbnail.tsx";
+import { MATCH_REPORT_MEDIA_SIZE, TWO_COLUMN_GRID_MIN_WIDTH } from "#/ui/layout.ts";
+
+const dateFormat = new Intl.DateTimeFormat(undefined, {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+});
+
+/**
+ * Every battle the player has finished, each one as its own after action
+ * report.
+ *
+ * The page is a stack of debriefs and nothing else: no filters and no tally
+ * above them, because the reports are what the player came back for. Each one
+ * opens on a band of the armies that fought it, so the matchup reads before the
+ * name does, and closes on the two things a finished battle is still good for —
+ * opening it again, and taking the replay away.
+ */
+export function MatchHistoryPage() {
+  const historyQuery = useSuspenseInfiniteQuery(myCompletedMatchesQueryOptions());
+  const [paginationError, setPaginationError] = useState<string | null>(null);
+  const matches = historyQuery.data.pages.flatMap((page) => page.matches);
+  const portraitCatalog = loadCoPortraitCatalog();
+
+  async function handleLoadMore(): Promise<void> {
+    if (historyQuery.isFetchingNextPage || !historyQuery.hasNextPage) return;
+
+    setPaginationError(null);
+    try {
+      await historyQuery.fetchNextPage();
+    } catch (nextError) {
+      setPaginationError(
+        nextError instanceof Error ? nextError.message : "More completed games failed to load.",
+      );
+    }
+  }
+
+  return (
+    <Section padding={6} variant="transparent">
+      <VStack gap={6}>
+        <Grid
+          align="end"
+          columns={{ minWidth: TWO_COLUMN_GRID_MIN_WIDTH, max: 2, repeat: "fit" }}
+          gap={4}
+        >
+          <VStack gap={2}>
+            <Heading level={1} type="display-2" xstyle={styles.pageTitle}>
+              Completed games
+            </Heading>
+            <Text color="secondary" type="large">
+              Every battle you have finished, and the replay archive it left behind.
+            </Text>
+          </VStack>
+          <HStack gap={2} justify="end" wrap="wrap">
+            <RouterButton label="Ongoing games" to="/my/matches" variant="secondary" />
+            <RouterButton label="Create match" to="/matches/new" variant="primary" />
+          </HStack>
+        </Grid>
+
+        {paginationError ? (
+          <Banner
+            description={paginationError}
+            endContent={
+              <Button clickAction={handleLoadMore} label="Retry" size="sm" variant="secondary" />
+            }
+            status="error"
+            title="More completed games failed to load"
+          />
+        ) : null}
+
+        {matches.length === 0 ? (
+          <EmptyState
+            actions={
+              <HStack gap={2} justify="center" wrap="wrap">
+                <RouterButton label="Browse lobbies" to="/matches" variant="primary" />
+                <RouterButton label="Ongoing games" to="/my/matches" variant="secondary" />
+              </HStack>
+            }
+            description="Play a match to the end and its report lands here, with the replay archive beside it."
+            headingLevel={2}
+            title="You have not finished a battle yet"
+          />
+        ) : (
+          <Section padding={0} variant="section">
+            <VStack as="ul" gap={0}>
+              {matches.map((entry, index) => (
+                <AfterActionReport
+                  entry={entry}
+                  hasRuleAbove={index > 0}
+                  key={entry.matchId}
+                  portraitCatalog={portraitCatalog}
+                />
+              ))}
+            </VStack>
+          </Section>
+        )}
+
+        {matches.length > 0 && historyQuery.hasNextPage ? (
+          <HStack justify="center">
+            <Button
+              clickAction={handleLoadMore}
+              isLoading={historyQuery.isFetchingNextPage}
+              label="Load more"
+              size="sm"
+              variant="secondary"
+            />
+          </HStack>
+        ) : null}
+      </VStack>
+    </Section>
+  );
+}
+
+/**
+ * One finished battle.
+ *
+ * The band across the top is the armies that fought, in seat order and in their
+ * own colors. It is also the rule between one report and the next, so the stack
+ * divides on the matchup rather than on a neutral line. Color is never the only
+ * carrier: every army named in the band is named again below it, beside its
+ * insignia and its CO.
+ */
+function AfterActionReport({
+  entry,
+  hasRuleAbove,
+  portraitCatalog,
+}: {
+  entry: MatchHistoryEntry;
+  hasRuleAbove: boolean;
+  portraitCatalog: ReturnType<typeof loadCoPortraitCatalog>;
+}) {
+  const viewerSeats = entry.seats.filter((seat) =>
+    entry.viewerSlotIndexes.includes(seat.slotIndex),
+  );
+  const opponents = opposingSeats(entry.seats, entry.viewerSlotIndexes);
+  const outcome = viewerOutcome(viewerSeats);
+  const isHotseat = viewerSeats.length > 1;
+  const duration = formatMatchDuration(entry.startedAt, entry.completedAt);
+
+  const details = [
+    dateFormat.format(new Date(entry.completedAt)),
+    duration,
+    `Map ${entry.mapId}`,
+    entry.settings.fogEnabled ? "Fog on" : "Fog off",
+    `${entry.settings.startingFunds.toLocaleString()} funds`,
+    entry.isPrivate ? "Private" : null,
+  ].filter((detail): detail is string => detail !== null);
+
+  return (
+    <VStack as="li" gap={0} xstyle={[styles.report, hasRuleAbove && styles.reportRule]}>
+      <ArmyBand seats={entry.seats} />
+      <HStack align="start" gap={4} wrap="wrap" xstyle={styles.reportBody}>
+        <HStack align="start" gap={3} xstyle={styles.brief}>
+          <Thumbnail
+            alt={`Map preview for ${entry.name}`}
+            label={`${entry.name} map`}
+            src={awbwSmallMapAssetPath(entry.mapId)}
+          />
+          <VStack gap={2} xstyle={styles.briefText}>
+            <Heading level={2}>
+              <RouterTextLink params={{ matchId: entry.matchId }} to="/matches/$matchId">
+                {entry.name}
+              </RouterTextLink>
+            </Heading>
+            <HStack align="center" gap={3} wrap="wrap">
+              {viewerSeats.map((seat) => (
+                <SeatMark
+                  isViewer
+                  key={seat.slotIndex}
+                  portraitCatalog={portraitCatalog}
+                  seat={seat}
+                />
+              ))}
+              {opponents.length > 0 ? (
+                <Text color="secondary" type="label" xstyle={styles.versus}>
+                  vs
+                </Text>
+              ) : null}
+              {opponents.map((seat) => (
+                <SeatMark key={seat.slotIndex} portraitCatalog={portraitCatalog} seat={seat} />
+              ))}
+            </HStack>
+            <Text color="secondary" type="label">
+              {details.join(" · ")}
+            </Text>
+          </VStack>
+        </HStack>
+
+        <VStack align="end" gap={2} xstyle={styles.verdictColumn}>
+          <Verdict isHotseat={isHotseat} outcome={outcome} seats={viewerSeats} />
+          {entry.hasReplay ? (
+            <Button
+              as="a"
+              href={matchReplayDownloadPath(entry.matchId)}
+              icon={<DownloadIcon />}
+              label={`Replay archive for ${entry.name}`}
+              size="sm"
+              variant="secondary"
+            >
+              Replay
+            </Button>
+          ) : (
+            <Text color="secondary" type="label">
+              No replay stored
+            </Text>
+          )}
+        </VStack>
+      </HStack>
+    </VStack>
+  );
+}
+
+/**
+ * The armies that fought, as one band across the top of the report.
+ *
+ * Decorative on purpose: it repeats what the seats below already say in words,
+ * so nothing here has to be read to understand the battle.
+ */
+function ArmyBand({ seats }: { seats: readonly MatchHistorySeat[] }) {
+  return (
+    <HStack aria-hidden="true" gap={0} xstyle={styles.band}>
+      {seats.map((seat) => {
+        const faction = getFactionById(seat.factionId);
+        return (
+          <HStack
+            as="span"
+            gap={0}
+            key={seat.slotIndex}
+            xstyle={[
+              styles.bandSegment,
+              faction && styles.factionBandSegment(`var(--color-faction-${faction.code}-accent)`),
+            ]}
+          />
+        );
+      })}
+    </HStack>
+  );
+}
+
+/** One army in the matchup: its insignia, its CO, and the player who ran it. */
+function SeatMark({
+  isViewer = false,
+  portraitCatalog,
+  seat,
+}: {
+  isViewer?: boolean;
+  portraitCatalog: ReturnType<typeof loadCoPortraitCatalog>;
+  seat: MatchHistorySeat;
+}) {
+  const faction = getFactionById(seat.factionId);
+  const co = seat.coId === null ? null : getCoPortraitByAwbwId(seat.coId);
+  const armyName = faction?.displayName ?? "Unknown army";
+
+  return (
+    <HStack align="center" gap={1.5}>
+      <CoPortrait
+        catalog={portraitCatalog}
+        coKey={co?.key ?? null}
+        fallbackLabel={co?.displayName ?? "No CO"}
+        size={MATCH_REPORT_MEDIA_SIZE.portrait}
+      />
+      <VStack gap={0.5}>
+        <Text maxLines={1} type="label" weight={isViewer ? "bold" : undefined}>
+          {seat.userName}
+          {isViewer ? <VisuallyHidden> (you)</VisuallyHidden> : null}
+        </Text>
+        <HStack align="center" gap={1}>
+          {faction ? (
+            <FactionLogo
+              factionCode={faction.code}
+              isFramed={false}
+              isLabelHidden
+              size={MATCH_REPORT_MEDIA_SIZE.crest}
+            />
+          ) : null}
+          <Text color="secondary" maxLines={1} type="label">
+            {armyName}
+            {co ? ` · ${co.displayName}` : ""}
+          </Text>
+        </HStack>
+      </VStack>
+    </HStack>
+  );
+}
+
+/**
+ * How the battle ended for the player.
+ *
+ * A hotseat match the player ran from every seat has no personal verdict, so it
+ * reports the army that won instead of claiming a victory nobody contested.
+ */
+function Verdict({
+  isHotseat,
+  outcome,
+  seats,
+}: {
+  isHotseat: boolean;
+  outcome: MatchOutcome | null;
+  seats: readonly MatchHistorySeat[];
+}) {
+  if (isHotseat) {
+    const winner = seats.find((seat) => seat.outcome === "win");
+    const winningArmy = winner ? getFactionById(winner.factionId)?.displayName : null;
+    return (
+      <VStack align="end" gap={0.5}>
+        <Text type="label" xstyle={[styles.verdict, styles.verdictNeutral]}>
+          Hotseat
+        </Text>
+        <Text color="secondary" type="label">
+          {winningArmy ? `${winningArmy} won` : "No result recorded"}
+        </Text>
+      </VStack>
+    );
+  }
+
+  const seat = seats[0];
+  return (
+    <VStack align="end" gap={0.5}>
+      <Text type="label" xstyle={[styles.verdict, verdictStyle(outcome)]}>
+        {formatVerdict(outcome)}
+      </Text>
+      <Text color="secondary" type="label">
+        {formatSeatResultReason(outcome, seat?.reason ?? null)}
+      </Text>
+    </VStack>
+  );
+}
+
+function verdictStyle(outcome: MatchOutcome | null) {
+  switch (outcome) {
+    case "win":
+      return styles.verdictWin;
+    case "loss":
+      return styles.verdictLoss;
+    case "draw":
+      return styles.verdictDraw;
+    case null:
+      return styles.verdictNeutral;
+  }
+}
+
+const styles = stylex.create({
+  // The signage face sets one long word here, and "COMPLETED" is wider than a
+  // phone at the display size. It scales with the viewport below the two-column
+  // breakpoint rather than being clipped.
+  pageTitle: {
+    fontSize: {
+      default: null,
+      "@media (max-width: 640px)": `clamp(${matchHistoryVars.titleMinimumSize}, ${matchHistoryVars.titleFluidSize}, ${matchHistoryVars.titleMaximumSize})`,
+    },
+  },
+  // Once the armies stack, the separator takes its own line; left at the end of
+  // a wrapped row it reads as a stray label rather than as a matchup.
+  versus: {
+    flexBasis: {
+      default: "auto",
+      "@media (max-width: 640px)": "100%",
+    },
+  },
+  report: {
+    listStyle: "none",
+  },
+  // The band is the rule between reports, so no second line is drawn above it.
+  reportRule: {
+    borderTopWidth: "var(--border-width)",
+    borderTopStyle: "solid",
+    borderTopColor: awbrnVars.colorBorderSoft,
+  },
+  reportBody: {
+    paddingBlock: spacingVars["--spacing-4"],
+    paddingInline: spacingVars["--spacing-4"],
+  },
+  // Wide enough that the map, the matchup, and the metadata hold one column
+  // together, and narrow enough that the verdict wraps beneath them on a phone.
+  brief: {
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: matchHistoryVars.briefWidth,
+    minWidth: 0,
+  },
+  briefText: {
+    minWidth: 0,
+  },
+  verdictColumn: {
+    flexGrow: 1,
+    flexShrink: 0,
+    flexBasis: "auto",
+  },
+  band: {
+    height: spacingVars["--spacing-1-5"],
+    width: "100%",
+  },
+  bandSegment: {
+    flexGrow: 1,
+    flexBasis: 0,
+    backgroundColor: colorVars["--color-background-muted"],
+  },
+  factionBandSegment: (backgroundColor: string) => ({
+    backgroundColor,
+  }),
+  // The verdict is a stamp: outlined, filled, and named. It never depends on
+  // its fill to be read.
+  verdict: {
+    borderWidth: "var(--border-width)",
+    borderStyle: "solid",
+    borderRadius: "var(--radius-inner)",
+    paddingBlock: spacingVars["--spacing-1"],
+    paddingInline: spacingVars["--spacing-2"],
+  },
+  // The status color outlines and fills the stamp, but the word is set in ink:
+  // a verdict has to clear its own ground, and no status hue does that at
+  // label size against its own tint.
+  verdictWin: {
+    backgroundColor: "var(--color-success-muted)",
+    borderColor: "var(--color-success)",
+    color: colorVars["--color-text-primary"],
+  },
+  verdictLoss: {
+    backgroundColor: "var(--color-error-muted)",
+    borderColor: "var(--color-error)",
+    color: colorVars["--color-text-primary"],
+  },
+  verdictDraw: {
+    backgroundColor: "var(--color-warning-muted)",
+    borderColor: "var(--color-warning)",
+    color: colorVars["--color-text-primary"],
+  },
+  verdictNeutral: {
+    backgroundColor: colorVars["--color-background-muted"],
+    borderColor: "var(--color-border-emphasized)",
+    color: colorVars["--color-text-primary"],
+  },
+});

--- a/web/src/matches/screens/MyMatchesPage.tsx
+++ b/web/src/matches/screens/MyMatchesPage.tsx
@@ -44,6 +44,7 @@ export function MyMatchesPage() {
           <HStack gap={2} justify="end" wrap="wrap">
             <RouterButton label="Create match" to="/matches/new" variant="primary" />
             <RouterButton label="Browse lobbies" to="/matches" variant="secondary" />
+            <RouterButton label="Completed games" to="/my/history" variant="secondary" />
           </HStack>
         </Grid>
 
@@ -53,6 +54,7 @@ export function MyMatchesPage() {
               <HStack gap={2} justify="center" wrap="wrap">
                 <RouterButton label="Create match" to="/matches/new" variant="primary" />
                 <RouterButton label="Browse lobbies" to="/matches" variant="secondary" />
+                <RouterButton label="Completed games" to="/my/history" variant="secondary" />
               </HStack>
             }
             description="Create a match or join an open lobby to see it here."

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as AuthRouteImport } from './routes/auth'
 import { Route as MatchesIndexRouteImport } from './routes/matches/index'
 import { Route as MatchesMatchIdRouteImport } from './routes/matches/$matchId'
 import { Route as MatchesNewRouteImport } from './routes/matches/new'
+import { Route as MyHistoryRouteImport } from './routes/my/history'
 import { Route as MyMatchesRouteImport } from './routes/my/matches'
 import { Route as ReplaysChar123matchIdChar125DotjsonRouteImport } from './routes/replays/{$matchId}[.]json'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
@@ -50,6 +51,11 @@ const MatchesMatchIdRoute = MatchesMatchIdRouteImport.update({
 const MatchesNewRoute = MatchesNewRouteImport.update({
   id: '/matches/new',
   path: '/matches/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MyHistoryRoute = MyHistoryRouteImport.update({
+  id: '/my/history',
+  path: '/my/history',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MyMatchesRoute = MyMatchesRouteImport.update({
@@ -90,6 +96,7 @@ export interface FileRoutesByFullPath {
   '/auth': typeof AuthRoute
   '/matches/$matchId': typeof MatchesMatchIdRoute
   '/matches/new': typeof MatchesNewRoute
+  '/my/history': typeof MyHistoryRoute
   '/my/matches': typeof MyMatchesRoute
   '/replays/{$matchId}.json': typeof ReplaysChar123matchIdChar125DotjsonRoute
   '/matches/': typeof MatchesIndexRoute
@@ -104,6 +111,7 @@ export interface FileRoutesByTo {
   '/auth': typeof AuthRoute
   '/matches/$matchId': typeof MatchesMatchIdRoute
   '/matches/new': typeof MatchesNewRoute
+  '/my/history': typeof MyHistoryRoute
   '/my/matches': typeof MyMatchesRoute
   '/replays/{$matchId}.json': typeof ReplaysChar123matchIdChar125DotjsonRoute
   '/matches': typeof MatchesIndexRoute
@@ -119,6 +127,7 @@ export interface FileRoutesById {
   '/auth': typeof AuthRoute
   '/matches/$matchId': typeof MatchesMatchIdRoute
   '/matches/new': typeof MatchesNewRoute
+  '/my/history': typeof MyHistoryRoute
   '/my/matches': typeof MyMatchesRoute
   '/replays/{$matchId}.json': typeof ReplaysChar123matchIdChar125DotjsonRoute
   '/matches/': typeof MatchesIndexRoute
@@ -135,6 +144,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/matches/$matchId'
     | '/matches/new'
+    | '/my/history'
     | '/my/matches'
     | '/replays/{$matchId}.json'
     | '/matches/'
@@ -149,6 +159,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/matches/$matchId'
     | '/matches/new'
+    | '/my/history'
     | '/my/matches'
     | '/replays/{$matchId}.json'
     | '/matches'
@@ -163,6 +174,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/matches/$matchId'
     | '/matches/new'
+    | '/my/history'
     | '/my/matches'
     | '/replays/{$matchId}.json'
     | '/matches/'
@@ -178,6 +190,7 @@ export interface RootRouteChildren {
   AuthRoute: typeof AuthRoute
   MatchesMatchIdRoute: typeof MatchesMatchIdRoute
   MatchesNewRoute: typeof MatchesNewRoute
+  MyHistoryRoute: typeof MyHistoryRoute
   MyMatchesRoute: typeof MyMatchesRoute
   ReplaysChar123matchIdChar125DotjsonRoute: typeof ReplaysChar123matchIdChar125DotjsonRoute
   MatchesIndexRoute: typeof MatchesIndexRoute
@@ -231,6 +244,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchesNewRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/my/history': {
+      id: '/my/history'
+      path: '/my/history'
+      fullPath: '/my/history'
+      preLoaderRoute: typeof MyHistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/my/matches': {
       id: '/my/matches'
       path: '/my/matches'
@@ -282,6 +302,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthRoute: AuthRoute,
   MatchesMatchIdRoute: MatchesMatchIdRoute,
   MatchesNewRoute: MatchesNewRoute,
+  MyHistoryRoute: MyHistoryRoute,
   MyMatchesRoute: MyMatchesRoute,
   ReplaysChar123matchIdChar125DotjsonRoute:
     ReplaysChar123matchIdChar125DotjsonRoute,

--- a/web/src/routes/my/history.tsx
+++ b/web/src/routes/my/history.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { sessionQueryOptions } from "#/auth/auth.queries.ts";
+import { myCompletedMatchesQueryOptions } from "#/matches/matches.queries.ts";
+import { MatchHistoryPage } from "#/matches/screens/MatchHistoryPage.tsx";
+
+export const Route = createFileRoute("/my/history")({
+  loader: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(sessionQueryOptions());
+    if (!session) {
+      throw redirect({ to: "/auth" });
+    }
+
+    await context.queryClient.ensureInfiniteQueryData(myCompletedMatchesQueryOptions());
+  },
+  component: MatchHistoryRoute,
+});
+
+function MatchHistoryRoute() {
+  return <MatchHistoryPage />;
+}

--- a/web/src/routes/replays/{$matchId}[.]json.ts
+++ b/web/src/routes/replays/{$matchId}[.]json.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { env } from "cloudflare:workers";
 import { matchIdSchema } from "#/matches/match_id.ts";
-import { getMatchReplayResponse } from "#/matches/replay_archive.ts";
+import { getMatchReplayResponse, isMatchReplayDownload } from "#/matches/replay_archive.ts";
 
 export const Route = createFileRoute("/replays/{$matchId}.json")({
   params: {
@@ -10,7 +10,10 @@ export const Route = createFileRoute("/replays/{$matchId}.json")({
   },
   server: {
     handlers: {
-      GET: ({ params }) => getMatchReplayResponse(env.CONTENT, params.matchId),
+      GET: ({ params, request }) =>
+        getMatchReplayResponse(env.CONTENT, params.matchId, {
+          asAttachment: isMatchReplayDownload(new URL(request.url)),
+        }),
     },
   },
 });

--- a/web/src/themes/awbrnTokens.stylex.ts
+++ b/web/src/themes/awbrnTokens.stylex.ts
@@ -6,3 +6,11 @@ export const awbrnVars = stylex.defineConsts({
   colorBorderSoft: "var(--color-border-soft)",
   offsetControlPressed: "var(--offset-control-pressed)",
 });
+
+/** Match report dimensions that do not map to the Astryx core scale. */
+export const matchHistoryVars = stylex.defineConsts({
+  briefWidth: "300px",
+  titleFluidSize: "13vw",
+  titleMaximumSize: "3.375rem",
+  titleMinimumSize: "1.75rem",
+});

--- a/web/src/ui/layout.ts
+++ b/web/src/ui/layout.ts
@@ -5,3 +5,9 @@ export const ROSTER_MEDIA_SIZE = {
   crest: 24,
   portrait: 36,
 } as const;
+
+/** Pixel-backed design tokens required by the match report's sprite component APIs. */
+export const MATCH_REPORT_MEDIA_SIZE = {
+  crest: 20,
+  portrait: 40,
+} as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a completed match history page at `/my/history`.
  - View after-action reports with match details, player outcomes, durations, and replay availability.
  - Added replay download support with downloadable filenames.
  - Added navigation links to match history from the main navigation and My Matches page.
  - Added an empty state when no completed matches are available.

- **Bug Fixes**
  - Improved replay validation and handling of missing or invalid replay archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->